### PR TITLE
feat: adiciona filtros de busca para pacientes

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,11 @@ src/
 │           └── V8__alter_pacientes_uf_to_varchar.sql
 └── test/java/com/carlesso/pilatesapi/
     ├── PilatesApiApplicationTests.java
+    ├── actuator/
+    │   └── ActuatorTest.java
     ├── service/
     │   ├── PacienteServiceTest.java
+    │   ├── PacienteServiceIntegrationTest.java
     │   ├── ProfissionalServiceTest.java
     │   ├── PlanoServiceTest.java
     │   ├── PagamentoServiceTest.java
@@ -471,20 +474,22 @@ curl -s -X PATCH http://localhost:8080/pacientes/1/inativar -w "%{http_code}"
 
 ## Testes
 
-O projeto possui **98 testes** organizados em onze suítes:
+O projeto possui **107 testes** organizados em treze suítes:
 
 | Suíte | Tipo | Testes |
 |---|---|---|
-| `PacienteServiceTest` | Unitário (Mockito) | 11 |
+| `PacienteServiceTest` | Unitário (Mockito) | 12 |
 | `PlanoServiceTest` | Unitário (Mockito) | 8 |
 | `PagamentoServiceTest` | Unitário (Mockito) | 8 |
 | `AulaServiceTest` | Unitário (Mockito) | 8 |
 | `ProfissionalServiceTest` | Unitário (Mockito) | 10 |
-| `PacienteControllerTest` | Controller (`@WebMvcTest`) | 15 |
+| `PacienteServiceIntegrationTest` | JPA (`@DataJpaTest`) | 4 |
+| `PacienteControllerTest` | Controller (`@WebMvcTest`) | 16 |
 | `PlanoControllerTest` | Controller (`@WebMvcTest`) | 11 |
 | `PagamentoControllerTest` | Controller (`@WebMvcTest`) | 9 |
 | `AulaControllerTest` | Controller (`@WebMvcTest`) | 7 |
 | `ProfissionalControllerTest` | Controller (`@WebMvcTest`) | 10 |
+| `ActuatorTest` | Integração (`@SpringBootTest`) | 3 |
 | `PilatesApiApplicationTests` | Integração (`@SpringBootTest`) | 1 |
 
 ### Executar os testes

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Base URL: `http://localhost:8080`
 | Método | Endpoint | Descrição |
 |---|---|---|
 | `POST` | `/pacientes` | Cadastrar novo paciente |
-| `GET` | `/pacientes` | Listar pacientes ativos (paginado) |
+| `GET` | `/pacientes` | Listar e filtrar pacientes (paginado) |
 | `GET` | `/pacientes/{id}` | Buscar paciente por ID |
 | `PUT` | `/pacientes/{id}` | Atualizar dados do paciente |
 | `PATCH` | `/pacientes/{id}/ativar` | Reativar paciente |
@@ -166,6 +166,13 @@ Os endpoints de listagem suportam os query params padrão do Spring:
 ```
 GET /pacientes?page=0&size=10&sort=nome,asc
 GET /profissionais?page=0&size=10&sort=nome,asc
+```
+
+O endpoint `GET /pacientes` também suporta filtros opcionais por `nome`, `email`, `cpf`, `telefone` e `ativo`. Quando `ativo` é omitido, retorna apenas pacientes ativos.
+
+```
+GET /pacientes?nome=maria&email=email.com&cpf=123&telefone=119&ativo=true&page=0&size=10&sort=nome,asc
+GET /pacientes?ativo=false
 ```
 
 ---
@@ -391,9 +398,9 @@ curl -s -X POST http://localhost:8080/pacientes \
   }' | jq
 ```
 
-### Listar pacientes ativos
+### Listar e filtrar pacientes
 ```bash
