### PR TITLE
feat: Flyway migrations, business rules for plans, payments and classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ API REST para gestão de pacientes do estúdio Carlesso Pilates, desenvolvida co
 | PostgreSQL | 16 |
 | Flyway | (via spring-boot-starter-parent) |
 | springdoc-openapi | 2.8.3 |
+| Spring Scheduler | (via spring-boot-starter) |
 | Maven | 3.9 |
 | Docker / Docker Compose | - |
 | JUnit 5 + Mockito | (via spring-boot-starter-test) |
@@ -43,17 +44,45 @@ src/
 │   │       ├── PacienteUpdateDTO.java       # Payload de atualização
 │   │       ├── PacienteResponseDTO.java     # Resposta da API
 │   │       └── EnderecoDTO.java             # DTO de endereço
+│   ├── java/com/carlesso/pilatesapi/
+│   │   ├── entity/enums/
+│   │   │   ├── TipoPagamento.java           # MENSAL, TRIMESTRAL, ANUAL
+│   │   │   ├── FrequenciaSemanal.java        # UMA_VEZ, DUAS_VEZES, TRES_VEZES
+│   │   │   └── StatusPagamento.java          # PENDENTE, PAGO, VENCIDO
+│   │   ├── entity/
+│   │   │   ├── Plano.java                   # Plano de pagamento do paciente
+│   │   │   ├── Pagamento.java               # Cobrança por período
+│   │   │   └── Aula.java                    # Aula agendada (com presença)
+│   │   ├── service/
+│   │   │   ├── PlanoService.java            # Regras de plano e frequência
+│   │   │   ├── PagamentoService.java        # Cobranças, confirmação, vencimentos
+│   │   │   └── AulaService.java             # Geração e controle de aulas
+│   │   ├── controller/
+│   │   │   ├── PlanoController.java         # /planos
+│   │   │   ├── PagamentoController.java     # /pagamentos
+│   │   │   └── AulaController.java          # /aulas
+│   │   └── scheduler/
+│   │       └── CobrancaScheduler.java       # Atualiza vencidos + gera cobranças futuras
 │   └── resources/
 │       ├── application.properties
 │       └── db/migration/
-│           ├── V1__create_pacientes_table.sql  # Criação da tabela pacientes
-│           └── V2__insert_pacientes_teste.sql  # Carga inicial com 10 pacientes de teste
+│           ├── V1__create_pacientes_table.sql
+│           ├── V2__insert_pacientes_teste.sql
+│           ├── V3__create_planos_table.sql
+│           ├── V4__create_pagamentos_table.sql
+│           └── V5__create_aulas_table.sql
 └── test/java/com/carlesso/pilatesapi/
-    ├── PilatesApiApplicationTests.java  # Context load test
+    ├── PilatesApiApplicationTests.java
     ├── service/
-    │   └── PacienteServiceTest.java     # Testes unitários do serviço
+    │   ├── PacienteServiceTest.java
+    │   ├── PlanoServiceTest.java
+    │   ├── PagamentoServiceTest.java
+    │   └── AulaServiceTest.java
     └── controller/
-        └── PacienteControllerTest.java  # Testes do controller com MockMvc
+        ├── PacienteControllerTest.java
+        ├── PlanoControllerTest.java
+        ├── PagamentoControllerTest.java
+        └── AulaControllerTest.java
 ```
 
 ---
@@ -62,6 +91,8 @@ src/
 
 Base URL: `http://localhost:8080`
 
+### Pacientes
+
 | Método | Endpoint | Descrição |
 |---|---|---|
 | `POST` | `/pacientes` | Cadastrar novo paciente |
@@ -69,6 +100,34 @@ Base URL: `http://localhost:8080`
 | `GET` | `/pacientes/{id}` | Buscar paciente por ID |
 | `PUT` | `/pacientes/{id}` | Atualizar dados do paciente |
 | `DELETE` | `/pacientes/{id}` | Inativar paciente (soft delete) |
+
+### Planos de Pagamento
+
+| Método | Endpoint | Descrição |
+|---|---|---|
+| `POST` | `/planos` | Criar plano para paciente |
+| `GET` | `/planos/{id}` | Buscar plano por ID |
+| `GET` | `/planos/paciente/{id}` | Listar planos do paciente |
+| `GET` | `/planos/paciente/{id}/ativo` | Buscar plano ativo do paciente |
+| `DELETE` | `/planos/{id}` | Inativar plano |
+
+### Pagamentos
+
+| Método | Endpoint | Descrição |
+|---|---|---|
+| `POST` | `/pagamentos` | Criar pagamento (PENDENTE) |
+| `GET` | `/pagamentos/{id}` | Buscar pagamento por ID |
+| `GET` | `/pagamentos/paciente/{id}` | Listar pagamentos do paciente |
+| `PATCH` | `/pagamentos/{id}/pagar` | Confirmar pagamento e gerar aulas |
+
+### Aulas
+
+| Método | Endpoint | Descrição |
+|---|---|---|
+| `GET` | `/aulas/{id}` | Buscar aula por ID |
+| `GET` | `/aulas/paciente/{id}` | Listar aulas do paciente |
+| `GET` | `/aulas/pagamento/{id}` | Listar aulas de um pagamento |
+| `PATCH` | `/aulas/{id}/realizar` | Marcar aula como realizada |
 
 ### Paginação
 
@@ -290,14 +349,57 @@ curl -s -X DELETE http://localhost:8080/pacientes/1 -w "%{http_code}"
 
 ---
 
+## Regras de Negócio
+
+### Pacientes
+- Um paciente pode ter **apenas um plano ativo** por vez
+- Pacientes **inativos** não recebem novas cobranças nem têm aulas geradas
+
+### Planos de Pagamento
+- Tipos: `MENSAL`, `TRIMESTRAL`, `ANUAL`
+- A quantidade de dias da semana selecionados deve corresponder exatamente à frequência contratada (1x, 2x ou 3x)
+- Ao criar um novo plano, o plano ativo anterior é automaticamente inativado
+
+### Frequência de Aulas
+| Frequência | Vezes/semana | Aulas/mês (referência) |
+|---|---|---|
+| `UMA_VEZ` | 1 | 4 |
+| `DUAS_VEZES` | 2 | 8 |
+| `TRES_VEZES` | 3 | 12 |
+
+### Pagamentos
+- Status: `PENDENTE` → `PAGO` ou `VENCIDO`
+- Valor não pode ser menor que o valor do plano
+- Não pode haver dois pagamentos para o mesmo plano no mesmo período
+- Ao confirmar (`PAGO`), as aulas do período são geradas automaticamente
+
+### Geração de Aulas
+- Aulas geradas com base nos dias da semana do plano e no período do pagamento
+- Sem duplicatas: se a aula do paciente naquela data já existir, ela é ignorada
+- Requer paciente ativo e pagamento confirmado
+
+### Scheduler (processos automáticos)
+| Horário | Ação |
+|---|---|
+| 06:00 todo dia | Marca como `VENCIDO` pagamentos `PENDENTE` com data de vencimento passada |
+| 07:00 todo dia | Gera cobranças futuras para planos ativos a partir de 7 dias antes do fim do período |
+
+---
+
 ## Testes
 
-O projeto possui **25 testes** organizados em duas suítes:
+O projeto possui **76 testes** organizados em seis suítes:
 
 | Suíte | Tipo | Testes |
 |---|---|---|
 | `PacienteServiceTest` | Unitário (Mockito) | 11 |
-| `PacienteControllerTest` | Controller (`@WebMvcTest` + MockMvc) | 13 |
+| `PlanoServiceTest` | Unitário (Mockito) | 8 |
+| `PagamentoServiceTest` | Unitário (Mockito) | 8 |
+| `AulaServiceTest` | Unitário (Mockito) | 8 |
+| `PacienteControllerTest` | Controller (`@WebMvcTest`) | 13 |
+| `PlanoControllerTest` | Controller (`@WebMvcTest`) | 11 |
+| `PagamentoControllerTest` | Controller (`@WebMvcTest`) | 9 |
+| `AulaControllerTest` | Controller (`@WebMvcTest`) | 7 |
 | `PilatesApiApplicationTests` | Integração (`@SpringBootTest`) | 1 |
 
 ### Executar os testes
@@ -309,6 +411,35 @@ JAVA_HOME=/caminho/para/jdk21 mvn test
 Os testes de serviço e controller não necessitam de banco de dados. O `@SpringBootTest` usa H2 em memória automaticamente via `src/test/resources/application.properties`.
 
 ### O que é testado
+
+**PlanoServiceTest** — regras de plano:
+- Criação com sucesso (frequência compatível com dias)
+- Paciente inativo bloqueia criação
+- Frequência incompatível com dias lança exceção
+- Criação de novo plano desativa o plano ativo anterior
+- Paciente não encontrado lança 404
+- Busca de plano ativo por paciente
+- Inativação de plano e tentativa de inativar já inativo
+
+**PagamentoServiceTest** — cobranças:
+- Criação com sucesso (status PENDENTE, período calculado)
+- Paciente inativo bloqueia cobrança
+- Valor abaixo do plano lança exceção
+- Duplicidade de período lança exceção
+- Paciente não encontrado lança 404
+- Confirmação muda status para PAGO e chama geração de aulas
+- Tentativa de pagar já confirmado lança exceção
+- Atualização de pagamentos vencidos
+
+**AulaServiceTest** — geração e controle de aulas:
+- Cálculo correto de aulas por frequência (fevereiro 2025: 2x semana = 8 aulas exatas)
+- Geração de datas corretas para os dias definidos
+- Não gera aulas duplicadas quando já existe registro
+- Pagamento pendente bloqueia geração
+- Paciente inativo bloqueia geração
+- Marcar aula como realizada
+- Tentativa de realizar já realizada lança exceção
+- Aula não encontrada lança 404
 
 **PacienteServiceTest** — lógica de negócio com repositório mockado:
 - `cadastrar` com e sem endereço

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -4,7 +4,7 @@
 
 A **Carlesso Pilates API** é uma API REST desenvolvida para gerenciar o cadastro de pacientes de um estúdio de pilates. Ela expõe endpoints para criação, consulta, atualização e inativação de pacientes, com dados de endereço embutidos e paginação nas listagens.
 
-A aplicação foi construída com **Spring Boot 3** e **Java 21**, utiliza **PostgreSQL** como banco de dados relacional, conta com documentação interativa via **Swagger UI** e possui suíte de testes cobrindo as camadas de serviço e controller.
+A aplicação foi construída com **Spring Boot 3** e **Java 21**, utiliza **PostgreSQL** como banco de dados relacional, gerencia o schema com **Flyway**, conta com documentação interativa via **Swagger UI**, processos automáticos via **Spring Scheduler** e possui suíte de testes cobrindo as camadas de serviço e controller.
 
 ---
 
@@ -18,6 +18,7 @@ A aplicação foi construída com **Spring Boot 3** e **Java 21**, utiliza **Pos
 | Spring Validation | 3.4.5 | Validação de entrada |
 | PostgreSQL | 16 | Banco de dados relacional |
 | Flyway | (via spring-boot-starter-parent) | Versionamento e migração de schema do banco |
+| Spring Scheduler | (via spring-boot-starter) | Processos automáticos agendados |
 | springdoc-openapi | 2.8.3 | Documentação Swagger/OpenAPI |
 | Maven | 3.9 | Build e gerenciamento de dependências |
 | Docker | - | Containerização |
@@ -70,22 +71,99 @@ src/
 │   │       ├── PacienteUpdateDTO.java       # Payload de atualização
 │   │       ├── PacienteResponseDTO.java     # Resposta da API
 │   │       └── EnderecoDTO.java             # DTO de endereço
+│   ├── java/com/carlesso/pilatesapi/
+│   │   ├── entity/enums/
+│   │   │   ├── TipoPagamento.java
+│   │   │   ├── FrequenciaSemanal.java
+│   │   │   └── StatusPagamento.java
+│   │   ├── entity/
+│   │   │   ├── Plano.java
+│   │   │   ├── Pagamento.java
+│   │   │   └── Aula.java
+│   │   ├── service/
+│   │   │   ├── PlanoService.java
+│   │   │   ├── PagamentoService.java
+│   │   │   └── AulaService.java
+│   │   ├── controller/
+│   │   │   ├── PlanoController.java
+│   │   │   ├── PagamentoController.java
+│   │   │   └── AulaController.java
+│   │   └── scheduler/
+│   │       └── CobrancaScheduler.java
 │   └── resources/
 │       ├── application.properties
 │       └── db/migration/
