### PR TITLE
Add Flyway database migrations for schema versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ API REST para gestão de pacientes do estúdio Carlesso Pilates, desenvolvida co
 | Spring Data JPA | 3.4.5 |
 | Spring Validation | 3.4.5 |
 | PostgreSQL | 16 |
+| Flyway | (via spring-boot-starter-parent) |
 | springdoc-openapi | 2.8.3 |
 | Maven | 3.9 |
 | Docker / Docker Compose | - |
@@ -23,24 +24,30 @@ API REST para gestão de pacientes do estúdio Carlesso Pilates, desenvolvida co
 
 ```
 src/
-├── main/java/com/carlesso/pilatesapi/
-│   ├── config/
-│   │   ├── GlobalExceptionHandler.java  # Handler 404 para EntityNotFoundException
-│   │   └── OpenApiConfig.java           # Configuração do Swagger/OpenAPI
-│   ├── controller/
-│   │   └── PacienteController.java      # Endpoints REST
-│   ├── service/
-│   │   └── PacienteService.java         # Regras de negócio
-│   ├── repository/
-│   │   └── PacienteRepository.java      # Acesso ao banco
-│   ├── entity/
-│   │   ├── Paciente.java                # Entidade JPA
-│   │   └── Endereco.java                # Embeddable de endereço
-│   └── dto/
-│       ├── PacienteRequestDTO.java      # Payload de criação
-│       ├── PacienteUpdateDTO.java       # Payload de atualização
-│       ├── PacienteResponseDTO.java     # Resposta da API
-│       └── EnderecoDTO.java             # DTO de endereço
+├── main/
+│   ├── java/com/carlesso/pilatesapi/
+│   │   ├── config/
+│   │   │   ├── GlobalExceptionHandler.java  # Handler 404 para EntityNotFoundException
+│   │   │   └── OpenApiConfig.java           # Configuração do Swagger/OpenAPI
+│   │   ├── controller/
+│   │   │   └── PacienteController.java      # Endpoints REST
+│   │   ├── service/
+│   │   │   └── PacienteService.java         # Regras de negócio
+│   │   ├── repository/
+│   │   │   └── PacienteRepository.java      # Acesso ao banco
+│   │   ├── entity/
+│   │   │   ├── Paciente.java                # Entidade JPA
+│   │   │   └── Endereco.java                # Embeddable de endereço
+│   │   └── dto/
+│   │       ├── PacienteRequestDTO.java      # Payload de criação
+│   │       ├── PacienteUpdateDTO.java       # Payload de atualização
+│   │       ├── PacienteResponseDTO.java     # Resposta da API
+│   │       └── EnderecoDTO.java             # DTO de endereço
+│   └── resources/
+│       ├── application.properties
+│       └── db/migration/
+│           ├── V1__create_pacientes_table.sql  # Criação da tabela pacientes
+│           └── V2__insert_pacientes_teste.sql  # Carga inicial com 10 pacientes de teste
 └── test/java/com/carlesso/pilatesapi/
     ├── PilatesApiApplicationTests.java  # Context load test
     ├── service/
@@ -208,6 +215,19 @@ Com a aplicação rodando, acesse:
 |---|---|
 | Swagger UI | http://localhost:8080/swagger-ui.html |
 | OpenAPI JSON | http://localhost:8080/api-docs |
+
+---
+
+## Migrações de banco (Flyway)
+
+O projeto utiliza **Flyway** para versionamento e execução automática das migrações de banco de dados. As migrações ficam em `src/main/resources/db/migration/` e são aplicadas na ordem de versão ao subir a aplicação.
+
+| Arquivo | Descrição |
+|---|---|
+| `V1__create_pacientes_table.sql` | Criação da tabela `pacientes` com todos os campos e constraints |
+| `V2__insert_pacientes_teste.sql` | Carga inicial com 10 pacientes de teste de diferentes estados do Brasil |
+
+> Nos testes automatizados o Flyway fica desabilitado (`spring.flyway.enabled=false`), pois o banco H2 é gerenciado pelo Hibernate com `ddl-auto=create-drop`.
 
 ---
 

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -17,6 +17,7 @@ A aplicação foi construída com **Spring Boot 3** e **Java 21**, utiliza **Pos
 | Spring Data JPA | 3.4.5 | Persistência e ORM |
 | Spring Validation | 3.4.5 | Validação de entrada |
 | PostgreSQL | 16 | Banco de dados relacional |
+| Flyway | (via spring-boot-starter-parent) | Versionamento e migração de schema do banco |
 | springdoc-openapi | 2.8.3 | Documentação Swagger/OpenAPI |
 | Maven | 3.9 | Build e gerenciamento de dependências |
 | Docker | - | Containerização |
@@ -50,24 +51,30 @@ Requisição HTTP
 
 ```
 src/
