### PR TITLE
Add Spring Boot Actuator

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ API REST para gestão de pacientes e profissionais do estúdio Carlesso Pilates,
 | Spring Boot | 3.4.5 |
 | Spring Data JPA | 3.4.5 |
 | Spring Validation | 3.4.5 |
+| Spring Boot Actuator | 3.4.5 |
 | PostgreSQL | 16 |
 | Flyway | (via spring-boot-starter-parent) |
 | springdoc-openapi | 2.8.3 |
@@ -323,6 +324,19 @@ Com a aplicação rodando, acesse:
 
 ---
 
+## Observabilidade (Actuator)
+
+O projeto expõe endpoints operacionais do Spring Boot Actuator para acompanhamento da aplicação em desenvolvimento:
+
+| Recurso | URL |
+|---|---|
+| Health | http://localhost:8080/actuator/health |
+| Info | http://localhost:8080/actuator/info |
+
+Somente `health` e `info` ficam expostos via HTTP.
+
+---
+
 ## Migrações de banco (Flyway)
 
 O projeto utiliza **Flyway** para versionamento e execução automática das migrações de banco de dados. As migrações ficam em `src/main/resources/db/migration/` e são aplicadas na ordem de versão ao subir a aplicação.
@@ -450,7 +464,7 @@ curl -s -X PATCH http://localhost:8080/pacientes/1/inativar -w "%{http_code}"
 
 ## Testes
 
-O projeto possui **96 testes** organizados em onze suítes:
+O projeto possui **98 testes** organizados em onze suítes:
 
 | Suíte | Tipo | Testes |
 |---|---|---|
@@ -459,7 +473,7 @@ O projeto possui **96 testes** organizados em onze suítes:
 | `PagamentoServiceTest` | Unitário (Mockito) | 8 |
 | `AulaServiceTest` | Unitário (Mockito) | 8 |
 | `ProfissionalServiceTest` | Unitário (Mockito) | 10 |
-| `PacienteControllerTest` | Controller (`@WebMvcTest`) | 13 |
+| `PacienteControllerTest` | Controller (`@WebMvcTest`) | 15 |
 | `PlanoControllerTest` | Controller (`@WebMvcTest`) | 11 |
 | `PagamentoControllerTest` | Controller (`@WebMvcTest`) | 9 |
 | `AulaControllerTest` | Controller (`@WebMvcTest`) | 7 |

--- a/docs/context.md
+++ b/docs/context.md
@@ -17,6 +17,7 @@ API REST para gerenciar pacientes e profissionais de um estúdio de pilates. Per
 | Migrações | Flyway |
 | Validação | Spring Validation (Bean Validation) |
 | Documentação | springdoc-openapi 2.8.3 (Swagger UI) |
+| Observabilidade | Spring Boot Actuator |
 | Scheduler | Spring Scheduler |
 | Build | Maven 3.9 |
 | Containerização | Docker + Docker Compose |
@@ -260,6 +261,26 @@ CPF não pode ser alterado após o cadastro.
 | API base | `http://localhost:8080` |
 | Swagger UI | `http://localhost:8080/swagger-ui.html` |
 | OpenAPI JSON | `http://localhost:8080/api-docs` |
+| Actuator health | `http://localhost:8080/actuator/health` |
+| Actuator info | `http://localhost:8080/actuator/info` |
+
+### Observabilidade
+
+O projeto usa Spring Boot Actuator para endpoints operacionais. Em desenvolvimento, ficam expostos via HTTP apenas `health` e `info`.
+
+| Endpoint | Uso |
+|---|---|
+| `GET /actuator/health` | Verificar status da aplicação e componentes monitorados |
+| `GET /actuator/info` | Consultar metadados configurados da aplicação |
+
+Configurações relevantes:
+
+```properties
+management.endpoints.web.exposure.include=health,info
+management.info.env.enabled=true
+info.app.name=${spring.application.name}
+info.app.description=Carlesso Pilates API
+```
 
 ---
 
@@ -295,7 +316,7 @@ JAVA_HOME=~/jdk mvn spring-boot:run
 | `PlanoServiceTest` | Unitário (Mockito, sem Spring) | 8 |
 | `PagamentoServiceTest` | Unitário (Mockito, sem Spring) | 8 |
 | `AulaServiceTest` | Unitário (Mockito, sem Spring) | 8 |