-│           ├── V1__create_pacientes_table.sql  # Criação da tabela pacientes
-│           └── V2__insert_pacientes_teste.sql  # Carga inicial com 10 pacientes de teste
+│           ├── V1__create_pacientes_table.sql
+│           ├── V2__insert_pacientes_teste.sql
+│           ├── V3__create_planos_table.sql
+│           ├── V4__create_pagamentos_table.sql
+│           └── V5__create_aulas_table.sql
 └── test/java/com/carlesso/pilatesapi/
-    ├── PilatesApiApplicationTests.java  # Context load test
+    ├── PilatesApiApplicationTests.java
     ├── service/
-    │   └── PacienteServiceTest.java     # Testes unitários do serviço (11 casos)
+    │   ├── PacienteServiceTest.java      # 11 casos
+    │   ├── PlanoServiceTest.java         # 8 casos
+    │   ├── PagamentoServiceTest.java     # 8 casos
+    │   └── AulaServiceTest.java          # 8 casos
     └── controller/
-        └── PacienteControllerTest.java  # Testes de controller com MockMvc (13 casos)
+        ├── PacienteControllerTest.java   # 13 casos
+        ├── PlanoControllerTest.java      # 11 casos
+        ├── PagamentoControllerTest.java  # 9 casos
+        └── AulaControllerTest.java       # 7 casos
 ```
 
 ---
 
-## 4. Modelo de Dados
+## 4. Regras de Negócio
+
+### 4.1 Pacientes
+- Um paciente pode ter **apenas um plano ativo** por vez
+- Pacientes com `ativo = false` não podem receber novas cobranças nem ter aulas geradas
+
+### 4.2 Planos de Pagamento
+
+| Tipo | Duração |
+|---|---|
+| `MENSAL` | 1 mês |
+| `TRIMESTRAL` | 3 meses |
+| `ANUAL` | 12 meses |
+
+- A quantidade de dias da semana selecionados deve corresponder à frequência (ex: `DUAS_VEZES` → exatamente 2 dias)
+- Ao criar um novo plano para o paciente, o plano ativo anterior é automaticamente inativado
+- Alterações de plano valem apenas para os próximos ciclos
+
+### 4.3 Frequência de Aulas
+
+| Enum | Vezes/semana | Aulas/mês (referência) |
+|---|---|---|
+| `UMA_VEZ` | 1 | 4 |
+| `DUAS_VEZES` | 2 | 8 |
+| `TRES_VEZES` | 3 | 12 |
+
+### 4.4 Pagamentos
+
+- Status possíveis: `PENDENTE` → `PAGO` ou `VENCIDO`
+- O valor pago não pode ser menor que o valor do plano
+- Não pode haver dois pagamentos para o mesmo plano no mesmo `periodoInicio`
+- Ao confirmar como `PAGO`, as aulas do período são geradas automaticamente
+- Pagamentos `VENCIDO` bloqueiam geração de novas aulas (via scheduler)
+
+### 4.5 Geração de Aulas
+
+- Aulas são geradas a partir dos dias da semana definidos no plano, percorrendo dia a dia entre `periodoInicio` e `periodoFim`
+- Não gera aulas duplicadas: se o paciente já tiver aula naquela data, ela é ignorada
+- Requer: paciente ativo + pagamento com status `PAGO`
+
+### 4.6 Processos Automáticos (Scheduler)
+
+| Cron | Ação |
+|---|---|
+| `0 0 6 * * *` (06:00) | Marca como `VENCIDO` todos os pagamentos `PENDENTE` com `dataVencimento` anterior à data atual |
+| `0 0 7 * * *` (07:00) | Gera cobranças futuras para planos ativos quando faltam ≤ 7 dias para o fim do período atual |
+
+---
+
+## 5. Modelo de Dados
 
 ### Entidade: Paciente
 
@@ -116,7 +194,62 @@ Armazenada nas colunas da própria tabela `pacientes`.
 
 ---
 
-## 5. Endpoints
+### Entidade: Plano
+
+Tabela: `planos`
+
+| Campo | Tipo | Restrições | Descrição |
+|---|---|---|---|
+| `id` | `BIGINT` | PK, auto-increment | Identificador único |
+| `paciente_id` | `BIGINT` | NOT NULL, FK | Paciente vinculado |
+| `tipo` | `VARCHAR(20)` | NOT NULL | MENSAL / TRIMESTRAL / ANUAL |
+| `valor` | `DECIMAL(10,2)` | NOT NULL | Valor do plano |
+| `frequencia_semanal` | `VARCHAR(20)` | NOT NULL | UMA_VEZ / DUAS_VEZES / TRES_VEZES |
+| `data_inicio` | `DATE` | NOT NULL | Data de início do plano |
+| `ativo` | `BOOLEAN` | NOT NULL, default `true` | Status do plano |
+
+Tabela de join: `plano_dias_semana`
+
+| Campo | Tipo | Descrição |
+|---|---|---|
+| `plano_id` | `BIGINT` | FK para planos |
+| `dia_semana` | `VARCHAR(15)` | Dia da semana (MONDAY, TUESDAY…) |
+
+### Entidade: Pagamento
+
+Tabela: `pagamentos`
+
+| Campo | Tipo | Restrições | Descrição |
+|---|---|---|---|
+| `id` | `BIGINT` | PK | Identificador único |
+| `paciente_id` | `BIGINT` | NOT NULL, FK | Paciente vinculado |
+| `plano_id` | `BIGINT` | NOT NULL, FK | Plano vinculado |
+| `valor` | `DECIMAL(10,2)` | NOT NULL | Valor pago |
+| `status` | `VARCHAR(20)` | NOT NULL | PENDENTE / PAGO / VENCIDO |
+| `data_pagamento` | `DATE` | nullable | Data de confirmação do pagamento |
+| `data_vencimento` | `DATE` | NOT NULL | Prazo limite para pagamento |
+| `periodo_inicio` | `DATE` | NOT NULL | Início do período cobrado |
+| `periodo_fim` | `DATE` | NOT NULL | Fim do período cobrado |
+
+Constraint: `UNIQUE (plano_id, periodo_inicio)`
+
+### Entidade: Aula
+
+Tabela: `aulas`
+
+| Campo | Tipo | Restrições | Descrição |
+|---|---|---|---|
+| `id` | `BIGINT` | PK | Identificador único |
+| `paciente_id` | `BIGINT` | NOT NULL, FK | Paciente vinculado |
+| `pagamento_id` | `BIGINT` | NOT NULL, FK | Pagamento que gerou a aula |
+| `data` | `DATE` | NOT NULL | Data da aula |
+| `realizada` | `BOOLEAN` | NOT NULL, default `false` | Presença confirmada |
+
+Constraint: `UNIQUE (paciente_id, data)`
+
+---
+
+## 6. Endpoints
 
 **Base URL:** `http://localhost:8080`
 
@@ -307,7 +440,7 @@ DELETE /pacientes/1
 
 ---
 
-## 6. Documentação Interativa
+## 7. Documentação Interativa
 
 Com a aplicação rodando, acesse o Swagger UI para explorar e testar os endpoints diretamente pelo navegador:
 
@@ -318,7 +451,7 @@ Com a aplicação rodando, acesse o Swagger UI para explorar e testar os endpoin
 
 ---
 
-## 7. Configuração
+## 8. Configuração
 
 ### Variáveis de ambiente
 
@@ -351,7 +484,7 @@ springdoc.api-docs.path=/api-docs
 
 ---
 
-## 7.1 Migrações de Banco (Flyway)
+## 8.1 Migrações de Banco (Flyway)
 
 O **Flyway** executa automaticamente os scripts SQL ao iniciar a aplicação, seguindo a ordem das versões. Os arquivos ficam em `src/main/resources/db/migration/`.
 
