### PR TITLE
feat: adiciona filtros de busca para profissionais

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Base URL: `http://localhost:8080`
 | Método | Endpoint | Descrição |
 |---|---|---|
 | `POST` | `/profissionais` | Cadastrar novo profissional |
-| `GET` | `/profissionais` | Listar profissionais ativos (paginado) |
+| `GET` | `/profissionais` | Listar e filtrar profissionais (paginado) |
 | `GET` | `/profissionais/{id}` | Buscar profissional por ID |
 | `PUT` | `/profissionais/{id}` | Atualizar dados do profissional |
 | `PATCH` | `/profissionais/{id}/ativar` | Reativar profissional |
@@ -176,6 +176,13 @@ O endpoint `GET /pacientes` também suporta filtros opcionais por `nome`, `email
 ```
 GET /pacientes?nome=maria&email=email.com&cpf=123&telefone=119&ativo=true&page=0&size=10&sort=nome,asc
 GET /pacientes?ativo=false
+```
+
+O endpoint `GET /profissionais` também suporta filtros opcionais por `nome`, `email`, `tipoContrato`, `percentualPagamentoAula` e `ativo`. Quando `ativo` é omitido, retorna apenas profissionais ativos.
+
+```
+GET /profissionais?nome=paula&email=email.com&tipoContrato=PJ&percentualPagamentoAula=45.00&ativo=true&page=0&size=10&sort=nome,asc
+GET /profissionais?ativo=false
 ```
 
 ---

--- a/docs/context.md
+++ b/docs/context.md
@@ -113,7 +113,7 @@ O endereço é um `@Embeddable` (`Endereco`), suas colunas ficam diretamente na 
 | `cpf` | VARCHAR(14) | NOT NULL, UNIQUE |
 | `telefone` | VARCHAR | — |
 | `tipo_contrato` | VARCHAR(30) | NOT NULL (`CLT`, `PJ`, `AUTONOMO`) |
-| `percentual_pagamento_aula` | NUMERIC(3,2) | NOT NULL |
+| `percentual_pagamento_aula` | NUMERIC(5,2) | NOT NULL |
 | `data_inicio` | DATE | NOT NULL |
 | `ativo` | BOOLEAN | NOT NULL, default `true` |
 
@@ -172,7 +172,7 @@ Constraint: `UNIQUE (paciente_id, data)`
 | PATCH | `/pacientes/{id}/ativar` | Reativar paciente | 204 / 404 |
 | PATCH | `/pacientes/{id}/inativar` | Soft delete (inativar) | 204 / 404 |
 | POST | `/profissionais` | Cadastrar profissional | 201 + Location header |
-| GET | `/profissionais` | Listar ativos (paginado) | 200 + Page |
+| GET | `/profissionais` | Listar e filtrar por nome, e-mail, contrato, percentual por aula e ativo/inativo (paginado) | 200 + Page |
 | GET | `/profissionais/{id}` | Buscar por ID | 200 / 404 |
 | PUT | `/profissionais/{id}` | Atualização parcial | 200 / 404 |
 | PATCH | `/profissionais/{id}/ativar` | Reativar profissional | 204 / 404 |
@@ -195,6 +195,7 @@ Campos obrigatórios no cadastro de pacientes: `nome`, `email`, `cpf`.
 Campos obrigatórios no cadastro de profissionais: `nome`, `email`, `cpf`, `tipoContrato`, `percentualPagamentoAula`, `dataInicio`.  
 CPF não pode ser alterado após o cadastro.  
 `GET /pacientes` retorna pacientes ativos por padrão e aceita `ativo=false` para consultar inativos.
+`GET /profissionais` retorna profissionais ativos por padrão e aceita filtros opcionais por `nome`, `email`, `tipoContrato`, `percentualPagamentoAula` e `ativo=false` para consultar inativos.
 
 ---
 

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -232,7 +232,7 @@ Tabela: `profissionais`
 | `cpf` | `VARCHAR(14)` | NOT NULL, UNIQUE | CPF do profissional |
 | `telefone` | `VARCHAR` | — | Telefone de contato |
 | `tipo_contrato` | `VARCHAR(30)` | NOT NULL | `CLT` / `PJ` / `AUTONOMO` |
-| `percentual_pagamento_aula` | `NUMERIC(3,2)` | NOT NULL | Percentual por aula ministrada |
+| `percentual_pagamento_aula` | `NUMERIC(5,2)` | NOT NULL | Percentual por aula ministrada |
 | `data_inicio` | `DATE` | NOT NULL | Data de início do contrato |
 | `ativo` | `BOOLEAN` | NOT NULL, default `true` | Indica se o profissional está ativo |
 
@@ -436,15 +436,21 @@ GET /pacientes?ativo=false
 
 ---
 
-#### Listar Profissionais Ativos
+#### Listar e Filtrar Profissionais
 
 | | |
 |---|---|
 | **Método** | `GET` |
 | **Rota** | `/profissionais` |
-| **Descrição** | Retorna uma página de profissionais ativos. Suporta `page`, `size` e `sort`. |
+| **Descrição** | Retorna uma página de profissionais filtrando por nome, e-mail, tipo de contrato, percentual por aula e status ativo/inativo. Quando `ativo` é omitido, retorna apenas ativos. Suporta `page`, `size` e `sort`. |
 
-**Exemplo:** `GET /profissionais?page=0&size=10&sort=nome`
+**Exemplos:**
+
+```http
+GET /profissionais?page=0&size=10&sort=nome
+GET /profissionais?nome=paula&email=email.com&tipoContrato=PJ&percentualPagamentoAula=45.00&ativo=true&page=0&size=10&sort=nome
+GET /profissionais?ativo=false
+```
 
 | Código | Situação |
 |---|---|

--- a/src/main/java/com/carlesso/pilatesapi/controller/ProfissionalController.java
+++ b/src/main/java/com/carlesso/pilatesapi/controller/ProfissionalController.java
@@ -3,6 +3,7 @@ package com.carlesso.pilatesapi.controller;
 import com.carlesso.pilatesapi.dto.ProfissionalRequestDTO;
 import com.carlesso.pilatesapi.dto.ProfissionalResponseDTO;
 import com.carlesso.pilatesapi.dto.ProfissionalUpdateDTO;
+import com.carlesso.pilatesapi.entity.enums.TipoContrato;
 import com.carlesso.pilatesapi.service.ProfissionalService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -17,6 +18,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import java.math.BigDecimal;
 
 @Tag(name = "Profissionais", description = "Gerenciamento de profissionais do estúdio")
 @RestController
@@ -43,14 +46,19 @@ public class ProfissionalController {
         return ResponseEntity.created(uri).body(response);
     }
 
-    @Operation(summary = "Listar profissionais ativos", description = "Retorna uma página de profissionais com status ativo. Suporta paginação e ordenação via query params.")
+    @Operation(summary = "Listar e filtrar profissionais", description = "Retorna uma página de profissionais filtrando por nome, e-mail, tipo de contrato, percentual por aula e status ativo/inativo. Por padrão retorna profissionais ativos. Suporta paginação e ordenação via query params.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Lista retornada com sucesso")
     })
     @GetMapping
     public ResponseEntity<Page<ProfissionalResponseDTO>> listar(
+            @Parameter(description = "Filtro parcial por nome") @RequestParam(required = false) String nome,
+            @Parameter(description = "Filtro parcial por e-mail") @RequestParam(required = false) String email,
+            @Parameter(description = "Filtro por tipo de contrato") @RequestParam(required = false) TipoContrato tipoContrato,
+            @Parameter(description = "Filtro por percentual de pagamento por aula") @RequestParam(required = false) BigDecimal percentualPagamentoAula,
+            @Parameter(description = "Filtra por status. Quando omitido, retorna apenas ativos.") @RequestParam(required = false) Boolean ativo,
             @ParameterObject @PageableDefault(size = 10, sort = "nome") Pageable pageable) {
-        return ResponseEntity.ok(service.listar(pageable));
+        return ResponseEntity.ok(service.listar(nome, email, tipoContrato, percentualPagamentoAula, ativo, pageable));
     }
 
     @Operation(summary = "Buscar profissional por ID", description = "Retorna os dados completos de um profissional pelo seu identificador único.")

--- a/src/main/java/com/carlesso/pilatesapi/entity/Profissional.java
+++ b/src/main/java/com/carlesso/pilatesapi/entity/Profissional.java
@@ -29,7 +29,7 @@ public class Profissional {
     @Column(nullable = false)
     private TipoContrato tipoContrato;
 
-    @Column(nullable = false, precision = 3, scale = 2)
+    @Column(nullable = false, precision = 5, scale = 2)
     private BigDecimal percentualPagamentoAula;
 
     @Column(nullable = false)

--- a/src/main/java/com/carlesso/pilatesapi/repository/ProfissionalRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/ProfissionalRepository.java
@@ -1,13 +1,10 @@
 package com.carlesso.pilatesapi.repository;
 
 import com.carlesso.pilatesapi.entity.Profissional;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface ProfissionalRepository extends JpaRepository<Profissional, Long> {
-
-    Page<Profissional> findAllByAtivoTrue(Pageable pageable);
+public interface ProfissionalRepository extends JpaRepository<Profissional, Long>, JpaSpecificationExecutor<Profissional> {
 
     boolean existsByEmail(String email);
 

--- a/src/main/java/com/carlesso/pilatesapi/service/ProfissionalService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/ProfissionalService.java
@@ -4,12 +4,17 @@ import com.carlesso.pilatesapi.dto.ProfissionalRequestDTO;
 import com.carlesso.pilatesapi.dto.ProfissionalResponseDTO;
 import com.carlesso.pilatesapi.dto.ProfissionalUpdateDTO;
 import com.carlesso.pilatesapi.entity.Profissional;
+import com.carlesso.pilatesapi.entity.enums.TipoContrato;
 import com.carlesso.pilatesapi.repository.ProfissionalRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.Locale;
 
 @Service
 public class ProfissionalService {
@@ -40,8 +45,15 @@ public class ProfissionalService {
     }
 
     @Transactional(readOnly = true)
-    public Page<ProfissionalResponseDTO> listar(Pageable pageable) {
-        return repository.findAllByAtivoTrue(pageable).map(ProfissionalResponseDTO::from);
+    public Page<ProfissionalResponseDTO> listar(
+            String nome,
+            String email,
+            TipoContrato tipoContrato,
+            BigDecimal percentualPagamentoAula,
+            Boolean ativo,
+            Pageable pageable) {
+        return repository.findAll(filtros(nome, email, tipoContrato, percentualPagamentoAula, ativo), pageable)
+                .map(ProfissionalResponseDTO::from);
     }
 
     @Transactional(readOnly = true)
@@ -74,5 +86,42 @@ public class ProfissionalService {
     private Profissional encontrar(Long id) {
         return repository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Profissional não encontrado: " + id));
+    }
+
+    private Specification<Profissional> filtros(
+            String nome,
+            String email,
+            TipoContrato tipoContrato,
+            BigDecimal percentualPagamentoAula,
+            Boolean ativo) {
+        Specification<Profissional> spec = porStatus(ativo);
+        spec = spec.and(contemIgnorandoCase("nome", nome));
+        spec = spec.and(contemIgnorandoCase("email", email));
+        spec = spec.and(igual("tipoContrato", tipoContrato));
+        spec = spec.and(igual("percentualPagamentoAula", percentualPagamentoAula));
+        return spec;
+    }
+
+    private Specification<Profissional> porStatus(Boolean ativo) {
+        boolean status = ativo == null || ativo;
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("ativo"), status);
+    }
+
+    private Specification<Profissional> contemIgnorandoCase(String campo, String valor) {
+        if (valor == null || valor.isBlank()) {
+            return Specification.where(null);
+        }
+
+        String filtro = "%" + valor.trim().toLowerCase(Locale.ROOT) + "%";
+        return (root, query, criteriaBuilder) ->
+                criteriaBuilder.like(criteriaBuilder.lower(root.get(campo)), filtro);
+    }
+
+    private <T> Specification<Profissional> igual(String campo, T valor) {
+        if (valor == null) {
+            return Specification.where(null);
+        }
+
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get(campo), valor);
     }
 }

--- a/src/main/resources/db/migration/V9__alter_profissionais_percentual_precision.sql
+++ b/src/main/resources/db/migration/V9__alter_profissionais_percentual_precision.sql
@@ -1,0 +1,2 @@
+ALTER TABLE profissionais
+    ALTER COLUMN percentual_pagamento_aula TYPE NUMERIC(5,2);

--- a/src/test/java/com/carlesso/pilatesapi/controller/ProfissionalControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/ProfissionalControllerTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
@@ -62,12 +63,36 @@ class ProfissionalControllerTest {
 
     @Test
     void listar_deveRetornar200() throws Exception {
-        when(service.listar(any())).thenReturn(new PageImpl<>(List.of(response()), PageRequest.of(0, 10), 1));
+        when(service.listar(any(), any(), any(), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of(response()), PageRequest.of(0, 10), 1));
 
         mvc.perform(get("/profissionais"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].tipoContrato").value("PJ"))
                 .andExpect(jsonPath("$.page.totalElements").value(1));
+    }
+
+    @Test
+    void listar_comFiltros_deveRepassarParametrosParaService() throws Exception {
+        when(service.listar(any(), any(), any(), any(), any(), any()))
+                .thenReturn(new PageImpl<>(List.of(response()), PageRequest.of(0, 10), 1));
+
+        mvc.perform(get("/profissionais")
+                        .param("nome", "paula")
+                        .param("email", "email.com")
+                        .param("tipoContrato", "PJ")
+                        .param("percentualPagamentoAula", "45.00")
+                        .param("ativo", "false"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].nome").value("Paula Mendes"));
+
+        verify(service).listar(
+                eq("paula"),
+                eq("email.com"),
+                eq(TipoContrato.PJ),
+                eq(new BigDecimal("45.00")),
+                eq(false),
+                any());
     }
 
     @Test

--- a/src/test/java/com/carlesso/pilatesapi/service/ProfissionalServiceIntegrationTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/ProfissionalServiceIntegrationTest.java
@@ -80,6 +80,18 @@ class ProfissionalServiceIntegrationTest {
                 .isEqualTo(3);
     }
 
+    @Test
+    void listar_filtraPorPercentualPagamentoAulaIsolado() {
+        var resultado = service.listar(null, null, null, new BigDecimal("40.00"), null, PageRequest.of(0, 10));
+
+        assertThat(resultado.getContent())
+                .singleElement()
+                .satisfies(profissional -> {
+                    assertThat(profissional.nome()).isEqualTo("Ricardo Souza");
+                    assertThat(profissional.percentualPagamentoAula()).isEqualByComparingTo("40.00");
+                });
+    }
+
     private Profissional profissional(
             String nome,
             String email,

--- a/src/test/java/com/carlesso/pilatesapi/service/ProfissionalServiceIntegrationTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/ProfissionalServiceIntegrationTest.java
@@ -1,0 +1,101 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.entity.Profissional;
+import com.carlesso.pilatesapi.entity.enums.TipoContrato;
+import com.carlesso.pilatesapi.repository.ProfissionalRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest(showSql = false)
+@Import(ProfissionalService.class)
+class ProfissionalServiceIntegrationTest {
+
+    @Autowired
+    private ProfissionalRepository repository;
+
+    @Autowired
+    private ProfissionalService service;
+
+    @BeforeEach
+    void setUp() {
+        repository.deleteAll();
+        repository.save(profissional("Paula Mendes", "paula@email.com", "12345678900", TipoContrato.PJ, "45.00", true));
+        repository.save(profissional("Ricardo Souza", "ricardo@email.com", "98765432100", TipoContrato.AUTONOMO, "40.00", true));
+        repository.save(profissional("Fernanda Lima", "fernanda@email.com", "11122233344", TipoContrato.CLT, "35.00", false));
+    }
+
+    @Test
+    void listar_semStatusRetornaAtivosPorPadrao() {
+        var resultado = service.listar(null, null, null, null, null, PageRequest.of(0, 10));
+
+        assertThat(resultado.getContent())
+                .extracting("nome")
+                .containsExactlyInAnyOrder("Paula Mendes", "Ricardo Souza");
+    }
+
+    @Test
+    void listar_filtraPorCamposDaIssueEStatus() {
+        var resultado = service.listar(
+                "fer",
+                "email.com",
+                TipoContrato.CLT,
+                new BigDecimal("35.00"),
+                false,
+                PageRequest.of(0, 10));
+
+        assertThat(resultado.getContent())
+                .singleElement()
+                .satisfies(profissional -> {
+                    assertThat(profissional.nome()).isEqualTo("Fernanda Lima");
+                    assertThat(profissional.ativo()).isFalse();
+                });
+    }
+
+    @Test
+    void listar_filtroNomeEmBranco_deveIgnorarFiltro() {
+        var resultado = service.listar("   ", null, null, null, null, PageRequest.of(0, 10));
+
+        assertThat(resultado.getContent())
+                .extracting("nome")
+                .containsExactlyInAnyOrder("Paula Mendes", "Ricardo Souza");
+    }
+
+    @Test
+    void listar_semAtivoNaoRetornaTodosProfissionais() {
+        var ativos = service.listar(null, null, null, null, null, PageRequest.of(0, 10));
+        var inativos = service.listar(null, null, null, null, false, PageRequest.of(0, 10));
+
+        assertThat(ativos.getTotalElements()).isEqualTo(2);
+        assertThat(inativos.getTotalElements()).isEqualTo(1);
+        assertThat(ativos.getTotalElements() + inativos.getTotalElements())
+                .isEqualTo(3);
+    }
+
+    private Profissional profissional(
+            String nome,
+            String email,
+            String cpf,
+            TipoContrato tipoContrato,
+            String percentualPagamentoAula,
+            boolean ativo) {
+        Profissional profissional = new Profissional();
+        profissional.setNome(nome);
+        profissional.setEmail(email);
+        profissional.setCpf(cpf);
+        profissional.setTelefone("11999999999");
+        profissional.setTipoContrato(tipoContrato);
+        profissional.setPercentualPagamentoAula(new BigDecimal(percentualPagamentoAula));
+        profissional.setDataInicio(LocalDate.of(2024, 1, 15));
+        profissional.setAtivo(ativo);
+        return profissional;
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/service/ProfissionalServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/ProfissionalServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -23,6 +24,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -89,11 +91,31 @@ class ProfissionalServiceTest {
     @Test
     void listar_deveRetornarApenasAtivos() {
         var pageable = PageRequest.of(0, 10);
-        when(repository.findAllByAtivoTrue(pageable)).thenReturn(new PageImpl<>(List.of(profissional())));
+        when(repository.findAll(org.mockito.ArgumentMatchers.<Specification<Profissional>>any(), eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(profissional())));
 
-        var resultado = service.listar(pageable);
+        var resultado = service.listar(null, null, null, null, null, pageable);
 
         assertThat(resultado.getTotalElements()).isEqualTo(1);
+    }
+
+    @Test
+    void listar_comFiltros_deveConsultarRepositoryComSpecification() {
+        var pageable = PageRequest.of(0, 10);
+        when(repository.findAll(org.mockito.ArgumentMatchers.<Specification<Profissional>>any(), eq(pageable)))
+                .thenReturn(new PageImpl<>(List.of(profissional()), pageable, 1));
+
+        var resultado = service.listar(
+                "paula",
+                "email.com",
+                TipoContrato.PJ,
+                new BigDecimal("45.00"),
+                false,
+                pageable);
+
+        assertThat(resultado.getTotalElements()).isEqualTo(1);
+        assertThat(resultado.getContent().get(0).tipoContrato()).isEqualTo(TipoContrato.PJ);
+        verify(repository).findAll(org.mockito.ArgumentMatchers.<Specification<Profissional>>any(), eq(pageable));
     }
 
     @Test

--- a/src/test/java/com/carlesso/pilatesapi/service/ProfissionalServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/ProfissionalServiceTest.java
@@ -89,7 +89,7 @@ class ProfissionalServiceTest {
     }
 
     @Test
-    void listar_deveRetornarApenasAtivos() {
+    void listar_semFiltros_delegaAoRepository() {
         var pageable = PageRequest.of(0, 10);
         when(repository.findAll(org.mockito.ArgumentMatchers.<Specification<Profissional>>any(), eq(pageable)))
                 .thenReturn(new PageImpl<>(List.of(profissional())));


### PR DESCRIPTION
## Resumo
- adiciona filtros em GET /profissionais por nome, e-mail, tipoContrato, percentualPagamentoAula e ativo
- mantém profissionais ativos como retorno padrão quando ativo não é informado
- alinha precisão de percentualPagamentoAula com o schema atual e atualiza README/docs

## Testes
- mvn test

Closes #11