-| `PacienteControllerTest` | `@WebMvcTest` + MockMvc | 13 |
+| `PacienteControllerTest` | `@WebMvcTest` + MockMvc | 15 |
 | `ProfissionalControllerTest` | `@WebMvcTest` + MockMvc | 10 |
 | `PlanoControllerTest` | `@WebMvcTest` + MockMvc | 11 |
 | `PagamentoControllerTest` | `@WebMvcTest` + MockMvc | 9 |

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -4,7 +4,7 @@
 
 A **Carlesso Pilates API** é uma API REST desenvolvida para gerenciar o cadastro de pacientes e profissionais de um estúdio de pilates. Ela expõe endpoints para criação, consulta, atualização e inativação de pacientes e profissionais, com gestão de planos de pagamento, cobranças e geração automática de aulas.
 
-A aplicação foi construída com **Spring Boot 3** e **Java 21**, utiliza **PostgreSQL** como banco de dados relacional, gerencia o schema com **Flyway**, conta com documentação interativa via **Swagger UI**, processos automáticos via **Spring Scheduler** e possui suíte de testes cobrindo as camadas de serviço e controller.
+A aplicação foi construída com **Spring Boot 3** e **Java 21**, utiliza **PostgreSQL** como banco de dados relacional, gerencia o schema com **Flyway**, conta com documentação interativa via **Swagger UI**, observabilidade com **Spring Boot Actuator**, processos automáticos via **Spring Scheduler** e possui suíte de testes cobrindo as camadas de serviço e controller.
 
 ---
 
@@ -16,6 +16,7 @@ A aplicação foi construída com **Spring Boot 3** e **Java 21**, utiliza **Pos
 | Spring Boot | 3.4.5 | Framework da aplicação |
 | Spring Data JPA | 3.4.5 | Persistência e ORM |
 | Spring Validation | 3.4.5 | Validação de entrada |
+| Spring Boot Actuator | 3.4.5 | Endpoints operacionais de health e info |
 | PostgreSQL | 16 | Banco de dados relacional |
 | Flyway | (via spring-boot-starter-parent) | Versionamento e migração de schema do banco |
 | Spring Scheduler | (via spring-boot-starter) | Processos automáticos agendados |
@@ -122,7 +123,7 @@ src/
     │   ├── PagamentoServiceTest.java     # 8 casos
     │   └── AulaServiceTest.java          # 8 casos
     └── controller/
-        ├── PacienteControllerTest.java   # 13 casos
+        ├── PacienteControllerTest.java   # 15 casos
         ├── ProfissionalControllerTest.java # 10 casos
         ├── PlanoControllerTest.java      # 11 casos
         ├── PagamentoControllerTest.java  # 9 casos
@@ -512,7 +513,18 @@ Com a aplicação rodando, acesse o Swagger UI para explorar e testar os endpoin
 
 ---
 
-## 8. Configuração
+## 8. Observabilidade (Actuator)
+
+O projeto utiliza **Spring Boot Actuator** para expor endpoints operacionais. Em desenvolvimento, apenas `health` e `info` ficam disponíveis via HTTP.
+
+| Endpoint | Descrição |
+|---|---|
+| `GET /actuator/health` | Status da aplicação |
+| `GET /actuator/info` | Metadados configurados da aplicação |
+
+---
+
+## 9. Configuração
 
 ### Variáveis de ambiente
 
@@ -539,13 +551,18 @@ spring.flyway.locations=classpath:db/migration
 
 springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.api-docs.path=/api-docs
+
+management.endpoints.web.exposure.include=health,info
+management.info.env.enabled=true
+info.app.name=${spring.application.name}
+info.app.description=Carlesso Pilates API
 ```
 
 > O DDL mode é `validate` — o Flyway é o responsável por criar e evoluir o schema; o Hibernate apenas valida que as entidades estão de acordo com o banco.
 
 ---
 
-## 8.1 Migrações de Banco (Flyway)
+## 9.1 Migrações de Banco (Flyway)
 
 O **Flyway** executa automaticamente os scripts SQL ao iniciar a aplicação, seguindo a ordem das versões. Os arquivos ficam em `src/main/resources/db/migration/`.
 
@@ -568,7 +585,7 @@ Nos testes automatizados o Flyway fica **desabilitado** (`spring.flyway.enabled=
 
 ---
 