-curl -s http://localhost:8080/pacientes | jq
+curl -s "http://localhost:8080/pacientes?nome=maria&ativo=true&page=0&size=10&sort=nome,asc" | jq
 ```
 
 ### Buscar por ID

--- a/docs/context.md
+++ b/docs/context.md
@@ -113,7 +113,7 @@ O endereço é um `@Embeddable` (`Endereco`), suas colunas ficam diretamente na 
 | `cpf` | VARCHAR(14) | NOT NULL, UNIQUE |
 | `telefone` | VARCHAR | — |
 | `tipo_contrato` | VARCHAR(30) | NOT NULL (`CLT`, `PJ`, `AUTONOMO`) |
-| `percentual_pagamento_aula` | NUMERIC(5,2) | NOT NULL |
+| `percentual_pagamento_aula` | NUMERIC(3,2) | NOT NULL |
 | `data_inicio` | DATE | NOT NULL |
 | `ativo` | BOOLEAN | NOT NULL, default `true` |
 
@@ -312,16 +312,18 @@ JAVA_HOME=~/jdk mvn spring-boot:run
 
 | Classe | Tipo | Casos |
 |---|---|---|
-| `PacienteServiceTest` | Unitário (Mockito, sem Spring) | 11 |
+| `PacienteServiceTest` | Unitário (Mockito, sem Spring) | 12 |
 | `ProfissionalServiceTest` | Unitário (Mockito, sem Spring) | 10 |
 | `PlanoServiceTest` | Unitário (Mockito, sem Spring) | 8 |
 | `PagamentoServiceTest` | Unitário (Mockito, sem Spring) | 8 |
 | `AulaServiceTest` | Unitário (Mockito, sem Spring) | 8 |
-| `PacienteControllerTest` | `@WebMvcTest` + MockMvc | 15 |
+| `PacienteServiceIntegrationTest` | `@DataJpaTest` + H2 | 4 |
+| `PacienteControllerTest` | `@WebMvcTest` + MockMvc | 16 |
 | `ProfissionalControllerTest` | `@WebMvcTest` + MockMvc | 10 |
 | `PlanoControllerTest` | `@WebMvcTest` + MockMvc | 11 |
 | `PagamentoControllerTest` | `@WebMvcTest` + MockMvc | 9 |
 | `AulaControllerTest` | `@WebMvcTest` + MockMvc | 7 |
+| `ActuatorTest` | `@SpringBootTest` + H2 | 3 |
 | `PilatesApiApplicationTests` | `@SpringBootTest` + H2 | 1 |
 
 ```bash

--- a/docs/context.md
+++ b/docs/context.md
@@ -166,7 +166,7 @@ Constraint: `UNIQUE (paciente_id, data)`
 | Método | Rota | Ação | Retorno |
 |---|---|---|---|
 | POST | `/pacientes` | Cadastrar paciente | 201 + Location header |
-| GET | `/pacientes` | Listar ativos (paginado) | 200 + Page |
+| GET | `/pacientes` | Listar e filtrar pacientes por nome, e-mail, CPF, telefone e ativo/inativo (paginado) | 200 + Page |
 | GET | `/pacientes/{id}` | Buscar por ID | 200 / 404 |
 | PUT | `/pacientes/{id}` | Atualização parcial | 200 / 404 |
 | PATCH | `/pacientes/{id}/ativar` | Reativar paciente | 204 / 404 |
@@ -193,7 +193,8 @@ Constraint: `UNIQUE (paciente_id, data)`
 
 Campos obrigatórios no cadastro de pacientes: `nome`, `email`, `cpf`.  
 Campos obrigatórios no cadastro de profissionais: `nome`, `email`, `cpf`, `tipoContrato`, `percentualPagamentoAula`, `dataInicio`.  
-CPF não pode ser alterado após o cadastro.
+CPF não pode ser alterado após o cadastro.  
+`GET /pacientes` retorna pacientes ativos por padrão e aceita `ativo=false` para consultar inativos.
 
 ---
 

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -116,18 +116,21 @@ src/
 │           └── V8__alter_pacientes_uf_to_varchar.sql
 └── test/java/com/carlesso/pilatesapi/
     ├── PilatesApiApplicationTests.java
+    ├── actuator/
+    │   └── ActuatorTest.java                    # 3 casos
     ├── service/