@@ -389,7 +522,7 @@ Nos testes automatizados o Flyway fica **desabilitado** (`spring.flyway.enabled=
 
 ---
 
-## 8. Como Rodar
+## 9. Como Rodar
 
 ### Opção A — Docker Compose (recomendado)
 
@@ -447,7 +580,7 @@ JAVA_HOME=/caminho/para/jdk21 mvn spring-boot:run
 
 ---
 
-## 9. Exemplos com curl
+## 10. Exemplos com curl
 
 ### Cadastrar paciente
 
@@ -500,7 +633,7 @@ curl -s -X DELETE http://localhost:8080/pacientes/1 -o /dev/null -w "%{http_code
 
 ---
 
-## 10. Infraestrutura Docker
+## 11. Infraestrutura Docker
 
 ### Dockerfile (multi-stage build)
 
@@ -520,16 +653,22 @@ O serviço `app` aguarda o `db` estar saudável (healthcheck via `pg_isready`) a
 
 ---
 
-## 11. Testes
+## 12. Testes
 
 ### Visão geral
 
-A suíte de testes possui **25 casos** distribuídos em três classes:
+A suíte de testes possui **76 casos** distribuídos em nove classes:
 
 | Classe | Tipo | Casos |
 |---|---|---|
-| `PacienteServiceTest` | Unitário (Mockito, sem Spring) | 11 |
-| `PacienteControllerTest` | Controller (`@WebMvcTest` + MockMvc) | 13 |
+| `PacienteServiceTest` | Unitário (Mockito) | 11 |
+| `PlanoServiceTest` | Unitário (Mockito) | 8 |
+| `PagamentoServiceTest` | Unitário (Mockito) | 8 |
+| `AulaServiceTest` | Unitário (Mockito) | 8 |
+| `PacienteControllerTest` | Controller (`@WebMvcTest`) | 13 |
+| `PlanoControllerTest` | Controller (`@WebMvcTest`) | 11 |
+| `PagamentoControllerTest` | Controller (`@WebMvcTest`) | 9 |
+| `AulaControllerTest` | Controller (`@WebMvcTest`) | 7 |
 | `PilatesApiApplicationTests` | Integração (`@SpringBootTest` + H2) | 1 |
 
 ### Estratégia por camada
@@ -571,7 +710,7 @@ Saída esperada:
 Tests run: 11 — PacienteServiceTest
 Tests run: 13 — PacienteControllerTest
 Tests run:  1 — PilatesApiApplicationTests
-Tests run: 25, Failures: 0, Errors: 0, Skipped: 0
+Tests run: 76, Failures: 0, Errors: 0, Skipped: 0
 BUILD SUCCESS
 ```
 

--- a/src/main/java/com/carlesso/pilatesapi/PilatesApiApplication.java
+++ b/src/main/java/com/carlesso/pilatesapi/PilatesApiApplication.java
@@ -2,8 +2,10 @@ package com.carlesso.pilatesapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class PilatesApiApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/carlesso/pilatesapi/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/carlesso/pilatesapi/config/GlobalExceptionHandler.java
@@ -16,4 +16,16 @@ public class GlobalExceptionHandler {
     public Map<String, String> handleNotFound(EntityNotFoundException e) {
         return Map.of("erro", e.getMessage());
     }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Map<String, String> handleBadRequest(IllegalArgumentException e) {
+        return Map.of("erro", e.getMessage());
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public Map<String, String> handleConflict(IllegalStateException e) {
+        return Map.of("erro", e.getMessage());
+    }
 }

--- a/src/main/java/com/carlesso/pilatesapi/controller/AulaController.java
+++ b/src/main/java/com/carlesso/pilatesapi/controller/AulaController.java
@@ -1,0 +1,64 @@
+package com.carlesso.pilatesapi.controller;
+
+import com.carlesso.pilatesapi.dto.AulaResponseDTO;
+import com.carlesso.pilatesapi.service.AulaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Aulas", description = "Consulta e controle de presença nas aulas")
+@RestController
+@RequestMapping("/aulas")
+public class AulaController {
+
+    private final AulaService service;
+
+    public AulaController(AulaService service) {
+        this.service = service;
+    }
+
+    @Operation(summary = "Buscar aula por ID")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Aula encontrada"),
+            @ApiResponse(responseCode = "404", description = "Aula não encontrada")
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<AulaResponseDTO> buscar(
+            @Parameter(description = "ID da aula") @PathVariable Long id) {
+        return ResponseEntity.ok(service.buscarPorId(id));
+    }
+
+    @Operation(summary = "Listar aulas do paciente", description = "Retorna todas as aulas de um paciente ordenadas por data.")
+    @ApiResponse(responseCode = "200", description = "Lista retornada com sucesso")
+    @GetMapping("/paciente/{pacienteId}")
+    public ResponseEntity<List<AulaResponseDTO>> listarPorPaciente(
+            @Parameter(description = "ID do paciente") @PathVariable Long pacienteId) {
+        return ResponseEntity.ok(service.buscarPorPaciente(pacienteId));
+    }
+
+    @Operation(summary = "Listar aulas de um pagamento")
+    @ApiResponse(responseCode = "200", description = "Lista retornada com sucesso")
+    @GetMapping("/pagamento/{pagamentoId}")
+    public ResponseEntity<List<AulaResponseDTO>> listarPorPagamento(
+            @Parameter(description = "ID do pagamento") @PathVariable Long pagamentoId) {
+        return ResponseEntity.ok(service.buscarPorPagamento(pagamentoId));
+    }
+
+    @Operation(summary = "Marcar aula como realizada")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Aula marcada como realizada"),
+            @ApiResponse(responseCode = "404", description = "Aula não encontrada"),
+            @ApiResponse(responseCode = "409", description = "Aula já marcada como realizada")
+    })
+    @PatchMapping("/{id}/realizar")
+    public ResponseEntity<AulaResponseDTO> realizar(
+            @Parameter(description = "ID da aula") @PathVariable Long id) {
+        return ResponseEntity.ok(service.realizarAula(id));
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/controller/PagamentoController.java
+++ b/src/main/java/com/carlesso/pilatesapi/controller/PagamentoController.java
@@ -1,0 +1,77 @@
+package com.carlesso.pilatesapi.controller;
+
+import com.carlesso.pilatesapi.dto.PagamentoRequestDTO;
+import com.carlesso.pilatesapi.dto.PagamentoResponseDTO;
+import com.carlesso.pilatesapi.service.PagamentoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Tag(name = "Pagamentos", description = "Gerenciamento de pagamentos e cobranças")
+@RestController
+@RequestMapping("/pagamentos")
+public class PagamentoController {
+
+    private final PagamentoService service;
+
+    public PagamentoController(PagamentoService service) {
+        this.service = service;
+    }
+
+    @Operation(summary = "Criar pagamento", description = "Cria um novo pagamento com status PENDENTE. O período final é calculado automaticamente com base no tipo do plano.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Pagamento criado com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Dados inválidos ou valor abaixo do plano"),
+            @ApiResponse(responseCode = "404", description = "Paciente ou plano não encontrado"),
+            @ApiResponse(responseCode = "409", description = "Paciente inativo ou pagamento duplicado para o período")
+    })
+    @PostMapping
+    public ResponseEntity<PagamentoResponseDTO> criar(
+            @RequestBody @Valid PagamentoRequestDTO dto,
+            UriComponentsBuilder uriBuilder) {
+        PagamentoResponseDTO response = service.criar(dto);
+        var uri = uriBuilder.path("/pagamentos/{id}").buildAndExpand(response.id()).toUri();
+        return ResponseEntity.created(uri).body(response);
+    }
+
+    @Operation(summary = "Buscar pagamento por ID")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Pagamento encontrado"),
+            @ApiResponse(responseCode = "404", description = "Pagamento não encontrado")
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<PagamentoResponseDTO> buscar(
+            @Parameter(description = "ID do pagamento") @PathVariable Long id) {
+        return ResponseEntity.ok(service.buscarPorId(id));
+    }
+
+    @Operation(summary = "Listar pagamentos do paciente")
+    @ApiResponse(responseCode = "200", description = "Lista retornada com sucesso")
+    @GetMapping("/paciente/{pacienteId}")
+    public ResponseEntity<List<PagamentoResponseDTO>> listarPorPaciente(
+            @Parameter(description = "ID do paciente") @PathVariable Long pacienteId) {
+        return ResponseEntity.ok(service.listarPorPaciente(pacienteId));
+    }
+
+    @Operation(summary = "Confirmar pagamento", description = "Marca o pagamento como PAGO e gera automaticamente as aulas do período.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Pagamento confirmado e aulas geradas"),
+            @ApiResponse(responseCode = "404", description = "Pagamento não encontrado"),
+            @ApiResponse(responseCode = "409", description = "Pagamento já confirmado")
+    })
+    @PatchMapping("/{id}/pagar")
+    public ResponseEntity<PagamentoResponseDTO> pagar(
+            @Parameter(description = "ID do pagamento") @PathVariable Long id,
+            @RequestParam(required = false) LocalDate dataPagamento) {
+        return ResponseEntity.ok(service.pagar(id, dataPagamento));
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/controller/PlanoController.java
+++ b/src/main/java/com/carlesso/pilatesapi/controller/PlanoController.java
@@ -1,0 +1,95 @@
+package com.carlesso.pilatesapi.controller;
+
+import com.carlesso.pilatesapi.dto.PlanoRequestDTO;
+import com.carlesso.pilatesapi.dto.PlanoResponseDTO;
+import com.carlesso.pilatesapi.service.PlanoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+
+@Tag(name = "Planos", description = "Gerenciamento de planos de pagamento dos pacientes")
+@RestController
+@RequestMapping("/planos")
+public class PlanoController {
+
+    private final PlanoService planoService;
+
+    public PlanoController(PlanoService planoService) {
+        this.planoService = planoService;
+    }
+
+    @Operation(
+            summary = "Criar plano",
+            description = "Cria um novo plano de pagamento para um paciente. Se já existir um plano ativo, ele será inativado automaticamente."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Plano criado com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Dados inválidos ou frequência incompatível com os dias informados"),
+            @ApiResponse(responseCode = "404", description = "Paciente não encontrado"),
+            @ApiResponse(responseCode = "409", description = "Paciente inativo")
+    })
+    @PostMapping
+    public ResponseEntity<PlanoResponseDTO> criar(
+            @RequestBody @Valid PlanoRequestDTO dto,
+            UriComponentsBuilder uriBuilder) {
+        PlanoResponseDTO response = planoService.criar(dto);
+        var uri = uriBuilder.path("/planos/{id}").buildAndExpand(response.id()).toUri();
+        return ResponseEntity.created(uri).body(response);
+    }
+
+    @Operation(summary = "Buscar plano por ID")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Plano encontrado"),
+            @ApiResponse(responseCode = "404", description = "Plano não encontrado")
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<PlanoResponseDTO> buscar(
+            @Parameter(description = "ID do plano") @PathVariable Long id) {
+        return ResponseEntity.ok(planoService.buscarPorId(id));
+    }
+
+    @Operation(summary = "Listar planos do paciente")
+    @ApiResponse(responseCode = "200", description = "Lista retornada com sucesso")
+    @GetMapping("/paciente/{pacienteId}")
+    public ResponseEntity<List<PlanoResponseDTO>> listarPorPaciente(
+            @Parameter(description = "ID do paciente") @PathVariable Long pacienteId) {
+        return ResponseEntity.ok(planoService.listarPorPaciente(pacienteId));
+    }
+
+    @Operation(summary = "Buscar plano ativo do paciente")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Plano ativo encontrado"),
+            @ApiResponse(responseCode = "204", description = "Paciente não possui plano ativo")
+    })
+    @GetMapping("/paciente/{pacienteId}/ativo")
+    public ResponseEntity<PlanoResponseDTO> buscarAtivoPorPaciente(
+            @Parameter(description = "ID do paciente") @PathVariable Long pacienteId) {
+        return planoService.buscarAtivoPorPaciente(pacienteId)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.noContent().build());
+    }
+
+    @Operation(
+            summary = "Inativar plano",
+            description = "Inativa o plano especificado. Não afeta pagamentos ou aulas já gerados."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Plano inativado com sucesso"),
+            @ApiResponse(responseCode = "404", description = "Plano não encontrado"),
+            @ApiResponse(responseCode = "409", description = "Plano já está inativo")
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> inativar(
+            @Parameter(description = "ID do plano") @PathVariable Long id) {
+        planoService.inativar(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/dto/AulaResponseDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/AulaResponseDTO.java
@@ -1,0 +1,25 @@
+package com.carlesso.pilatesapi.dto;
+
+import com.carlesso.pilatesapi.entity.Aula;
+
+import java.time.LocalDate;
+
+public record AulaResponseDTO(
+        Long id,
+        Long pacienteId,
+        String pacienteNome,
+        Long pagamentoId,
+        LocalDate data,
+        boolean realizada
+) {
+    public static AulaResponseDTO from(Aula aula) {
+        return new AulaResponseDTO(
+                aula.getId(),
+                aula.getPaciente().getId(),
+                aula.getPaciente().getNome(),
+                aula.getPagamento().getId(),
+                aula.getData(),
+                aula.isRealizada()
+        );
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/dto/PagamentoRequestDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/PagamentoRequestDTO.java
@@ -1,0 +1,26 @@
+package com.carlesso.pilatesapi.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record PagamentoRequestDTO(
+
+        @NotNull(message = "pacienteId é obrigatório")
+        Long pacienteId,
+
+        @NotNull(message = "planoId é obrigatório")
+        Long planoId,
+
+        @NotNull(message = "valor é obrigatório")
+        @DecimalMin(value = "0.01", message = "valor deve ser maior que zero")
+        BigDecimal valor,
+
+        @NotNull(message = "dataVencimento é obrigatória")
+        LocalDate dataVencimento,
+
+        @NotNull(message = "periodoInicio é obrigatório")
+        LocalDate periodoInicio
+) {}

--- a/src/main/java/com/carlesso/pilatesapi/dto/PagamentoResponseDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/PagamentoResponseDTO.java
@@ -1,0 +1,35 @@
+package com.carlesso.pilatesapi.dto;
+
+import com.carlesso.pilatesapi.entity.Pagamento;
+import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record PagamentoResponseDTO(
+        Long id,
+        Long pacienteId,
+        String pacienteNome,
+        Long planoId,
+        BigDecimal valor,
+        StatusPagamento status,
+        LocalDate dataPagamento,
+        LocalDate dataVencimento,
+        LocalDate periodoInicio,
+        LocalDate periodoFim
+) {
+    public static PagamentoResponseDTO from(Pagamento pagamento) {
+        return new PagamentoResponseDTO(
+                pagamento.getId(),
+                pagamento.getPaciente().getId(),
+                pagamento.getPaciente().getNome(),
+                pagamento.getPlano().getId(),
+                pagamento.getValor(),
+                pagamento.getStatus(),
+                pagamento.getDataPagamento(),
+                pagamento.getDataVencimento(),
+                pagamento.getPeriodoInicio(),
+                pagamento.getPeriodoFim()
+        );
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/dto/PlanoRequestDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/PlanoRequestDTO.java
@@ -1,0 +1,33 @@
+package com.carlesso.pilatesapi.dto;
+
+import com.carlesso.pilatesapi.entity.enums.FrequenciaSemanal;
+import com.carlesso.pilatesapi.entity.enums.TipoPagamento;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+
+public record PlanoRequestDTO(
+
+        @NotNull(message = "pacienteId é obrigatório")
+        Long pacienteId,
+
+        @NotNull(message = "tipo é obrigatório")
+        TipoPagamento tipo,
+
+        @NotNull(message = "valor é obrigatório")
+        @DecimalMin(value = "0.01", message = "valor deve ser maior que zero")
+        BigDecimal valor,
+
+        @NotNull(message = "frequenciaSemanal é obrigatória")
+        FrequenciaSemanal frequenciaSemanal,
+
+        @NotEmpty(message = "diasSemana não pode ser vazio")
+        List<DayOfWeek> diasSemana,
+
+        LocalDate dataInicio
+) {}

--- a/src/main/java/com/carlesso/pilatesapi/dto/PlanoResponseDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/PlanoResponseDTO.java
@@ -1,0 +1,36 @@
+package com.carlesso.pilatesapi.dto;
+
+import com.carlesso.pilatesapi.entity.Plano;
+import com.carlesso.pilatesapi.entity.enums.FrequenciaSemanal;
+import com.carlesso.pilatesapi.entity.enums.TipoPagamento;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+
+public record PlanoResponseDTO(
+        Long id,
+        Long pacienteId,
+        String pacienteNome,
+        TipoPagamento tipo,
+        BigDecimal valor,
+        FrequenciaSemanal frequenciaSemanal,
+        List<DayOfWeek> diasSemana,
+        LocalDate dataInicio,
+        boolean ativo
+) {
+    public static PlanoResponseDTO from(Plano plano) {
+        return new PlanoResponseDTO(
+                plano.getId(),
+                plano.getPaciente().getId(),
+                plano.getPaciente().getNome(),
+                plano.getTipo(),
+                plano.getValor(),
+                plano.getFrequenciaSemanal(),
+                plano.getDiasSemana(),
+                plano.getDataInicio(),
+                plano.isAtivo()
+        );
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/entity/Aula.java
+++ b/src/main/java/com/carlesso/pilatesapi/entity/Aula.java
@@ -1,0 +1,46 @@
+package com.carlesso.pilatesapi.entity;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "aulas", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"paciente_id", "data"})
+})
+public class Aula {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "paciente_id", nullable = false)
+    private Paciente paciente;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "pagamento_id", nullable = false)
+    private Pagamento pagamento;
+
+    @Column(nullable = false)
+    private LocalDate data;
+
+    @Column(nullable = false)
+    private boolean realizada = false;
+
+    public Aula() {}
+
+    public Long getId() { return id; }
+
+    public Paciente getPaciente() { return paciente; }
+    public void setPaciente(Paciente paciente) { this.paciente = paciente; }
+
+    public Pagamento getPagamento() { return pagamento; }
+    public void setPagamento(Pagamento pagamento) { this.pagamento = pagamento; }
+
+    public LocalDate getData() { return data; }
+    public void setData(LocalDate data) { this.data = data; }
+
+    public boolean isRealizada() { return realizada; }
+    public void setRealizada(boolean realizada) { this.realizada = realizada; }
+}

--- a/src/main/java/com/carlesso/pilatesapi/entity/Pagamento.java
+++ b/src/main/java/com/carlesso/pilatesapi/entity/Pagamento.java
@@ -1,0 +1,71 @@
+package com.carlesso.pilatesapi.entity;
+
+import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "pagamentos")
+public class Pagamento {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "paciente_id", nullable = false)
+    private Paciente paciente;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "plano_id", nullable = false)
+    private Plano plano;
+
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal valor;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private StatusPagamento status = StatusPagamento.PENDENTE;
+
+    @Column(name = "data_pagamento")
+    private LocalDate dataPagamento;
+
+    @Column(name = "data_vencimento", nullable = false)
+    private LocalDate dataVencimento;
+
+    @Column(name = "periodo_inicio", nullable = false)
+    private LocalDate periodoInicio;
+
+    @Column(name = "periodo_fim", nullable = false)
+    private LocalDate periodoFim;
+
+    public Pagamento() {}
+
+    public Long getId() { return id; }
+
+    public Paciente getPaciente() { return paciente; }
+    public void setPaciente(Paciente paciente) { this.paciente = paciente; }
+
+    public Plano getPlano() { return plano; }
+    public void setPlano(Plano plano) { this.plano = plano; }
+
+    public BigDecimal getValor() { return valor; }
+    public void setValor(BigDecimal valor) { this.valor = valor; }
+
+    public StatusPagamento getStatus() { return status; }
+    public void setStatus(StatusPagamento status) { this.status = status; }
+
+    public LocalDate getDataPagamento() { return dataPagamento; }
+    public void setDataPagamento(LocalDate dataPagamento) { this.dataPagamento = dataPagamento; }
+
+    public LocalDate getDataVencimento() { return dataVencimento; }
+    public void setDataVencimento(LocalDate dataVencimento) { this.dataVencimento = dataVencimento; }
+
+    public LocalDate getPeriodoInicio() { return periodoInicio; }
+    public void setPeriodoInicio(LocalDate periodoInicio) { this.periodoInicio = periodoInicio; }
+
+    public LocalDate getPeriodoFim() { return periodoFim; }
+    public void setPeriodoFim(LocalDate periodoFim) { this.periodoFim = periodoFim; }
+}