-## 9. Como Rodar
+## 10. Como Rodar
 
 ### Opção A — Docker Compose (recomendado)
 
@@ -619,7 +636,7 @@ JAVA_HOME=/caminho/para/jdk21 mvn spring-boot:run
 
 ---
 
-## 10. Exemplos com curl
+## 11. Exemplos com curl
 
 ### Cadastrar paciente
 
@@ -673,7 +690,7 @@ curl -s -X PATCH http://localhost:8080/pacientes/1/inativar -o /dev/null -w "%{h
 
 ---
 
-## 11. Infraestrutura Docker
+## 12. Infraestrutura Docker
 
 ### Dockerfile (multi-stage build)
 
@@ -693,11 +710,11 @@ O serviço `app` aguarda o `db` estar saudável (healthcheck via `pg_isready`) a
 
 ---
 
-## 12. Testes
+## 13. Testes
 
 ### Visão geral
 
-A suíte de testes possui **96 casos** distribuídos em onze classes:
+A suíte de testes possui **98 casos** distribuídos em onze classes:
 
 | Classe | Tipo | Casos |
 |---|---|---|
@@ -706,7 +723,7 @@ A suíte de testes possui **96 casos** distribuídos em onze classes:
 | `PlanoServiceTest` | Unitário (Mockito) | 8 |
 | `PagamentoServiceTest` | Unitário (Mockito) | 8 |
 | `AulaServiceTest` | Unitário (Mockito) | 8 |
-| `PacienteControllerTest` | Controller (`@WebMvcTest`) | 13 |
+| `PacienteControllerTest` | Controller (`@WebMvcTest`) | 15 |
 | `ProfissionalControllerTest` | Controller (`@WebMvcTest`) | 10 |
 | `PlanoControllerTest` | Controller (`@WebMvcTest`) | 11 |
 | `PagamentoControllerTest` | Controller (`@WebMvcTest`) | 9 |

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.8.3</version>

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,5 @@
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.show-details=always
+management.info.env.enabled=true
+info.app.name=${spring.application.name}
+info.app.description=Carlesso Pilates API

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,7 +18,4 @@ springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.swagger-ui.operationsSorter=method
 
-management.endpoints.web.exposure.include=health,info
-management.info.env.enabled=true
-info.app.name=${spring.application.name}
-info.app.description=Carlesso Pilates API
+management.endpoints.web.exposure.include=health

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,3 +17,8 @@ spring.flyway.baseline-on-migrate=true
 springdoc.api-docs.path=/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.swagger-ui.operationsSorter=method
+
+management.endpoints.web.exposure.include=health,info
+management.info.env.enabled=true
+info.app.name=${spring.application.name}
+info.app.description=Carlesso Pilates API

--- a/src/test/java/com/carlesso/pilatesapi/actuator/ActuatorTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/actuator/ActuatorTest.java
@@ -1,0 +1,39 @@
+package com.carlesso.pilatesapi.actuator;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ActuatorTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    void healthEndpointReturns200WithStatusUp() throws Exception {
+        mvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("UP"));
+    }
+
+    @Test
+    void infoEndpointReturns200() throws Exception {
+        mvc.perform(get("/actuator/info"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.app.name").value("CarlessoPilatesApi"));
+    }
+
+    @Test
+    void unexposedEndpointReturns404() throws Exception {
+        mvc.perform(get("/actuator/env"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -7,3 +7,10 @@ spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=false
 
 spring.flyway.enabled=false
+
+spring.application.name=CarlessoPilatesApi
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.show-details=always
+management.info.env.enabled=true
+info.app.name=${spring.application.name}
+info.app.description=Carlesso Pilates API


### PR DESCRIPTION
## Resumo
- Adiciona `spring-boot-starter-actuator` ao projeto
- Expõe os endpoints operacionais `health` e `info`
- Atualiza `README.md`, `docs/context.md` e `docs/documentacao.md` com URLs e configuração do Actuator
- Corrige a contagem documentada da suíte para 98 testes

## Validação
- `JAVA_HOME=~/jdk mvn test`