-    │   ├── PacienteServiceTest.java      # 11 casos
-    │   ├── ProfissionalServiceTest.java  # 10 casos
-    │   ├── PlanoServiceTest.java         # 8 casos
-    │   ├── PagamentoServiceTest.java     # 8 casos
-    │   └── AulaServiceTest.java          # 8 casos
+    │   ├── PacienteServiceTest.java             # 12 casos
+    │   ├── PacienteServiceIntegrationTest.java  # 4 casos
+    │   ├── ProfissionalServiceTest.java         # 10 casos
+    │   ├── PlanoServiceTest.java                # 8 casos
+    │   ├── PagamentoServiceTest.java            # 8 casos
+    │   └── AulaServiceTest.java                 # 8 casos
     └── controller/
-        ├── PacienteControllerTest.java   # 15 casos
-        ├── ProfissionalControllerTest.java # 10 casos
-        ├── PlanoControllerTest.java      # 11 casos
-        ├── PagamentoControllerTest.java  # 9 casos
-        └── AulaControllerTest.java       # 7 casos
+        ├── PacienteControllerTest.java          # 16 casos
+        ├── ProfissionalControllerTest.java      # 10 casos
+        ├── PlanoControllerTest.java             # 11 casos
+        ├── PagamentoControllerTest.java         # 9 casos
+        └── AulaControllerTest.java              # 7 casos
 ```
 
 ---
@@ -229,7 +232,7 @@ Tabela: `profissionais`
 | `cpf` | `VARCHAR(14)` | NOT NULL, UNIQUE | CPF do profissional |
 | `telefone` | `VARCHAR` | — | Telefone de contato |
 | `tipo_contrato` | `VARCHAR(30)` | NOT NULL | `CLT` / `PJ` / `AUTONOMO` |
-| `percentual_pagamento_aula` | `NUMERIC(5,2)` | NOT NULL | Percentual por aula ministrada |
+| `percentual_pagamento_aula` | `NUMERIC(3,2)` | NOT NULL | Percentual por aula ministrada |
 | `data_inicio` | `DATE` | NOT NULL | Data de início do contrato |
 | `ativo` | `BOOLEAN` | NOT NULL, default `true` | Indica se o profissional está ativo |
 

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -336,15 +336,21 @@ Constraint: `UNIQUE (paciente_id, data)`
 
 ---
 
-#### Listar Pacientes Ativos
+#### Listar e Filtrar Pacientes
 
 | | |
 |---|---|
 | **Método** | `GET` |
 | **Rota** | `/pacientes` |
-| **Descrição** | Retorna página de pacientes ativos. Suporta `page`, `size` e `sort`. |
+| **Descrição** | Retorna página de pacientes com filtros opcionais por `nome`, `email`, `cpf`, `telefone` e `ativo`. Quando `ativo` é omitido, retorna apenas pacientes ativos. Suporta `page`, `size` e `sort`. |
 
-**Exemplo:** `GET /pacientes?page=0&size=5&sort=nome,asc`
+**Exemplos:**
+
+```http
+GET /pacientes?nome=maria&ativo=true&page=0&size=5&sort=nome,asc
+GET /pacientes?cpf=123&telefone=119
+GET /pacientes?ativo=false
+```
 
 | Código | Situação |
 |---|---|
@@ -663,7 +669,7 @@ curl -s -X POST http://localhost:8080/pacientes \
 ### Listar pacientes
 
 ```bash