--- a/src/main/java/com/carlesso/pilatesapi/entity/Plano.java
+++ b/src/main/java/com/carlesso/pilatesapi/entity/Plano.java
@@ -1,0 +1,71 @@
+package com.carlesso.pilatesapi.entity;
+
+import com.carlesso.pilatesapi.entity.enums.FrequenciaSemanal;
+import com.carlesso.pilatesapi.entity.enums.TipoPagamento;
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+
+@Entity
+@Table(name = "planos")
+public class Plano {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "paciente_id", nullable = false)
+    private Paciente paciente;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private TipoPagamento tipo;
+
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal valor;
+
+    @Column(name = "frequencia_semanal", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private FrequenciaSemanal frequenciaSemanal;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "plano_dias_semana", joinColumns = @JoinColumn(name = "plano_id"))
+    @Column(name = "dia_semana")
+    @Enumerated(EnumType.STRING)
+    private List<DayOfWeek> diasSemana;
+
+    @Column(name = "data_inicio", nullable = false)
+    private LocalDate dataInicio;
+
+    @Column(nullable = false)
+    private boolean ativo = true;
+
+    public Plano() {}
+
+    public Long getId() { return id; }
+
+    public Paciente getPaciente() { return paciente; }
+    public void setPaciente(Paciente paciente) { this.paciente = paciente; }
+
+    public TipoPagamento getTipo() { return tipo; }
+    public void setTipo(TipoPagamento tipo) { this.tipo = tipo; }
+
+    public BigDecimal getValor() { return valor; }
+    public void setValor(BigDecimal valor) { this.valor = valor; }
+
+    public FrequenciaSemanal getFrequenciaSemanal() { return frequenciaSemanal; }
+    public void setFrequenciaSemanal(FrequenciaSemanal frequenciaSemanal) { this.frequenciaSemanal = frequenciaSemanal; }
+
+    public List<DayOfWeek> getDiasSemana() { return diasSemana; }
+    public void setDiasSemana(List<DayOfWeek> diasSemana) { this.diasSemana = diasSemana; }
+
+    public LocalDate getDataInicio() { return dataInicio; }
+    public void setDataInicio(LocalDate dataInicio) { this.dataInicio = dataInicio; }
+
+    public boolean isAtivo() { return ativo; }
+    public void setAtivo(boolean ativo) { this.ativo = ativo; }
+}