-├── main/java/com/carlesso/pilatesapi/
-│   ├── config/
-│   │   ├── GlobalExceptionHandler.java  # Handler 404 para EntityNotFoundException
-│   │   └── OpenApiConfig.java           # Configuração do Swagger/OpenAPI
-│   ├── controller/
-│   │   └── PacienteController.java      # Endpoints REST
-│   ├── service/
-│   │   └── PacienteService.java         # Regras de negócio
-│   ├── repository/
-│   │   └── PacienteRepository.java      # Acesso ao banco
-│   ├── entity/
-│   │   ├── Paciente.java                # Entidade JPA
-│   │   └── Endereco.java                # Embeddable de endereço
-│   └── dto/
-│       ├── PacienteRequestDTO.java      # Payload de criação
-│       ├── PacienteUpdateDTO.java       # Payload de atualização
-│       ├── PacienteResponseDTO.java     # Resposta da API
-│       └── EnderecoDTO.java             # DTO de endereço
+├── main/
+│   ├── java/com/carlesso/pilatesapi/
+│   │   ├── config/
+│   │   │   ├── GlobalExceptionHandler.java  # Handler 404 para EntityNotFoundException
+│   │   │   └── OpenApiConfig.java           # Configuração do Swagger/OpenAPI
+│   │   ├── controller/
+│   │   │   └── PacienteController.java      # Endpoints REST
+│   │   ├── service/
+│   │   │   └── PacienteService.java         # Regras de negócio
+│   │   ├── repository/
+│   │   │   └── PacienteRepository.java      # Acesso ao banco
+│   │   ├── entity/
+│   │   │   ├── Paciente.java                # Entidade JPA
+│   │   │   └── Endereco.java                # Embeddable de endereço
+│   │   └── dto/
+│   │       ├── PacienteRequestDTO.java      # Payload de criação
+│   │       ├── PacienteUpdateDTO.java       # Payload de atualização
+│   │       ├── PacienteResponseDTO.java     # Resposta da API
+│   │       └── EnderecoDTO.java             # DTO de endereço
+│   └── resources/
+│       ├── application.properties
+│       └── db/migration/
+│           ├── V1__create_pacientes_table.sql  # Criação da tabela pacientes
+│           └── V2__insert_pacientes_teste.sql  # Carga inicial com 10 pacientes de teste
 └── test/java/com/carlesso/pilatesapi/
     ├── PilatesApiApplicationTests.java  # Context load test
     ├── service/