-curl -s "http://localhost:8080/pacientes?page=0&size=5" | jq
+curl -s "http://localhost:8080/pacientes?nome=maria&ativo=true&page=0&size=5" | jq
 ```
 
 ### Cadastrar profissional

--- a/src/main/java/com/carlesso/pilatesapi/controller/PacienteController.java
+++ b/src/main/java/com/carlesso/pilatesapi/controller/PacienteController.java
@@ -48,16 +48,21 @@ public class PacienteController {
     }
 
     @Operation(
-            summary = "Listar pacientes ativos",
-            description = "Retorna uma página de pacientes com status ativo. Suporta paginação e ordenação via query params (page, size, sort)."
+            summary = "Listar e filtrar pacientes",
+            description = "Retorna uma página de pacientes filtrando por nome, e-mail, CPF, telefone e status ativo/inativo. Por padrão retorna pacientes ativos. Suporta paginação e ordenação via query params (page, size, sort)."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Lista retornada com sucesso")
     })
     @GetMapping
     public ResponseEntity<Page<PacienteResponseDTO>> listar(
+            @Parameter(description = "Filtro parcial por nome") @RequestParam(required = false) String nome,
+            @Parameter(description = "Filtro parcial por e-mail") @RequestParam(required = false) String email,
+            @Parameter(description = "Filtro parcial por CPF") @RequestParam(required = false) String cpf,
+            @Parameter(description = "Filtro parcial por telefone") @RequestParam(required = false) String telefone,
+            @Parameter(description = "Filtra por status. Quando omitido, retorna apenas ativos.") @RequestParam(required = false) Boolean ativo,
             @ParameterObject @PageableDefault(size = 10, sort = "nome") Pageable pageable) {
-        return ResponseEntity.ok(service.listar(pageable));
+        return ResponseEntity.ok(service.listar(nome, email, cpf, telefone, ativo, pageable));
     }
 
     @Operation(

--- a/src/main/java/com/carlesso/pilatesapi/repository/PacienteRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/PacienteRepository.java
@@ -1,11 +1,8 @@
 package com.carlesso.pilatesapi.repository;
 
 import com.carlesso.pilatesapi.entity.Paciente;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface PacienteRepository extends JpaRepository<Paciente, Long> {
-
-    Page<Paciente> findAllByAtivoTrue(Pageable pageable);
+public interface PacienteRepository extends JpaRepository<Paciente, Long>, JpaSpecificationExecutor<Paciente> {
 }

--- a/src/main/java/com/carlesso/pilatesapi/service/PacienteService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/PacienteService.java
@@ -9,8 +9,11 @@ import com.carlesso.pilatesapi.repository.PacienteRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Locale;
 
 @Service
 public class PacienteService {
@@ -42,8 +45,15 @@ public class PacienteService {
         return PacienteResponseDTO.from(repository.save(paciente));
     }
 
-    public Page<PacienteResponseDTO> listar(Pageable pageable) {
-        return repository.findAllByAtivoTrue(pageable).map(PacienteResponseDTO::from);
+    public Page<PacienteResponseDTO> listar(
+            String nome,
+            String email,
+            String cpf,
+            String telefone,
+            Boolean ativo,
+            Pageable pageable) {
+        return repository.findAll(filtros(nome, email, cpf, telefone, ativo), pageable)
+                .map(PacienteResponseDTO::from);
     }
 
     public PacienteResponseDTO buscarPorId(Long id) {
@@ -85,5 +95,29 @@ public class PacienteService {
     private Paciente encontrar(Long id) {
         return repository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Paciente não encontrado: " + id));
+    }
+
+    private Specification<Paciente> filtros(String nome, String email, String cpf, String telefone, Boolean ativo) {
+        Specification<Paciente> spec = porStatus(ativo);
+        spec = spec.and(contemIgnorandoCase("nome", nome));
+        spec = spec.and(contemIgnorandoCase("email", email));
+        spec = spec.and(contemIgnorandoCase("cpf", cpf));
+        spec = spec.and(contemIgnorandoCase("telefone", telefone));
+        return spec;
+    }
+
+    private Specification<Paciente> porStatus(Boolean ativo) {
+        boolean status = ativo == null || ativo;
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("ativo"), status);
+    }
+
+    private Specification<Paciente> contemIgnorandoCase(String campo, String valor) {
+        if (valor == null || valor.isBlank()) {
+            return Specification.where(null);
+        }
+
+        String filtro = "%" + valor.trim().toLowerCase(Locale.ROOT) + "%";
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.like(criteriaBuilder.lower(root.get(campo)), filtro);
     }
 }

--- a/src/main/java/com/carlesso/pilatesapi/service/PacienteService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/PacienteService.java
@@ -45,6 +45,7 @@ public class PacienteService {
         return PacienteResponseDTO.from(repository.save(paciente));
     }
 
+    @Transactional(readOnly = true)
     public Page<PacienteResponseDTO> listar(
             String nome,
             String email,

--- a/src/test/java/com/carlesso/pilatesapi/controller/PacienteControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/PacienteControllerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -124,7 +125,7 @@ class PacienteControllerTest {
     @Test
     void listar_deveRetornar200ComPaginaDeResultados() throws Exception {
         var page = new PageImpl<>(List.of(responseDTO()), PageRequest.of(0, 10), 1);
-        when(service.listar(any())).thenReturn(page);
+        when(service.listar(any(), any(), any(), any(), any(), any())).thenReturn(page);
 
         mvc.perform(get("/pacientes"))
                 .andExpect(status().isOk())
@@ -134,12 +135,29 @@ class PacienteControllerTest {
 
     @Test
     void listar_semPacientes_deveRetornar200ComPaginaVazia() throws Exception {
-        when(service.listar(any())).thenReturn(new PageImpl<>(List.of()));
+        when(service.listar(any(), any(), any(), any(), any(), any())).thenReturn(new PageImpl<>(List.of()));
 
         mvc.perform(get("/pacientes"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.page.totalElements").value(0))
                 .andExpect(jsonPath("$.content").isEmpty());
+    }
+
+    @Test
+    void listar_comFiltros_deveEncaminharParametrosParaService() throws Exception {
+        var page = new PageImpl<>(List.of(responseDTO()), PageRequest.of(0, 10), 1);
+        when(service.listar(any(), any(), any(), any(), any(), any())).thenReturn(page);
+
+        mvc.perform(get("/pacientes")
+                        .param("nome", "Maria")
+                        .param("email", "maria@email.com")
+                        .param("cpf", "123")
+                        .param("telefone", "119")
+                        .param("ativo", "false"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].nome").value("Maria Souza"));
+
+        verify(service).listar(eq("Maria"), eq("maria@email.com"), eq("123"), eq("119"), eq(false), any());
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/com/carlesso/pilatesapi/service/PacienteServiceIntegrationTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/PacienteServiceIntegrationTest.java
@@ -23,8 +23,6 @@ class PacienteServiceIntegrationTest {
 
     @BeforeEach
     void setUp() {
-        repository.deleteAll();
-
         repository.save(paciente("Maria Souza", "maria@email.com", "12345678900", "11912345678", true));
         repository.save(paciente("Mariana Lima", "mariana@email.com", "98765432100", "11999990000", false));
         repository.save(paciente("João Silva", "joao@email.com", "11122233344", "21912340000", true));
@@ -49,6 +47,26 @@ class PacienteServiceIntegrationTest {
                     assertThat(paciente.nome()).isEqualTo("Mariana Lima");
                     assertThat(paciente.ativo()).isFalse();
                 });
+    }
+
+    @Test
+    void listar_filtroNomeEmBranco_deveIgnorarFiltro() {
+        var resultado = service.listar("   ", null, null, null, null, PageRequest.of(0, 10));
+
+        assertThat(resultado.getContent())
+                .extracting("nome")
+                .containsExactlyInAnyOrder("Maria Souza", "João Silva");
+    }
+
+    @Test
+    void listar_semAtivoNaoRetornaTodosPacientes() {
+        var ativos = service.listar(null, null, null, null, null, PageRequest.of(0, 10));
+        var inativos = service.listar(null, null, null, null, false, PageRequest.of(0, 10));
+
+        assertThat(ativos.getTotalElements()).isEqualTo(2);
+        assertThat(inativos.getTotalElements()).isEqualTo(1);
+        assertThat(ativos.getTotalElements() + inativos.getTotalElements())
+                .isEqualTo(3);
     }
 
     private Paciente paciente(String nome, String email, String cpf, String telefone, boolean ativo) {

--- a/src/test/java/com/carlesso/pilatesapi/service/PacienteServiceIntegrationTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/PacienteServiceIntegrationTest.java
@@ -1,0 +1,63 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.entity.Paciente;
+import com.carlesso.pilatesapi.repository.PacienteRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest(showSql = false)
+@Import(PacienteService.class)
+class PacienteServiceIntegrationTest {
+
+    @Autowired
+    private PacienteRepository repository;
+
+    @Autowired
+    private PacienteService service;
+
+    @BeforeEach
+    void setUp() {
+        repository.deleteAll();
+
+        repository.save(paciente("Maria Souza", "maria@email.com", "12345678900", "11912345678", true));
+        repository.save(paciente("Mariana Lima", "mariana@email.com", "98765432100", "11999990000", false));
+        repository.save(paciente("João Silva", "joao@email.com", "11122233344", "21912340000", true));
+    }
+
+    @Test
+    void listar_semStatusRetornaAtivosPorPadrao() {
+        var resultado = service.listar(null, null, null, null, null, PageRequest.of(0, 10));
+
+        assertThat(resultado.getContent())
+                .extracting("nome")
+                .containsExactlyInAnyOrder("Maria Souza", "João Silva");
+    }
+
+    @Test
+    void listar_filtraPorCamposTextuaisEStatus() {
+        var resultado = service.listar("mari", "email.com", "987", "1199", false, PageRequest.of(0, 10));
+
+        assertThat(resultado.getContent())
+                .singleElement()
+                .satisfies(paciente -> {
+                    assertThat(paciente.nome()).isEqualTo("Mariana Lima");
+                    assertThat(paciente.ativo()).isFalse();
+                });
+    }
+
+    private Paciente paciente(String nome, String email, String cpf, String telefone, boolean ativo) {
+        Paciente paciente = new Paciente();
+        paciente.setNome(nome);
+        paciente.setEmail(email);
+        paciente.setCpf(cpf);
+        paciente.setTelefone(telefone);
+        paciente.setAtivo(ativo);
+        return paciente;
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/service/PacienteServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/PacienteServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -23,6 +24,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -114,9 +116,9 @@ class PacienteServiceTest {
     void listar_deveRetornarPageComPacientesAtivos() {
         var pageable = PageRequest.of(0, 10);
         var page = new PageImpl<>(List.of(paciente()), pageable, 1);
-        when(repository.findAllByAtivoTrue(pageable)).thenReturn(page);
+        when(repository.findAll(org.mockito.ArgumentMatchers.<Specification<Paciente>>any(), eq(pageable))).thenReturn(page);
 
-        var resultado = service.listar(pageable);
+        var resultado = service.listar(null, null, null, null, null, pageable);
 
         assertThat(resultado.getTotalElements()).isEqualTo(1);
         assertThat(resultado.getContent().get(0).nome()).isEqualTo("Maria Souza");
@@ -125,12 +127,25 @@ class PacienteServiceTest {
     @Test
     void listar_semPacientes_deveRetornarPageVazia() {
         var pageable = PageRequest.of(0, 10);
-        when(repository.findAllByAtivoTrue(pageable)).thenReturn(new PageImpl<>(List.of()));
+        when(repository.findAll(org.mockito.ArgumentMatchers.<Specification<Paciente>>any(), eq(pageable))).thenReturn(new PageImpl<>(List.of()));
 
-        var resultado = service.listar(pageable);
+        var resultado = service.listar(null, null, null, null, null, pageable);
 
         assertThat(resultado.getTotalElements()).isZero();
         assertThat(resultado.getContent()).isEmpty();
+    }
+
+    @Test
+    void listar_comFiltros_deveConsultarRepositoryComSpecification() {
+        var pageable = PageRequest.of(0, 10);
+        var page = new PageImpl<>(List.of(paciente()), pageable, 1);
+        when(repository.findAll(org.mockito.ArgumentMatchers.<Specification<Paciente>>any(), eq(pageable))).thenReturn(page);
+
+        var resultado = service.listar("maria", "email.com", "123", "119", false, pageable);
+
+        assertThat(resultado.getTotalElements()).isEqualTo(1);
+        assertThat(resultado.getContent().get(0).email()).isEqualTo("maria@email.com");
+        verify(repository).findAll(org.mockito.ArgumentMatchers.<Specification<Paciente>>any(), eq(pageable));
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Resumo
- Adiciona filtros opcionais em `GET /pacientes` por `nome`, `email`, `cpf`, `telefone` e `ativo`
- Mantém compatibilidade: sem `ativo`, a listagem continua retornando apenas pacientes ativos
- Atualiza testes unitários, adiciona teste JPA dos filtros e documenta README/docs

## Testes
- `mvn test` (105 testes, 0 falhas)

Closes #12