--- a/src/main/java/com/carlesso/pilatesapi/entity/enums/FrequenciaSemanal.java
+++ b/src/main/java/com/carlesso/pilatesapi/entity/enums/FrequenciaSemanal.java
@@ -1,0 +1,23 @@
+package com.carlesso.pilatesapi.entity.enums;
+
+public enum FrequenciaSemanal {
+    UMA_VEZ(1, 4),
+    DUAS_VEZES(2, 8),
+    TRES_VEZES(3, 12);
+
+    private final int vezesPorSemana;
+    private final int aulasPorMes;
+
+    FrequenciaSemanal(int vezesPorSemana, int aulasPorMes) {
+        this.vezesPorSemana = vezesPorSemana;
+        this.aulasPorMes = aulasPorMes;
+    }
+
+    public int getVezesPorSemana() {
+        return vezesPorSemana;
+    }
+
+    public int getAulasPorMes() {
+        return aulasPorMes;
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/entity/enums/StatusPagamento.java
+++ b/src/main/java/com/carlesso/pilatesapi/entity/enums/StatusPagamento.java
@@ -1,0 +1,7 @@
+package com.carlesso.pilatesapi.entity.enums;
+
+public enum StatusPagamento {
+    PENDENTE,
+    PAGO,
+    VENCIDO
+}

--- a/src/main/java/com/carlesso/pilatesapi/entity/enums/TipoPagamento.java
+++ b/src/main/java/com/carlesso/pilatesapi/entity/enums/TipoPagamento.java
@@ -1,0 +1,17 @@
+package com.carlesso.pilatesapi.entity.enums;
+
+public enum TipoPagamento {
+    MENSAL(1),
+    TRIMESTRAL(3),
+    ANUAL(12);
+
+    private final int meses;
+
+    TipoPagamento(int meses) {
+        this.meses = meses;
+    }
+
+    public int getMeses() {
+        return meses;
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/repository/AulaRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/AulaRepository.java
@@ -1,0 +1,17 @@
+package com.carlesso.pilatesapi.repository;
+
+import com.carlesso.pilatesapi.entity.Aula;
+import com.carlesso.pilatesapi.entity.Paciente;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface AulaRepository extends JpaRepository<Aula, Long> {
+
+    boolean existsByPacienteAndData(Paciente paciente, LocalDate data);
+
+    List<Aula> findByPacienteIdOrderByData(Long pacienteId);
+
+    List<Aula> findByPagamentoIdOrderByData(Long pagamentoId);
+}

--- a/src/main/java/com/carlesso/pilatesapi/repository/PagamentoRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/PagamentoRepository.java
@@ -1,0 +1,21 @@
+package com.carlesso.pilatesapi.repository;
+
+import com.carlesso.pilatesapi.entity.Pagamento;
+import com.carlesso.pilatesapi.entity.Plano;
+import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface PagamentoRepository extends JpaRepository<Pagamento, Long> {
+
+    List<Pagamento> findByPacienteId(Long pacienteId);
+
+    List<Pagamento> findByStatusAndDataVencimentoBefore(StatusPagamento status, LocalDate data);
+
+    boolean existsByPlanoAndPeriodoInicio(Plano plano, LocalDate periodoInicio);
+
+    Optional<Pagamento> findTopByPlanoOrderByPeriodoFimDesc(Plano plano);
+}

--- a/src/main/java/com/carlesso/pilatesapi/repository/PlanoRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/PlanoRepository.java
@@ -1,0 +1,16 @@
+package com.carlesso.pilatesapi.repository;
+
+import com.carlesso.pilatesapi.entity.Plano;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PlanoRepository extends JpaRepository<Plano, Long> {
+
+    Optional<Plano> findByPacienteIdAndAtivoTrue(Long pacienteId);
+
+    List<Plano> findByPacienteId(Long pacienteId);
+
+    List<Plano> findByAtivoTrue();
+}

--- a/src/main/java/com/carlesso/pilatesapi/scheduler/CobrancaScheduler.java
+++ b/src/main/java/com/carlesso/pilatesapi/scheduler/CobrancaScheduler.java
@@ -1,0 +1,33 @@
+package com.carlesso.pilatesapi.scheduler;
+
+import com.carlesso.pilatesapi.service.PagamentoService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CobrancaScheduler {
+
+    private static final Logger log = LoggerFactory.getLogger(CobrancaScheduler.class);
+
+    private final PagamentoService pagamentoService;
+
+    public CobrancaScheduler(PagamentoService pagamentoService) {
+        this.pagamentoService = pagamentoService;
+    }
+
+    // Executa todo dia às 06:00 — marca como VENCIDO pagamentos pendentes expirados
+    @Scheduled(cron = "0 0 6 * * *")
+    public void atualizarPagamentosVencidos() {
+        int total = pagamentoService.atualizarVencidos();
+        log.info("Pagamentos marcados como VENCIDO: {}", total);
+    }
+
+    // Executa todo dia às 07:00 — gera cobranças futuras para planos ativos
+    @Scheduled(cron = "0 0 7 * * *")
+    public void gerarCobrancasFuturas() {
+        int total = pagamentoService.gerarCobrancasFuturas();
+        log.info("Cobranças futuras geradas: {}", total);
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/service/AulaService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/AulaService.java
@@ -1,0 +1,88 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.AulaResponseDTO;
+import com.carlesso.pilatesapi.entity.Aula;
+import com.carlesso.pilatesapi.entity.Pagamento;
+import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
+import com.carlesso.pilatesapi.repository.AulaRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class AulaService {
+
+    private final AulaRepository aulaRepository;
+
+    public AulaService(AulaRepository aulaRepository) {
+        this.aulaRepository = aulaRepository;
+    }
+
+    @Transactional
+    public List<Aula> gerarAulas(Pagamento pagamento) {
+        if (pagamento.getStatus() != StatusPagamento.PAGO) {
+            throw new IllegalStateException("Aulas só podem ser geradas para pagamentos com status PAGO");
+        }
+        if (!pagamento.getPaciente().isAtivo()) {
+            throw new IllegalStateException("Paciente inativo não pode ter aulas geradas");
+        }
+
+        var diasSemana = pagamento.getPlano().getDiasSemana();
+        LocalDate inicio = pagamento.getPeriodoInicio();
+        LocalDate fim = pagamento.getPeriodoFim();
+
+        List<Aula> aulas = new ArrayList<>();
+        LocalDate data = inicio;
+        while (!data.isAfter(fim)) {
+            if (diasSemana.contains(data.getDayOfWeek())) {
+                if (!aulaRepository.existsByPacienteAndData(pagamento.getPaciente(), data)) {
+                    Aula aula = new Aula();
+                    aula.setPaciente(pagamento.getPaciente());
+                    aula.setPagamento(pagamento);
+                    aula.setData(data);
+                    aulas.add(aula);
+                }
+            }
+            data = data.plusDays(1);
+        }
+
+        return aulaRepository.saveAll(aulas);
+    }
+
+    public List<AulaResponseDTO> buscarPorPaciente(Long pacienteId) {
+        return aulaRepository.findByPacienteIdOrderByData(pacienteId)
+                .stream()
+                .map(AulaResponseDTO::from)
+                .toList();
+    }
+
+    public List<AulaResponseDTO> buscarPorPagamento(Long pagamentoId) {
+        return aulaRepository.findByPagamentoIdOrderByData(pagamentoId)
+                .stream()
+                .map(AulaResponseDTO::from)
+                .toList();
+    }
+
+    public AulaResponseDTO buscarPorId(Long id) {
+        return AulaResponseDTO.from(encontrar(id));
+    }
+
+    @Transactional
+    public AulaResponseDTO realizarAula(Long id) {
+        Aula aula = encontrar(id);
+        if (aula.isRealizada()) {
+            throw new IllegalStateException("Aula já foi marcada como realizada");
+        }
+        aula.setRealizada(true);
+        return AulaResponseDTO.from(aula);
+    }
+
+    private Aula encontrar(Long id) {
+        return aulaRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Aula não encontrada: " + id));
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/service/PagamentoService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/PagamentoService.java
@@ -1,0 +1,152 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.PagamentoRequestDTO;
+import com.carlesso.pilatesapi.dto.PagamentoResponseDTO;
+import com.carlesso.pilatesapi.entity.Paciente;
+import com.carlesso.pilatesapi.entity.Pagamento;
+import com.carlesso.pilatesapi.entity.Plano;
+import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
+import com.carlesso.pilatesapi.repository.PacienteRepository;
+import com.carlesso.pilatesapi.repository.PagamentoRepository;
+import com.carlesso.pilatesapi.repository.PlanoRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+public class PagamentoService {
+
+    private final PagamentoRepository pagamentoRepository;
+    private final PacienteRepository pacienteRepository;
+    private final PlanoRepository planoRepository;
+    private final AulaService aulaService;
+
+    public PagamentoService(PagamentoRepository pagamentoRepository,
+                            PacienteRepository pacienteRepository,
+                            PlanoRepository planoRepository,
+                            AulaService aulaService) {
+        this.pagamentoRepository = pagamentoRepository;
+        this.pacienteRepository = pacienteRepository;
+        this.planoRepository = planoRepository;
+        this.aulaService = aulaService;
+    }
+
+    @Transactional
+    public PagamentoResponseDTO criar(PagamentoRequestDTO dto) {
+        Paciente paciente = pacienteRepository.findById(dto.pacienteId())
+                .orElseThrow(() -> new EntityNotFoundException("Paciente não encontrado: " + dto.pacienteId()));
+
+        if (!paciente.isAtivo()) {
+            throw new IllegalStateException("Paciente inativo não pode receber novas cobranças");
+        }
+
+        Plano plano = planoRepository.findById(dto.planoId())
+                .orElseThrow(() -> new EntityNotFoundException("Plano não encontrado: " + dto.planoId()));
+
+        if (dto.valor().compareTo(plano.getValor()) < 0) {
+            throw new IllegalArgumentException(
+                    "Valor do pagamento (R$ %s) não pode ser menor que o valor do plano (R$ %s)"
+                            .formatted(dto.valor(), plano.getValor())
+            );
+        }
+
+        LocalDate periodoFim = dto.periodoInicio().plusMonths(plano.getTipo().getMeses()).minusDays(1);
+
+        if (pagamentoRepository.existsByPlanoAndPeriodoInicio(plano, dto.periodoInicio())) {
+            throw new IllegalStateException(
+                    "Já existe um pagamento para este plano no período iniciado em " + dto.periodoInicio()
+            );
+        }
+
+        Pagamento pagamento = new Pagamento();
+        pagamento.setPaciente(paciente);
+        pagamento.setPlano(plano);
+        pagamento.setValor(dto.valor());
+        pagamento.setDataVencimento(dto.dataVencimento());
+        pagamento.setPeriodoInicio(dto.periodoInicio());
+        pagamento.setPeriodoFim(periodoFim);
+
+        return PagamentoResponseDTO.from(pagamentoRepository.save(pagamento));
+    }
+
+    @Transactional
+    public PagamentoResponseDTO pagar(Long id, LocalDate dataPagamento) {
+        Pagamento pagamento = encontrar(id);
+
+        if (pagamento.getStatus() == StatusPagamento.PAGO) {
+            throw new IllegalStateException("Pagamento já foi confirmado");
+        }
+
+        pagamento.setStatus(StatusPagamento.PAGO);
+        pagamento.setDataPagamento(dataPagamento != null ? dataPagamento : LocalDate.now());
+        pagamentoRepository.save(pagamento);
+
+        aulaService.gerarAulas(pagamento);
+
+        return PagamentoResponseDTO.from(pagamento);
+    }
+
+    public PagamentoResponseDTO buscarPorId(Long id) {
+        return PagamentoResponseDTO.from(encontrar(id));
+    }
+
+    public List<PagamentoResponseDTO> listarPorPaciente(Long pacienteId) {
+        return pagamentoRepository.findByPacienteId(pacienteId)
+                .stream()
+                .map(PagamentoResponseDTO::from)
+                .toList();
+    }
+
+    @Transactional
+    public int atualizarVencidos() {
+        List<Pagamento> vencidos = pagamentoRepository
+                .findByStatusAndDataVencimentoBefore(StatusPagamento.PENDENTE, LocalDate.now());
+        vencidos.forEach(p -> p.setStatus(StatusPagamento.VENCIDO));
+        return vencidos.size();
+    }
+
+    @Transactional
+    public int gerarCobrancasFuturas() {
+        List<Plano> planosAtivos = planoRepository.findByAtivoTrue();
+        int count = 0;
+
+        for (Plano plano : planosAtivos) {
+            if (!plano.getPaciente().isAtivo()) continue;
+
+            var ultimoPagamento = pagamentoRepository.findTopByPlanoOrderByPeriodoFimDesc(plano);
+
+            LocalDate periodoInicio;
+            if (ultimoPagamento.isEmpty()) {
+                periodoInicio = LocalDate.now();
+            } else {
+                var ultimo = ultimoPagamento.get();
+                if (LocalDate.now().isBefore(ultimo.getPeriodoFim().minusDays(6))) continue;
+                periodoInicio = ultimo.getPeriodoFim().plusDays(1);
+                if (pagamentoRepository.existsByPlanoAndPeriodoInicio(plano, periodoInicio)) continue;
+            }
+
+            LocalDate periodoFim = periodoInicio.plusMonths(plano.getTipo().getMeses()).minusDays(1);
+
+            Pagamento novoPagamento = new Pagamento();
+            novoPagamento.setPaciente(plano.getPaciente());
+            novoPagamento.setPlano(plano);
+            novoPagamento.setValor(plano.getValor());
+            novoPagamento.setDataVencimento(periodoInicio.plusDays(10));
+            novoPagamento.setPeriodoInicio(periodoInicio);
+            novoPagamento.setPeriodoFim(periodoFim);
+
+            pagamentoRepository.save(novoPagamento);
+            count++;
+        }
+
+        return count;
+    }
+
+    private Pagamento encontrar(Long id) {
+        return pagamentoRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Pagamento não encontrado: " + id));
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/service/PlanoService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/PlanoService.java
@@ -1,0 +1,94 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.PlanoRequestDTO;
+import com.carlesso.pilatesapi.dto.PlanoResponseDTO;
+import com.carlesso.pilatesapi.entity.Paciente;
+import com.carlesso.pilatesapi.entity.Plano;
+import com.carlesso.pilatesapi.repository.PacienteRepository;
+import com.carlesso.pilatesapi.repository.PlanoRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class PlanoService {
+
+    private final PlanoRepository planoRepository;
+    private final PacienteRepository pacienteRepository;
+
+    public PlanoService(PlanoRepository planoRepository, PacienteRepository pacienteRepository) {
+        this.planoRepository = planoRepository;
+        this.pacienteRepository = pacienteRepository;
+    }
+
+    @Transactional
+    public PlanoResponseDTO criar(PlanoRequestDTO dto) {
+        Paciente paciente = pacienteRepository.findById(dto.pacienteId())
+                .orElseThrow(() -> new EntityNotFoundException("Paciente não encontrado: " + dto.pacienteId()));
+
+        if (!paciente.isAtivo()) {
+            throw new IllegalStateException("Paciente inativo não pode receber novo plano");
+        }
+
+        if (dto.diasSemana().size() != dto.frequenciaSemanal().getVezesPorSemana()) {
+            throw new IllegalArgumentException(
+                    "Número de dias da semana (%d) incompatível com a frequência contratada (%s = %d dia(s) por semana)"
+                            .formatted(
+                                    dto.diasSemana().size(),
+                                    dto.frequenciaSemanal(),
+                                    dto.frequenciaSemanal().getVezesPorSemana()
+                            )
+            );
+        }
+
+        planoRepository.findByPacienteIdAndAtivoTrue(dto.pacienteId())
+                .ifPresent(planoAtivo -> {
+                    planoAtivo.setAtivo(false);
+                    planoRepository.save(planoAtivo);
+                });
+
+        Plano plano = new Plano();
+        plano.setPaciente(paciente);
+        plano.setTipo(dto.tipo());
+        plano.setValor(dto.valor());
+        plano.setFrequenciaSemanal(dto.frequenciaSemanal());
+        plano.setDiasSemana(dto.diasSemana());
+        plano.setDataInicio(dto.dataInicio() != null ? dto.dataInicio() : LocalDate.now());
+
+        return PlanoResponseDTO.from(planoRepository.save(plano));
+    }
+
+    public PlanoResponseDTO buscarPorId(Long id) {
+        return PlanoResponseDTO.from(encontrar(id));
+    }
+
+    public Optional<PlanoResponseDTO> buscarAtivoPorPaciente(Long pacienteId) {
+        return planoRepository.findByPacienteIdAndAtivoTrue(pacienteId)
+                .map(PlanoResponseDTO::from);
+    }
+
+    public List<PlanoResponseDTO> listarPorPaciente(Long pacienteId) {
+        return planoRepository.findByPacienteId(pacienteId)
+                .stream()
+                .map(PlanoResponseDTO::from)
+                .toList();
+    }
+
+    @Transactional
+    public void inativar(Long id) {
+        Plano plano = encontrar(id);
+        if (!plano.isAtivo()) {
+            throw new IllegalStateException("Plano já está inativo");
+        }
+        plano.setAtivo(false);
+    }
+
+    private Plano encontrar(Long id) {
+        return planoRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Plano não encontrado: " + id));
+    }
+}

--- a/src/main/resources/db/migration/V3__create_planos_table.sql
+++ b/src/main/resources/db/migration/V3__create_planos_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE planos (
+    id                  BIGSERIAL       PRIMARY KEY,
+    paciente_id         BIGINT          NOT NULL REFERENCES pacientes(id),
+    tipo                VARCHAR(20)     NOT NULL,
+    valor               DECIMAL(10,2)   NOT NULL,
+    frequencia_semanal  VARCHAR(20)     NOT NULL,
+    data_inicio         DATE            NOT NULL,
+    ativo               BOOLEAN         NOT NULL DEFAULT TRUE
+);
+
+CREATE TABLE plano_dias_semana (
+    plano_id    BIGINT      NOT NULL REFERENCES planos(id),
+    dia_semana  VARCHAR(15) NOT NULL,
+    PRIMARY KEY (plano_id, dia_semana)
+);

--- a/src/main/resources/db/migration/V4__create_pagamentos_table.sql
+++ b/src/main/resources/db/migration/V4__create_pagamentos_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE pagamentos (
+    id              BIGSERIAL       PRIMARY KEY,
+    paciente_id     BIGINT          NOT NULL REFERENCES pacientes(id),
+    plano_id        BIGINT          NOT NULL REFERENCES planos(id),
+    valor           DECIMAL(10,2)   NOT NULL,
+    status          VARCHAR(20)     NOT NULL DEFAULT 'PENDENTE',
+    data_pagamento  DATE,
+    data_vencimento DATE            NOT NULL,
+    periodo_inicio  DATE            NOT NULL,
+    periodo_fim     DATE            NOT NULL,
+    UNIQUE (plano_id, periodo_inicio)
+);

--- a/src/main/resources/db/migration/V5__create_aulas_table.sql
+++ b/src/main/resources/db/migration/V5__create_aulas_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE aulas (
+    id              BIGSERIAL   PRIMARY KEY,
+    paciente_id     BIGINT      NOT NULL REFERENCES pacientes(id),
+    pagamento_id    BIGINT      NOT NULL REFERENCES pagamentos(id),
+    data            DATE        NOT NULL,
+    realizada       BOOLEAN     NOT NULL DEFAULT FALSE,
+    UNIQUE (paciente_id, data)
+);

--- a/src/test/java/com/carlesso/pilatesapi/controller/AulaControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/AulaControllerTest.java
@@ -1,0 +1,94 @@
+package com.carlesso.pilatesapi.controller;
+
+import com.carlesso.pilatesapi.dto.AulaResponseDTO;
+import com.carlesso.pilatesapi.service.AulaService;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AulaController.class)
+class AulaControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockitoBean AulaService aulaService;
+
+    private AulaResponseDTO aulaResponse(boolean realizada) {
+        return new AulaResponseDTO(1L, 1L, "Ana", 1L, LocalDate.of(2025, 2, 3), realizada);
+    }
+
+    @Test
+    void buscar_encontrada_retorna200() throws Exception {
+        when(aulaService.buscarPorId(1L)).thenReturn(aulaResponse(false));
+
+        mockMvc.perform(get("/aulas/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.realizada").value(false))
+                .andExpect(jsonPath("$.data").value("2025-02-03"));
+    }
+
+    @Test
+    void buscar_naoEncontrada_retorna404() throws Exception {
+        when(aulaService.buscarPorId(99L))
+                .thenThrow(new EntityNotFoundException("Aula não encontrada: 99"));
+
+        mockMvc.perform(get("/aulas/99"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.erro").value("Aula não encontrada: 99"));
+    }
+
+    @Test
+    void listarPorPaciente_retorna200() throws Exception {
+        when(aulaService.buscarPorPaciente(1L)).thenReturn(List.of(aulaResponse(false), aulaResponse(true)));
+
+        mockMvc.perform(get("/aulas/paciente/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2));
+    }
+
+    @Test
+    void listarPorPagamento_retorna200() throws Exception {
+        when(aulaService.buscarPorPagamento(1L)).thenReturn(List.of(aulaResponse(false)));
+
+        mockMvc.perform(get("/aulas/pagamento/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1));
+    }
+
+    @Test
+    void realizar_retorna200ComRealizadaTrue() throws Exception {
+        when(aulaService.realizarAula(1L)).thenReturn(aulaResponse(true));
+
+        mockMvc.perform(patch("/aulas/1/realizar"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.realizada").value(true));
+    }
+
+    @Test
+    void realizar_aaulaJaRealizada_retorna409() throws Exception {
+        when(aulaService.realizarAula(1L))
+                .thenThrow(new IllegalStateException("Aula já foi marcada como realizada"));
+
+        mockMvc.perform(patch("/aulas/1/realizar"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.erro").exists());
+    }
+
+    @Test
+    void realizar_naoEncontrada_retorna404() throws Exception {
+        when(aulaService.realizarAula(99L))
+                .thenThrow(new EntityNotFoundException("Aula não encontrada: 99"));
+
+        mockMvc.perform(patch("/aulas/99/realizar"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/controller/PagamentoControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/PagamentoControllerTest.java
@@ -1,0 +1,147 @@
+package com.carlesso.pilatesapi.controller;
+
+import com.carlesso.pilatesapi.dto.PagamentoRequestDTO;
+import com.carlesso.pilatesapi.dto.PagamentoResponseDTO;
+import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
+import com.carlesso.pilatesapi.service.PagamentoService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(PagamentoController.class)
+class PagamentoControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @MockitoBean PagamentoService pagamentoService;
+
+    private PagamentoResponseDTO pagamentoPendente() {
+        return new PagamentoResponseDTO(1L, 1L, "Ana", 1L, new BigDecimal("200.00"),
+                StatusPagamento.PENDENTE, null,
+                LocalDate.now().plusDays(10), LocalDate.now(),
+                LocalDate.now().plusMonths(1).minusDays(1));
+    }
+
+    private PagamentoResponseDTO pagamentoPago() {
+        return new PagamentoResponseDTO(1L, 1L, "Ana", 1L, new BigDecimal("200.00"),
+                StatusPagamento.PAGO, LocalDate.now(),
+                LocalDate.now().plusDays(10), LocalDate.now(),
+                LocalDate.now().plusMonths(1).minusDays(1));
+    }
+
+    @Test
+    void criar_retorna201() throws Exception {
+        var dto = new PagamentoRequestDTO(1L, 1L, new BigDecimal("200.00"),
+                LocalDate.now().plusDays(10), LocalDate.now());
+
+        when(pagamentoService.criar(any())).thenReturn(pagamentoPendente());
+
+        mockMvc.perform(post("/pagamentos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("PENDENTE"));
+    }
+
+    @Test
+    void criar_semPacienteId_retorna400() throws Exception {
+        var dto = new PagamentoRequestDTO(null, 1L, new BigDecimal("200.00"),
+                LocalDate.now().plusDays(10), LocalDate.now());
+
+        mockMvc.perform(post("/pagamentos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void criar_pacienteInativo_retorna409() throws Exception {
+        var dto = new PagamentoRequestDTO(1L, 1L, new BigDecimal("200.00"),
+                LocalDate.now().plusDays(10), LocalDate.now());
+
+        when(pagamentoService.criar(any()))
+                .thenThrow(new IllegalStateException("Paciente inativo não pode receber novas cobranças"));
+
+        mockMvc.perform(post("/pagamentos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.erro").exists());
+    }
+
+    @Test
+    void criar_valorMenorQuePlano_retorna400() throws Exception {
+        var dto = new PagamentoRequestDTO(1L, 1L, new BigDecimal("100.00"),
+                LocalDate.now().plusDays(10), LocalDate.now());
+
+        when(pagamentoService.criar(any()))
+                .thenThrow(new IllegalArgumentException("menor que o valor do plano"));
+
+        mockMvc.perform(post("/pagamentos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.erro").exists());
+    }
+
+    @Test
+    void buscar_encontrado_retorna200() throws Exception {
+        when(pagamentoService.buscarPorId(1L)).thenReturn(pagamentoPendente());
+
+        mockMvc.perform(get("/pagamentos/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.valor").value(200.00));
+    }
+
+    @Test
+    void buscar_naoEncontrado_retorna404() throws Exception {
+        when(pagamentoService.buscarPorId(99L))
+                .thenThrow(new EntityNotFoundException("Pagamento não encontrado: 99"));
+
+        mockMvc.perform(get("/pagamentos/99"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void listarPorPaciente_retorna200() throws Exception {
+        when(pagamentoService.listarPorPaciente(1L)).thenReturn(List.of(pagamentoPendente()));
+
+        mockMvc.perform(get("/pagamentos/paciente/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1));
+    }
+
+    @Test
+    void pagar_retorna200ComStatusPago() throws Exception {
+        when(pagamentoService.pagar(eq(1L), any())).thenReturn(pagamentoPago());
+
+        mockMvc.perform(patch("/pagamentos/1/pagar"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("PAGO"));
+    }
+
+    @Test
+    void pagar_jaConfirmado_retorna409() throws Exception {
+        when(pagamentoService.pagar(eq(1L), any()))
+                .thenThrow(new IllegalStateException("Pagamento já foi confirmado"));
+
+        mockMvc.perform(patch("/pagamentos/1/pagar"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.erro").exists());
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/controller/PlanoControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/PlanoControllerTest.java
@@ -1,0 +1,155 @@
+package com.carlesso.pilatesapi.controller;
+
+import com.carlesso.pilatesapi.dto.PlanoRequestDTO;
+import com.carlesso.pilatesapi.dto.PlanoResponseDTO;
+import com.carlesso.pilatesapi.entity.enums.FrequenciaSemanal;
+import com.carlesso.pilatesapi.entity.enums.TipoPagamento;
+import com.carlesso.pilatesapi.service.PlanoService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(PlanoController.class)
+class PlanoControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+    @MockitoBean PlanoService planoService;
+
+    private PlanoResponseDTO planoResponse() {
+        return new PlanoResponseDTO(1L, 1L, "Ana", TipoPagamento.MENSAL, new BigDecimal("200.00"),
+                FrequenciaSemanal.DUAS_VEZES, List.of(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY),
+                LocalDate.now(), true);
+    }
+
+    @Test
+    void criar_retorna201() throws Exception {
+        var dto = new PlanoRequestDTO(1L, TipoPagamento.MENSAL, new BigDecimal("200.00"),
+                FrequenciaSemanal.DUAS_VEZES, List.of(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY), LocalDate.now());
+
+        when(planoService.criar(any())).thenReturn(planoResponse());
+
+        mockMvc.perform(post("/planos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.tipo").value("MENSAL"))
+                .andExpect(jsonPath("$.frequenciaSemanal").value("DUAS_VEZES"));
+    }
+
+    @Test
+    void criar_semPacienteId_retorna400() throws Exception {
+        var dto = new PlanoRequestDTO(null, TipoPagamento.MENSAL, new BigDecimal("200.00"),
+                FrequenciaSemanal.UMA_VEZ, List.of(DayOfWeek.MONDAY), null);
+
+        mockMvc.perform(post("/planos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void criar_pacienteInativo_retorna409() throws Exception {
+        var dto = new PlanoRequestDTO(1L, TipoPagamento.MENSAL, new BigDecimal("200.00"),
+                FrequenciaSemanal.UMA_VEZ, List.of(DayOfWeek.MONDAY), null);
+
+        when(planoService.criar(any())).thenThrow(new IllegalStateException("Paciente inativo"));
+
+        mockMvc.perform(post("/planos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.erro").value("Paciente inativo"));
+    }
+
+    @Test
+    void criar_frequenciaIncompativel_retorna400() throws Exception {
+        var dto = new PlanoRequestDTO(1L, TipoPagamento.MENSAL, new BigDecimal("200.00"),
+                FrequenciaSemanal.DUAS_VEZES, List.of(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY), null);
+
+        when(planoService.criar(any())).thenThrow(new IllegalArgumentException("incompatível"));
+
+        mockMvc.perform(post("/planos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.erro").value("incompatível"));
+    }
+
+    @Test
+    void buscar_encontrado_retorna200() throws Exception {
+        when(planoService.buscarPorId(1L)).thenReturn(planoResponse());
+
+        mockMvc.perform(get("/planos/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1));
+    }
+
+    @Test
+    void buscar_naoEncontrado_retorna404() throws Exception {
+        when(planoService.buscarPorId(99L)).thenThrow(new EntityNotFoundException("Plano não encontrado: 99"));
+
+        mockMvc.perform(get("/planos/99"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.erro").value("Plano não encontrado: 99"));
+    }
+
+    @Test
+    void listarPorPaciente_retorna200() throws Exception {
+        when(planoService.listarPorPaciente(1L)).thenReturn(List.of(planoResponse()));
+
+        mockMvc.perform(get("/planos/paciente/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(1));
+    }
+
+    @Test
+    void buscarAtivoPorPaciente_comPlano_retorna200() throws Exception {
+        when(planoService.buscarAtivoPorPaciente(1L)).thenReturn(Optional.of(planoResponse()));
+
+        mockMvc.perform(get("/planos/paciente/1/ativo"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ativo").value(true));
+    }
+
+    @Test
+    void buscarAtivoPorPaciente_semPlano_retorna204() throws Exception {
+        when(planoService.buscarAtivoPorPaciente(1L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/planos/paciente/1/ativo"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void inativar_comSucesso_retorna204() throws Exception {
+        doNothing().when(planoService).inativar(1L);
+
+        mockMvc.perform(delete("/planos/1"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void inativar_naoEncontrado_retorna404() throws Exception {
+        doThrow(new EntityNotFoundException("Plano não encontrado: 99")).when(planoService).inativar(99L);
+
+        mockMvc.perform(delete("/planos/99"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/service/AulaServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/AulaServiceTest.java
@@ -1,0 +1,164 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.entity.Aula;
+import com.carlesso.pilatesapi.entity.Paciente;
+import com.carlesso.pilatesapi.entity.Pagamento;
+import com.carlesso.pilatesapi.entity.Plano;
+import com.carlesso.pilatesapi.entity.enums.FrequenciaSemanal;
+import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
+import com.carlesso.pilatesapi.entity.enums.TipoPagamento;
+import com.carlesso.pilatesapi.repository.AulaRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AulaServiceTest {
+
+    @Mock AulaRepository aulaRepository;
+    @InjectMocks AulaService service;
+
+    private Paciente paciente;
+    private Plano plano;
+    private Pagamento pagamentoPago;
+
+    @BeforeEach
+    void setUp() {
+        paciente = new Paciente();
+        paciente.setNome("Ana");
+        paciente.setEmail("ana@email.com");
+        paciente.setCpf("111.222.333-44");
+
+        // Fevereiro 2025: MONDAY (3,10,17,24) e WEDNESDAY (5,12,19,26) → 8 aulas exatas
+        plano = new Plano();
+        plano.setPaciente(paciente);
+        plano.setTipo(TipoPagamento.MENSAL);
+        plano.setValor(new BigDecimal("200.00"));
+        plano.setFrequenciaSemanal(FrequenciaSemanal.DUAS_VEZES);
+        plano.setDiasSemana(List.of(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY));
+        plano.setDataInicio(LocalDate.of(2025, 2, 1));
+
+        pagamentoPago = new Pagamento();
+        pagamentoPago.setPaciente(paciente);
+        pagamentoPago.setPlano(plano);
+        pagamentoPago.setValor(new BigDecimal("200.00"));
+        pagamentoPago.setStatus(StatusPagamento.PAGO);
+        pagamentoPago.setPeriodoInicio(LocalDate.of(2025, 2, 1));
+        pagamentoPago.setPeriodoFim(LocalDate.of(2025, 2, 28));
+        pagamentoPago.setDataVencimento(LocalDate.of(2025, 2, 10));
+    }
+
+    @Test
+    void gerarAulas_calculaCorretamenteQuantidadePorFrequencia() {
+        when(aulaRepository.existsByPacienteAndData(any(), any())).thenReturn(false);
+        when(aulaRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+        List<Aula> aulas = service.gerarAulas(pagamentoPago);
+
+        // Fevereiro 2025: 4 segundas + 4 quartas = 8 aulas
+        assertThat(aulas).hasSize(8);
+    }
+
+    @Test
+    void gerarAulas_geraDatasCorrentes() {
+        when(aulaRepository.existsByPacienteAndData(any(), any())).thenReturn(false);
+        when(aulaRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+        List<Aula> aulas = service.gerarAulas(pagamentoPago);
+
+        List<LocalDate> datas = aulas.stream().map(Aula::getData).toList();
+        assertThat(datas).containsExactlyInAnyOrder(
+                LocalDate.of(2025, 2, 3),  // seg
+                LocalDate.of(2025, 2, 5),  // qua
+                LocalDate.of(2025, 2, 10), // seg
+                LocalDate.of(2025, 2, 12), // qua
+                LocalDate.of(2025, 2, 17), // seg
+                LocalDate.of(2025, 2, 19), // qua
+                LocalDate.of(2025, 2, 24), // seg
+                LocalDate.of(2025, 2, 26)  // qua
+        );
+    }
+
+    @Test
+    void gerarAulas_naoDuplicaAulasExistentes() {
+        // Simula que segunda dia 3 já existe
+        when(aulaRepository.existsByPacienteAndData(paciente, LocalDate.of(2025, 2, 3))).thenReturn(true);
+        when(aulaRepository.existsByPacienteAndData(any(), argThat(d -> !d.equals(LocalDate.of(2025, 2, 3))))).thenReturn(false);
+        when(aulaRepository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+        List<Aula> aulas = service.gerarAulas(pagamentoPago);
+
+        assertThat(aulas).hasSize(7); // 8 - 1 existente
+    }
+
+    @Test
+    void gerarAulas_pagamentoPendente_lancaExcecao() {
+        pagamentoPago.setStatus(StatusPagamento.PENDENTE);
+
+        assertThatThrownBy(() -> service.gerarAulas(pagamentoPago))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("PAGO");
+    }
+
+    @Test
+    void gerarAulas_pacienteInativo_lancaExcecao() {
+        paciente.setAtivo(false);
+
+        assertThatThrownBy(() -> service.gerarAulas(pagamentoPago))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("inativo");
+    }
+
+    @Test
+    void realizarAula_marcaComoRealizada() {
+        Aula aula = new Aula();
+        aula.setPaciente(paciente);
+        aula.setPagamento(pagamentoPago);
+        aula.setData(LocalDate.of(2025, 2, 3));
+
+        when(aulaRepository.findById(1L)).thenReturn(Optional.of(aula));
+
+        var response = service.realizarAula(1L);
+
+        assertThat(response.realizada()).isTrue();
+    }
+
+    @Test
+    void realizarAula_jaRealizada_lancaExcecao() {
+        Aula aula = new Aula();
+        aula.setPaciente(paciente);
+        aula.setPagamento(pagamentoPago);
+        aula.setData(LocalDate.of(2025, 2, 3));
+        aula.setRealizada(true);
+
+        when(aulaRepository.findById(1L)).thenReturn(Optional.of(aula));
+
+        assertThatThrownBy(() -> service.realizarAula(1L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("já foi marcada");
+    }
+
+    @Test
+    void buscarPorId_naoEncontrado_lancaExcecao() {
+        when(aulaRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.buscarPorId(99L))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/service/PagamentoServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/PagamentoServiceTest.java
@@ -1,0 +1,193 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.PagamentoRequestDTO;
+import com.carlesso.pilatesapi.dto.PagamentoResponseDTO;
+import com.carlesso.pilatesapi.entity.Paciente;
+import com.carlesso.pilatesapi.entity.Pagamento;
+import com.carlesso.pilatesapi.entity.Plano;
+import com.carlesso.pilatesapi.entity.enums.FrequenciaSemanal;
+import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
+import com.carlesso.pilatesapi.entity.enums.TipoPagamento;
+import com.carlesso.pilatesapi.repository.PacienteRepository;
+import com.carlesso.pilatesapi.repository.PagamentoRepository;
+import com.carlesso.pilatesapi.repository.PlanoRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PagamentoServiceTest {
+
+    @Mock PagamentoRepository pagamentoRepository;
+    @Mock PacienteRepository pacienteRepository;
+    @Mock PlanoRepository planoRepository;
+    @Mock AulaService aulaService;
+    @InjectMocks PagamentoService service;
+
+    private Paciente paciente;
+    private Plano plano;
+
+    @BeforeEach
+    void setUp() {
+        paciente = new Paciente();
+        paciente.setNome("Ana");
+        paciente.setEmail("ana@email.com");
+        paciente.setCpf("111.222.333-44");
+
+        plano = new Plano();
+        plano.setPaciente(paciente);
+        plano.setTipo(TipoPagamento.MENSAL);
+        plano.setValor(new BigDecimal("200.00"));
+        plano.setFrequenciaSemanal(FrequenciaSemanal.DUAS_VEZES);
+        plano.setDiasSemana(List.of(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY));
+        plano.setDataInicio(LocalDate.now());
+    }
+
+    @Test
+    void criarPagamento_comSucesso() {
+        var dto = new PagamentoRequestDTO(1L, 1L, new BigDecimal("200.00"),
+                LocalDate.now().plusDays(10), LocalDate.now());
+
+        when(pacienteRepository.findById(1L)).thenReturn(Optional.of(paciente));
+        when(planoRepository.findById(1L)).thenReturn(Optional.of(plano));
+        when(pagamentoRepository.existsByPlanoAndPeriodoInicio(plano, dto.periodoInicio())).thenReturn(false);
+
+        Pagamento salvo = new Pagamento();
+        salvo.setPaciente(paciente);
+        salvo.setPlano(plano);
+        salvo.setValor(dto.valor());
+        salvo.setDataVencimento(dto.dataVencimento());
+        salvo.setPeriodoInicio(dto.periodoInicio());
+        salvo.setPeriodoFim(dto.periodoInicio().plusMonths(1).minusDays(1));
+        when(pagamentoRepository.save(any())).thenReturn(salvo);
+
+        PagamentoResponseDTO response = service.criar(dto);
+
+        assertThat(response.status()).isEqualTo(StatusPagamento.PENDENTE);
+        assertThat(response.valor()).isEqualByComparingTo(new BigDecimal("200.00"));
+    }
+
+    @Test
+    void criarPagamento_pacienteInativo_lancaExcecao() {
+        paciente.setAtivo(false);
+        var dto = new PagamentoRequestDTO(1L, 1L, new BigDecimal("200.00"),
+                LocalDate.now().plusDays(10), LocalDate.now());
+
+        when(pacienteRepository.findById(1L)).thenReturn(Optional.of(paciente));
+
+        assertThatThrownBy(() -> service.criar(dto))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("inativo");
+    }
+
+    @Test
+    void criarPagamento_valorMenorQuePlano_lancaExcecao() {
+        var dto = new PagamentoRequestDTO(1L, 1L, new BigDecimal("100.00"),
+                LocalDate.now().plusDays(10), LocalDate.now());
+
+        when(pacienteRepository.findById(1L)).thenReturn(Optional.of(paciente));
+        when(planoRepository.findById(1L)).thenReturn(Optional.of(plano));
+
+        assertThatThrownBy(() -> service.criar(dto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("menor que o valor do plano");
+    }
+
+    @Test
+    void criarPagamento_duplicadoParaMesmoPeriodo_lancaExcecao() {
+        var dto = new PagamentoRequestDTO(1L, 1L, new BigDecimal("200.00"),
+                LocalDate.now().plusDays(10), LocalDate.now());
+
+        when(pacienteRepository.findById(1L)).thenReturn(Optional.of(paciente));
+        when(planoRepository.findById(1L)).thenReturn(Optional.of(plano));
+        when(pagamentoRepository.existsByPlanoAndPeriodoInicio(plano, dto.periodoInicio())).thenReturn(true);
+
+        assertThatThrownBy(() -> service.criar(dto))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Já existe um pagamento");
+    }
+
+    @Test
+    void criarPagamento_pacienteNaoEncontrado_lancaExcecao() {
+        var dto = new PagamentoRequestDTO(99L, 1L, new BigDecimal("200.00"),
+                LocalDate.now().plusDays(10), LocalDate.now());
+
+        when(pacienteRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.criar(dto))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    void pagar_registraPagamentoEGeraAulas() {
+        Pagamento pagamento = new Pagamento();
+        pagamento.setPaciente(paciente);
+        pagamento.setPlano(plano);
+        pagamento.setValor(new BigDecimal("200.00"));
+        pagamento.setStatus(StatusPagamento.PENDENTE);
+        pagamento.setDataVencimento(LocalDate.now().plusDays(5));
+        pagamento.setPeriodoInicio(LocalDate.now());
+        pagamento.setPeriodoFim(LocalDate.now().plusMonths(1).minusDays(1));
+
+        when(pagamentoRepository.findById(1L)).thenReturn(Optional.of(pagamento));
+        when(pagamentoRepository.save(any())).thenReturn(pagamento);
+
+        PagamentoResponseDTO response = service.pagar(1L, LocalDate.now());
+
+        assertThat(response.status()).isEqualTo(StatusPagamento.PAGO);
+        verify(aulaService).gerarAulas(pagamento);
+    }
+
+    @Test
+    void pagar_pagamentoJaConfirmado_lancaExcecao() {
+        Pagamento pagamento = new Pagamento();
+        pagamento.setPaciente(paciente);
+        pagamento.setPlano(plano);
+        pagamento.setValor(new BigDecimal("200.00"));
+        pagamento.setStatus(StatusPagamento.PAGO);
+        pagamento.setDataVencimento(LocalDate.now());
+        pagamento.setPeriodoInicio(LocalDate.now());
+        pagamento.setPeriodoFim(LocalDate.now().plusMonths(1).minusDays(1));
+
+        when(pagamentoRepository.findById(1L)).thenReturn(Optional.of(pagamento));
+
+        assertThatThrownBy(() -> service.pagar(1L, null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("já foi confirmado");
+    }
+
+    @Test
+    void atualizarVencidos_marcaPagamentosExpirados() {
+        Pagamento p1 = new Pagamento();
+        p1.setPaciente(paciente);
+        p1.setPlano(plano);
+        p1.setValor(new BigDecimal("200.00"));
+        p1.setStatus(StatusPagamento.PENDENTE);
+        p1.setDataVencimento(LocalDate.now().minusDays(1));
+        p1.setPeriodoInicio(LocalDate.now().minusMonths(1));
+        p1.setPeriodoFim(LocalDate.now().minusDays(1));
+
+        when(pagamentoRepository.findByStatusAndDataVencimentoBefore(eq(StatusPagamento.PENDENTE), any()))
+                .thenReturn(List.of(p1));
+
+        int total = service.atualizarVencidos();
+
+        assertThat(total).isEqualTo(1);
+        assertThat(p1.getStatus()).isEqualTo(StatusPagamento.VENCIDO);
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/service/PlanoServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/PlanoServiceTest.java
@@ -1,0 +1,192 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.PlanoRequestDTO;
+import com.carlesso.pilatesapi.dto.PlanoResponseDTO;
+import com.carlesso.pilatesapi.entity.Paciente;
+import com.carlesso.pilatesapi.entity.Plano;
+import com.carlesso.pilatesapi.entity.enums.FrequenciaSemanal;
+import com.carlesso.pilatesapi.entity.enums.TipoPagamento;
+import com.carlesso.pilatesapi.repository.PacienteRepository;
+import com.carlesso.pilatesapi.repository.PlanoRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PlanoServiceTest {
+
+    @Mock PlanoRepository planoRepository;
+    @Mock PacienteRepository pacienteRepository;
+    @InjectMocks PlanoService service;
+
+    private Paciente pacienteAtivo;
+    private Paciente pacienteInativo;
+
+    @BeforeEach
+    void setUp() {
+        pacienteAtivo = new Paciente();
+        pacienteAtivo.setNome("Ana");
+        pacienteAtivo.setEmail("ana@email.com");
+        pacienteAtivo.setCpf("111.222.333-44");
+
+        pacienteInativo = new Paciente();
+        pacienteInativo.setNome("Inativo");
+        pacienteInativo.setEmail("inativo@email.com");
+        pacienteInativo.setCpf("999.888.777-66");
+        pacienteInativo.setAtivo(false);
+    }
+
+    @Test
+    void criarPlano_comSucesso() {
+        var dto = new PlanoRequestDTO(1L, TipoPagamento.MENSAL, new BigDecimal("200.00"),
+                FrequenciaSemanal.DUAS_VEZES, List.of(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY), LocalDate.now());
+
+        when(pacienteRepository.findById(1L)).thenReturn(Optional.of(pacienteAtivo));
+        when(planoRepository.findByPacienteIdAndAtivoTrue(1L)).thenReturn(Optional.empty());
+
+        Plano planoSalvo = new Plano();
+        planoSalvo.setPaciente(pacienteAtivo);
+        planoSalvo.setTipo(dto.tipo());
+        planoSalvo.setValor(dto.valor());
+        planoSalvo.setFrequenciaSemanal(dto.frequenciaSemanal());
+        planoSalvo.setDiasSemana(dto.diasSemana());
+        planoSalvo.setDataInicio(dto.dataInicio());
+        when(planoRepository.save(any())).thenReturn(planoSalvo);
+
+        PlanoResponseDTO response = service.criar(dto);
+
+        assertThat(response.tipo()).isEqualTo(TipoPagamento.MENSAL);
+        assertThat(response.frequenciaSemanal()).isEqualTo(FrequenciaSemanal.DUAS_VEZES);
+        assertThat(response.diasSemana()).containsExactlyInAnyOrder(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY);
+    }
+
+    @Test
+    void criarPlano_pacienteInativo_lancaExcecao() {
+        var dto = new PlanoRequestDTO(2L, TipoPagamento.MENSAL, new BigDecimal("200.00"),
+                FrequenciaSemanal.UMA_VEZ, List.of(DayOfWeek.MONDAY), null);
+
+        when(pacienteRepository.findById(2L)).thenReturn(Optional.of(pacienteInativo));
+
+        assertThatThrownBy(() -> service.criar(dto))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("inativo");
+    }
+
+    @Test
+    void criarPlano_frequenciaIncompativel_lancaExcecao() {
+        // DUAS_VEZES requer exatamente 2 dias — enviando 3 dias
+        var dto = new PlanoRequestDTO(1L, TipoPagamento.MENSAL, new BigDecimal("200.00"),
+                FrequenciaSemanal.DUAS_VEZES,
+                List.of(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY), null);
+
+        when(pacienteRepository.findById(1L)).thenReturn(Optional.of(pacienteAtivo));
+
+        assertThatThrownBy(() -> service.criar(dto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("incompatível");
+    }
+
+    @Test
+    void criarPlano_desativaPlanoAtivoAnterior() {
+        var dto = new PlanoRequestDTO(1L, TipoPagamento.MENSAL, new BigDecimal("250.00"),
+                FrequenciaSemanal.UMA_VEZ, List.of(DayOfWeek.TUESDAY), null);
+
+        Plano planoExistente = new Plano();
+        planoExistente.setPaciente(pacienteAtivo);
+
+        when(pacienteRepository.findById(1L)).thenReturn(Optional.of(pacienteAtivo));
+        when(planoRepository.findByPacienteIdAndAtivoTrue(1L)).thenReturn(Optional.of(planoExistente));
+
+        Plano novoPlano = new Plano();
+        novoPlano.setPaciente(pacienteAtivo);
+        novoPlano.setTipo(dto.tipo());
+        novoPlano.setValor(dto.valor());
+        novoPlano.setFrequenciaSemanal(dto.frequenciaSemanal());
+        novoPlano.setDiasSemana(dto.diasSemana());
+        novoPlano.setDataInicio(LocalDate.now());
+        when(planoRepository.save(any())).thenReturn(novoPlano);
+
+        service.criar(dto);
+
+        assertThat(planoExistente.isAtivo()).isFalse();
+        verify(planoRepository, times(2)).save(any()); // um para inativar, outro para criar
+    }
+
+    @Test
+    void criarPlano_pacienteNaoEncontrado_lancaExcecao() {
+        var dto = new PlanoRequestDTO(99L, TipoPagamento.MENSAL, new BigDecimal("200.00"),
+                FrequenciaSemanal.UMA_VEZ, List.of(DayOfWeek.MONDAY), null);
+
+        when(pacienteRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.criar(dto))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    void buscarAtivoPorPaciente_retornaPlanoAtivo() {
+        Plano plano = new Plano();
+        plano.setPaciente(pacienteAtivo);
+        plano.setTipo(TipoPagamento.MENSAL);
+        plano.setValor(new BigDecimal("200.00"));
+        plano.setFrequenciaSemanal(FrequenciaSemanal.UMA_VEZ);
+        plano.setDiasSemana(List.of(DayOfWeek.MONDAY));
+        plano.setDataInicio(LocalDate.now());
+
+        when(planoRepository.findByPacienteIdAndAtivoTrue(1L)).thenReturn(Optional.of(plano));
+
+        var result = service.buscarAtivoPorPaciente(1L);
+
+        assertThat(result).isPresent();
+    }
+
+    @Test
+    void inativar_planoAtivo_comSucesso() {
+        Plano plano = new Plano();
+        plano.setPaciente(pacienteAtivo);
+        plano.setTipo(TipoPagamento.MENSAL);
+        plano.setValor(new BigDecimal("200.00"));
+        plano.setFrequenciaSemanal(FrequenciaSemanal.UMA_VEZ);
+        plano.setDiasSemana(List.of(DayOfWeek.FRIDAY));
+        plano.setDataInicio(LocalDate.now());
+
+        when(planoRepository.findById(1L)).thenReturn(Optional.of(plano));
+
+        service.inativar(1L);
+
+        assertThat(plano.isAtivo()).isFalse();
+    }
+
+    @Test
+    void inativar_planoJaInativo_lancaExcecao() {
+        Plano plano = new Plano();
+        plano.setPaciente(pacienteAtivo);
+        plano.setAtivo(false);
+        plano.setTipo(TipoPagamento.MENSAL);
+        plano.setValor(new BigDecimal("200.00"));
+        plano.setFrequenciaSemanal(FrequenciaSemanal.UMA_VEZ);
+        plano.setDiasSemana(List.of(DayOfWeek.FRIDAY));
+        plano.setDataInicio(LocalDate.now());
+
+        when(planoRepository.findById(1L)).thenReturn(Optional.of(plano));
+
+        assertThatThrownBy(() -> service.inativar(1L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("já está inativo");
+    }
+}


### PR DESCRIPTION
## Summary

Esta PR consolida todas as mudanças desenvolvidas nas branches anteriores e introduz as regras de negócio completas do sistema.

### Flyway — Migrações de banco
- Dependências `flyway-core` e `flyway-database-postgresql` adicionadas
- `ddl-auto` alterado de `update` para `validate`
- **V1** — criação da tabela `pacientes`
- **V2** — carga inicial com 10 pacientes de teste (SP, RJ, MG, PR, RS, DF, BA, CE, PA, PE)
- **V3** — tabelas `planos` e `plano_dias_semana`
- **V4** — tabela `pagamentos`
- **V5** — tabela `aulas`

### Regras de Negócio

**Planos de Pagamento:**
- Tipos: MENSAL / TRIMESTRAL / ANUAL
- Um paciente só pode ter **um plano ativo** — novo plano desativa o anterior automaticamente
- Quantidade de dias da semana deve corresponder exatamente à frequência (ex: `DUAS_VEZES` → 2 dias)
- Paciente inativo não pode receber novo plano

**Pagamentos:**
- Ciclo: PENDENTE → PAGO / VENCIDO
- Valor não pode ser menor que o valor do plano
- Sem duplicidade de pagamento para o mesmo período
- Ao confirmar (`PAGO`) → aulas do período geradas automaticamente

**Aulas:**
- Geradas percorrendo os dias da semana do plano dentro do período do pagamento
- Constraint `UNIQUE (paciente_id, data)` garante sem duplicatas
- Requer paciente ativo e pagamento PAGO

**Scheduler (`CobrancaScheduler`):**
- 06:00 diário → marca pagamentos PENDENTE vencidos como VENCIDO
- 07:00 diário → gera cobranças futuras para planos ativos

**GlobalExceptionHandler** — handlers para 400 (`IllegalArgumentException`) e 409 (`IllegalStateException`)

### Novos Endpoints

| Método | Rota | Descrição |
|---|---|---|
| POST | `/planos` | Criar plano |
| GET | `/planos/{id}` | Buscar plano |
| GET | `/planos/paciente/{id}` | Listar planos do paciente |
| GET | `/planos/paciente/{id}/ativo` | Plano ativo do paciente |
| DELETE | `/planos/{id}` | Inativar plano |
| POST | `/pagamentos` | Criar cobrança |
| GET | `/pagamentos/{id}` | Buscar pagamento |
| GET | `/pagamentos/paciente/{id}` | Listar pagamentos do paciente |
| PATCH | `/pagamentos/{id}/pagar` | Confirmar pagamento + gerar aulas |
| GET | `/aulas/{id}` | Buscar aula |
| GET | `/aulas/paciente/{id}` | Listar aulas do paciente |
| GET | `/aulas/pagamento/{id}` | Listar aulas por pagamento |
| PATCH | `/aulas/{id}/realizar` | Marcar aula como realizada |

## Test plan

- [ ] `mvn test` — 76 testes, 0 falhas
- [ ] Criar plano com frequência incompatível → 400
- [ ] Confirmar pagamento via `PATCH /pagamentos/{id}/pagar` → verificar aulas geradas em `/aulas/pagamento/{id}`
- [ ] Tentar criar segundo pagamento no mesmo período → 409
- [ ] Verificar Swagger UI em `/swagger-ui.html` com os grupos Planos, Pagamentos e Aulas
- [ ] Subir com `docker compose up --build` e validar que todas as migrations V1–V5 são aplicadas

https://claude.ai/code/session_016yMNw4XkeppdX5VPmvypqe