@@ -330,12 +337,55 @@ spring.datasource.url=jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${D
 spring.datasource.username=${DB_USER:postgres}
 spring.datasource.password=${DB_PASSWORD:postgres}
 
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=true
+
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
 
 springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.api-docs.path=/api-docs
 ```
+
+> O DDL mode foi alterado de `update` para `validate` — o Flyway é o responsável por criar e evoluir o schema; o Hibernate apenas valida que as entidades estão de acordo com o banco.
+
+---
+
+## 7.1 Migrações de Banco (Flyway)
+
+O **Flyway** executa automaticamente os scripts SQL ao iniciar a aplicação, seguindo a ordem das versões. Os arquivos ficam em `src/main/resources/db/migration/`.
+
+### Convenção de nomes
+
+```
+V{versão}__{descrição}.sql
+```
+
+### Migrações existentes
+
+| Versão | Arquivo | Descrição |
+|---|---|---|
+| V1 | `V1__create_pacientes_table.sql` | Cria a tabela `pacientes` com todos os campos, PKs, constraints de unicidade e valor padrão para `ativo` |
+| V2 | `V2__insert_pacientes_teste.sql` | Insere 10 pacientes de teste representando estados diferentes do Brasil |
+
+### Pacientes de carga inicial (V2)
+
+| # | Nome | Estado |
+|---|---|---|
+| 1 | Ana Clara Ferreira | SP |
+| 2 | Bruno Santos Lima | RJ |
+| 3 | Carla Oliveira Mendes | MG |
+| 4 | Diego Alves Costa | PR |
+| 5 | Eduarda Rocha Pinheiro | RS |
+| 6 | Felipe Nascimento Brito | DF |
+| 7 | Gabriela Torres Souza | BA |
+| 8 | Henrique Lima Cardoso | CE |
+| 9 | Isabela Martins Gomes | PA |
+| 10 | João Pedro Araújo | PE |
+
+### Comportamento nos testes
+
+Nos testes automatizados o Flyway fica **desabilitado** (`spring.flyway.enabled=false` em `src/test/resources/application.properties`). O banco H2 em memória é gerenciado pelo Hibernate com `ddl-auto=create-drop`, garantindo isolamento e idempotência dos testes.
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,16 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,9 +6,12 @@ spring.datasource.password=${DB_PASSWORD:postgres}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
 
 springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html

--- a/src/main/resources/db/migration/V1__create_pacientes_table.sql
+++ b/src/main/resources/db/migration/V1__create_pacientes_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE pacientes (
+    id              BIGSERIAL       PRIMARY KEY,
+    nome            VARCHAR(255)    NOT NULL,
+    email           VARCHAR(255)    NOT NULL UNIQUE,
+    cpf             VARCHAR(14)     NOT NULL UNIQUE,
+    telefone        VARCHAR(20),
+    data_nascimento DATE,
+    logradouro      VARCHAR(255),
+    numero          VARCHAR(20),
+    bairro          VARCHAR(100),
+    cidade          VARCHAR(100),
+    uf              CHAR(2),
+    cep             VARCHAR(9),
+    ativo           BOOLEAN         NOT NULL DEFAULT TRUE
+);

--- a/src/main/resources/db/migration/V2__insert_pacientes_teste.sql
+++ b/src/main/resources/db/migration/V2__insert_pacientes_teste.sql
@@ -1,0 +1,11 @@
+INSERT INTO pacientes (nome, email, cpf, telefone, data_nascimento, logradouro, numero, bairro, cidade, uf, cep, ativo) VALUES
+('Ana Clara Ferreira',      'ana.ferreira@email.com',    '111.222.333-44', '(11) 91234-5678', '1985-03-12', 'Rua das Flores',       '42',   'Centro',         'São Paulo',       'SP', '01001-000', TRUE),
+('Bruno Santos Lima',       'bruno.lima@email.com',      '222.333.444-55', '(21) 98765-4321', '1990-07-25', 'Av. Brasil',           '500',  'Copacabana',     'Rio de Janeiro',  'RJ', '22020-010', TRUE),
+('Carla Oliveira Mendes',   'carla.mendes@email.com',    '333.444.555-66', '(31) 97654-3210', '1978-11-08', 'Rua da Liberdade',     '15',   'Savassi',        'Belo Horizonte',  'MG', '30130-010', TRUE),
+('Diego Alves Costa',       'diego.costa@email.com',     '444.555.666-77', '(41) 96543-2109', '1995-01-30', 'Rua XV de Novembro',   '200',  'Centro',         'Curitiba',        'PR', '80020-310', TRUE),
+('Eduarda Rocha Pinheiro',  'eduarda.pinheiro@email.com','555.666.777-88', '(51) 95432-1098', '1988-06-14', 'Av. Ipiranga',         '1000', 'Floresta',       'Porto Alegre',    'RS', '90160-091', TRUE),
+('Felipe Nascimento Brito', 'felipe.brito@email.com',    '666.777.888-99', '(61) 94321-0987', '1992-09-02', 'SQN 204',              '10A',  'Asa Norte',      'Brasília',        'DF', '70844-040', TRUE),
+('Gabriela Torres Souza',   'gabriela.souza@email.com',  '777.888.999-00', '(71) 93210-9876', '1983-04-19', 'Rua da Bahia',         '77',   'Pelourinho',     'Salvador',        'BA', '40025-010', TRUE),
+('Henrique Lima Cardoso',   'henrique.cardoso@email.com','888.999.000-11', '(85) 92109-8765', '1997-12-05', 'Av. Bezerra de Menezes','350', 'São Gerardo',    'Fortaleza',       'CE', '60325-000', TRUE),
+('Isabela Martins Gomes',   'isabela.gomes@email.com',   '999.000.111-22', '(91) 91098-7654', '1980-08-22', 'Tv. das Mercês',       '8',    'Batista Campos', 'Belém',           'PA', '66035-180', TRUE),
+('João Pedro Araújo',       'joao.araujo@email.com',     '000.111.222-33', '(81) 90987-6543', '1993-02-17', 'Av. Boa Viagem',       '3300', 'Boa Viagem',     'Recife',          'PE', '51020-000', TRUE);

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -5,3 +5,5 @@ spring.datasource.password=
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=false
+
+spring.flyway.enabled=false


### PR DESCRIPTION
## Summary
Integrate Flyway for automated database schema versioning and management, replacing Hibernate's auto-DDL approach with explicit SQL migrations.

## Key Changes

- **Added Flyway dependencies** to `pom.xml`:
  - `flyway-core` for migration execution
  - `flyway-database-postgresql` for PostgreSQL support

- **Created migration scripts** in `src/main/resources/db/migration/`:
  - `V1__create_pacientes_table.sql`: Creates the `pacientes` table with all columns, primary key, unique constraints, and default values
  - `V2__insert_pacientes_teste.sql`: Inserts 10 test patients representing different Brazilian states

- **Updated Hibernate configuration** in `src/main/resources/application.properties`:
  - Changed `spring.jpa.hibernate.ddl-auto` from `update` to `validate` — Hibernate now only validates schema consistency instead of auto-creating/modifying tables
  - Enabled Flyway with `spring.flyway.enabled=true` and configured migration location

- **Disabled Flyway in tests** (`src/test/resources/application.properties`):
  - Set `spring.flyway.enabled=false` to allow H2 in-memory database to be managed by Hibernate with `ddl-auto=create-drop` for test isolation

- **Updated documentation** (README.md and docs/documentacao.md):
  - Added Flyway to technology stack
  - Updated project structure to show `db/migration/` directory
  - Added section explaining migration conventions and existing migrations
  - Documented test behavior with Flyway disabled

## Implementation Details

- Flyway executes migrations automatically on application startup in order of version number
- Migration naming follows Flyway convention: `V{version}__{description}.sql`
- Test environment remains isolated with H2 and Hibernate-managed schema creation/destruction
- Schema is now version-controlled and reproducible across environments

https://claude.ai/code/session_016yMNw4XkeppdX5VPmvypqe