### PR TITLE
Fix soft-delete de paciente no AulaRepository

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,14 +494,14 @@ curl -s -X PATCH http://localhost:8080/pacientes/1/inativar -w "%{http_code}"
 
 ## Testes
 
-O projeto possui **127 testes** organizados em quinze suítes:
+O projeto possui **129 testes** organizados em quinze suítes:
 
 | Suíte | Tipo | Testes |
 |---|---|---|
 | `PacienteServiceTest` | Unitário (Mockito) | 12 |
 | `PlanoServiceTest` | Unitário (Mockito) | 8 |
 | `PagamentoServiceTest` | Unitário (Mockito) | 8 |
-| `AulaServiceTest` | Unitário (Mockito) | 10 |
+| `AulaServiceTest` | Unitário (Mockito) | 12 |
 | `ProfissionalServiceTest` | Unitário (Mockito) | 13 |
 | `PacienteServiceIntegrationTest` | JPA (`@DataJpaTest`) | 4 |
 | `ProfissionalServiceIntegrationTest` | JPA (`@DataJpaTest`) | 5 |

--- a/README.md
+++ b/README.md
@@ -98,10 +98,13 @@ src/
     ├── service/
     │   ├── PacienteServiceTest.java
     │   ├── PacienteServiceIntegrationTest.java
+    │   ├── ProfissionalServiceIntegrationTest.java
     │   ├── ProfissionalServiceTest.java
     │   ├── PlanoServiceTest.java
     │   ├── PagamentoServiceTest.java
     │   └── AulaServiceTest.java
+    ├── repository/
+    │   └── AulaRepositoryTest.java
     └── controller/
         ├── PacienteControllerTest.java
         ├── ProfissionalControllerTest.java
@@ -453,7 +456,7 @@ curl -s -X PATCH http://localhost:8080/pacientes/1/inativar -w "%{http_code}"
 - Tipos de contrato: `CLT`, `PJ`, `AUTONOMO`
 - O `percentualPagamentoAula` representa o percentual recebido por aula ministrada
 - Profissionais inativos são mantidos no banco (soft delete)
-- O relatório de pagamento considera aulas realizadas vinculadas ao profissional no período informado
+- O relatório de pagamento considera aulas realizadas vinculadas ao profissional no período informado e ignora aulas de pacientes inativos
 - O valor devido por aula é calculado por `valor do pagamento / quantidade de aulas do pagamento * percentualPagamentoAula / 100`
 
 ### Planos de Pagamento
@@ -478,6 +481,7 @@ curl -s -X PATCH http://localhost:8080/pacientes/1/inativar -w "%{http_code}"
 - Aulas geradas com base nos dias da semana do plano e no período do pagamento
 - Sem duplicatas: se a aula do paciente naquela data já existir, ela é ignorada
 - Requer paciente ativo e pagamento confirmado
+- Consultas de aulas por ID, paciente, pagamento e relatório retornam apenas aulas associadas a pacientes ativos
 - Ao marcar uma aula como realizada, `profissionalId` pode ser informado para alimentar o relatório de pagamento do profissional
 
 ### Scheduler (processos automáticos)
@@ -490,7 +494,7 @@ curl -s -X PATCH http://localhost:8080/pacientes/1/inativar -w "%{http_code}"
 
 ## Testes
 
-O projeto possui **122 testes** organizados em treze suítes:
+O projeto possui **127 testes** organizados em quinze suítes:
 
 | Suíte | Tipo | Testes |
 |---|---|---|
@@ -500,6 +504,8 @@ O projeto possui **122 testes** organizados em treze suítes:
 | `AulaServiceTest` | Unitário (Mockito) | 10 |
 | `ProfissionalServiceTest` | Unitário (Mockito) | 13 |
 | `PacienteServiceIntegrationTest` | JPA (`@DataJpaTest`) | 4 |
+| `ProfissionalServiceIntegrationTest` | JPA (`@DataJpaTest`) | 5 |
+| `AulaRepositoryTest` | JPA (`@DataJpaTest`) | 5 |
 | `PacienteControllerTest` | Controller (`@WebMvcTest`) | 16 |
 | `PlanoControllerTest` | Controller (`@WebMvcTest`) | 11 |
 | `PagamentoControllerTest` | Controller (`@WebMvcTest`) | 9 |

--- a/docs/context.md
+++ b/docs/context.md
@@ -327,8 +327,10 @@ JAVA_HOME=~/jdk mvn spring-boot:run
 | `ProfissionalServiceTest` | Unitário (Mockito, sem Spring) | 13 |
 | `PlanoServiceTest` | Unitário (Mockito, sem Spring) | 8 |
 | `PagamentoServiceTest` | Unitário (Mockito, sem Spring) | 8 |
-| `AulaServiceTest` | Unitário (Mockito, sem Spring) | 10 |
+| `AulaServiceTest` | Unitário (Mockito, sem Spring) | 12 |
 | `PacienteServiceIntegrationTest` | `@DataJpaTest` + H2 | 4 |
+| `ProfissionalServiceIntegrationTest` | `@DataJpaTest` + H2 | 5 |
+| `AulaRepositoryTest` | `@DataJpaTest` + H2 | 5 |
 | `PacienteControllerTest` | `@WebMvcTest` + MockMvc | 16 |
 | `ProfissionalControllerTest` | `@WebMvcTest` + MockMvc | 13 |
 | `PlanoControllerTest` | `@WebMvcTest` + MockMvc | 11 |

--- a/docs/context.md
+++ b/docs/context.md
@@ -208,11 +208,12 @@ CPF não pode ser alterado após o cadastro.
 ### Pacientes
 - Apenas um plano ativo por paciente por vez
 - Pacientes inativos não recebem cobranças nem têm aulas geradas
+- Consultas de aulas não retornam registros associados a pacientes inativos
 
 ### Profissionais
 - Tipos de contrato: `CLT`, `PJ`, `AUTONOMO`
 - Soft delete mantém o registro no banco
-- O relatório de pagamento considera apenas aulas `realizada = true` vinculadas ao profissional e dentro do período informado
+- O relatório de pagamento considera apenas aulas `realizada = true` vinculadas ao profissional, dentro do período informado e associadas a pacientes ativos
 - Valor por aula no relatório: `valor do pagamento / quantidade de aulas do pagamento`
 - Valor devido ao profissional por aula: `valor por aula * percentualPagamentoAula / 100`
 
@@ -231,6 +232,7 @@ CPF não pode ser alterado após o cadastro.
 - Geradas percorrendo dia a dia entre `periodoInicio` e `periodoFim`
 - Sem duplicatas: ignora datas onde o paciente já tem aula registrada
 - Requer: paciente ativo + pagamento `PAGO`
+- Consultas por ID, paciente, pagamento e relatório filtram `paciente.ativo = true`
 - Uma aula realizada pode ser vinculada ao profissional que ministrou a aula
 
 ### Scheduler (processos automáticos)

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -129,7 +129,7 @@ src/
     │   ├── ProfissionalServiceTest.java         # 13 casos
     │   ├── PlanoServiceTest.java                # 8 casos
     │   ├── PagamentoServiceTest.java            # 8 casos
-    │   └── AulaServiceTest.java                 # 10 casos
+    │   └── AulaServiceTest.java                 # 12 casos
     ├── repository/
     │   └── AulaRepositoryTest.java              # 5 casos
     └── controller/

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -125,10 +125,13 @@ src/
     ├── service/
     │   ├── PacienteServiceTest.java             # 12 casos
     │   ├── PacienteServiceIntegrationTest.java  # 4 casos
+    │   ├── ProfissionalServiceIntegrationTest.java # 5 casos
     │   ├── ProfissionalServiceTest.java         # 13 casos
     │   ├── PlanoServiceTest.java                # 8 casos
     │   ├── PagamentoServiceTest.java            # 8 casos
     │   └── AulaServiceTest.java                 # 10 casos
+    ├── repository/
+    │   └── AulaRepositoryTest.java              # 5 casos
     └── controller/
         ├── PacienteControllerTest.java          # 16 casos
         ├── ProfissionalControllerTest.java      # 13 casos
@@ -144,12 +147,13 @@ src/
 ### 4.1 Pacientes
 - Um paciente pode ter **apenas um plano ativo** por vez
 - Pacientes com `ativo = false` não podem receber novas cobranças nem ter aulas geradas
+- Consultas de aulas não retornam registros associados a pacientes inativos
 
 ### 4.2 Profissionais
 - Tipos de contrato: `CLT`, `PJ`, `AUTONOMO`
 - O campo `percentualPagamentoAula` representa o percentual recebido por aula ministrada
 - Soft delete: profissionais inativos são mantidos no banco
-- O relatório de pagamento considera aulas realizadas vinculadas ao profissional dentro do período solicitado
+- O relatório de pagamento considera aulas realizadas vinculadas ao profissional dentro do período solicitado e associadas a pacientes ativos
 - O valor devido por aula é proporcional ao valor do pagamento (`valor / quantidade de aulas geradas`) multiplicado pelo `percentualPagamentoAula`
 
 ### 4.3 Planos de Pagamento
@@ -185,6 +189,7 @@ src/
 - Aulas são geradas a partir dos dias da semana definidos no plano, percorrendo dia a dia entre `periodoInicio` e `periodoFim`
 - Não gera aulas duplicadas: se o paciente já tiver aula naquela data, ela é ignorada
 - Requer: paciente ativo + pagamento com status `PAGO`
+- Consultas por ID, paciente, pagamento e relatório filtram `paciente.ativo = true`
 
 ### 4.7 Processos Automáticos (Scheduler)
 

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -774,7 +774,7 @@ O serviço `app` aguarda o `db` estar saudável (healthcheck via `pg_isready`) a
 
 ### Visão geral
 
-A suíte de testes possui **122 casos** distribuídos em treze classes:
+A suíte de testes possui **129 casos** distribuídos em quinze classes:
 
 | Classe | Tipo | Casos |
 |---|---|---|
@@ -782,8 +782,10 @@ A suíte de testes possui **122 casos** distribuídos em treze classes:
 | `ProfissionalServiceTest` | Unitário (Mockito) | 13 |
 | `PlanoServiceTest` | Unitário (Mockito) | 8 |
 | `PagamentoServiceTest` | Unitário (Mockito) | 8 |
-| `AulaServiceTest` | Unitário (Mockito) | 10 |
+| `AulaServiceTest` | Unitário (Mockito) | 12 |
 | `PacienteServiceIntegrationTest` | JPA (`@DataJpaTest`) | 4 |
+| `ProfissionalServiceIntegrationTest` | JPA (`@DataJpaTest`) | 5 |
+| `AulaRepositoryTest` | JPA (`@DataJpaTest`) | 5 |
 | `PacienteControllerTest` | Controller (`@WebMvcTest`) | 16 |
 | `ProfissionalControllerTest` | Controller (`@WebMvcTest`) | 13 |
 | `PlanoControllerTest` | Controller (`@WebMvcTest`) | 11 |

--- a/src/main/java/com/carlesso/pilatesapi/repository/AulaRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/AulaRepository.java
@@ -8,20 +8,40 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface AulaRepository extends JpaRepository<Aula, Long> {
 
     boolean existsByPacienteAndData(Paciente paciente, LocalDate data);
 
-    List<Aula> findByPacienteIdOrderByData(Long pacienteId);
+    Optional<Aula> findByIdAndPacienteAtivoTrue(Long id);
 
-    List<Aula> findByPagamentoIdOrderByData(Long pagamentoId);
+    @Query("SELECT a FROM Aula a WHERE a.paciente.id = :pacienteId AND a.paciente.ativo = true ORDER BY a.data")
+    List<Aula> findByPacienteIdOrderByData(@Param("pacienteId") Long pacienteId);
 
-    @Query("SELECT a.pagamento.id, COUNT(a) FROM Aula a WHERE a.pagamento.id IN :ids GROUP BY a.pagamento.id")
+    @Query("SELECT a FROM Aula a WHERE a.pagamento.id = :pagamentoId AND a.paciente.ativo = true ORDER BY a.data")
+    List<Aula> findByPagamentoIdOrderByData(@Param("pagamentoId") Long pagamentoId);
+
+    @Query("""
+            SELECT a.pagamento.id, COUNT(a)
+            FROM Aula a
+            WHERE a.pagamento.id IN :ids
+              AND a.paciente.ativo = true
+            GROUP BY a.pagamento.id
+            """)
     List<Object[]> countGroupedByPagamentoId(@Param("ids") List<Long> ids);
 
+    @Query("""
+            SELECT a
+            FROM Aula a
+            WHERE a.profissional.id = :profissionalId
+              AND a.realizada = true
+              AND a.data BETWEEN :inicio AND :fim
+              AND a.paciente.ativo = true
+            ORDER BY a.data
+            """)
     List<Aula> findByProfissionalIdAndRealizadaTrueAndDataBetweenOrderByData(
-            Long profissionalId,
-            LocalDate inicio,
-            LocalDate fim);
+            @Param("profissionalId") Long profissionalId,
+            @Param("inicio") LocalDate inicio,
+            @Param("fim") LocalDate fim);
 }

--- a/src/main/java/com/carlesso/pilatesapi/service/AulaService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/AulaService.java
@@ -99,7 +99,7 @@ public class AulaService {
     }
 
     private Aula encontrar(Long id) {
-        return aulaRepository.findById(id)
+        return aulaRepository.findByIdAndPacienteAtivoTrue(id)
                 .orElseThrow(() -> new EntityNotFoundException("Aula não encontrada: " + id));
     }
 }

--- a/src/test/java/com/carlesso/pilatesapi/repository/AulaRepositoryTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/repository/AulaRepositoryTest.java
@@ -1,0 +1,160 @@
+package com.carlesso.pilatesapi.repository;
+
+import com.carlesso.pilatesapi.entity.Aula;
+import com.carlesso.pilatesapi.entity.Paciente;
+import com.carlesso.pilatesapi.entity.Pagamento;
+import com.carlesso.pilatesapi.entity.Plano;
+import com.carlesso.pilatesapi.entity.Profissional;
+import com.carlesso.pilatesapi.entity.enums.FrequenciaSemanal;
+import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
+import com.carlesso.pilatesapi.entity.enums.TipoContrato;
+import com.carlesso.pilatesapi.entity.enums.TipoPagamento;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest(showSql = false)
+class AulaRepositoryTest {
+
+    @Autowired
+    private AulaRepository repository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private Paciente pacienteAtivo;
+    private Paciente pacienteInativo;
+    private Pagamento pagamentoAtivo;
+    private Pagamento pagamentoInativo;
+    private Profissional profissional;
+    private Aula aulaAtiva;
+    private Aula aulaInativa;
+
+    @BeforeEach
+    void setUp() {
+        pacienteAtivo = entityManager.persist(paciente("Ana Ativa", "ana.ativa@email.com", "11122233344", true));
+        pacienteInativo = entityManager.persist(paciente("Bia Inativa", "bia.inativa@email.com", "55566677788", false));
+        profissional = entityManager.persist(profissional());
+
+        Plano planoAtivo = entityManager.persist(plano(pacienteAtivo));
+        Plano planoInativo = entityManager.persist(plano(pacienteInativo));
+
+        pagamentoAtivo = entityManager.persist(pagamento(pacienteAtivo, planoAtivo, LocalDate.of(2025, 2, 1)));
+        pagamentoInativo = entityManager.persist(pagamento(pacienteInativo, planoInativo, LocalDate.of(2025, 3, 1)));
+
+        aulaAtiva = entityManager.persist(aula(pacienteAtivo, pagamentoAtivo, LocalDate.of(2025, 2, 3)));
+        aulaInativa = entityManager.persist(aula(pacienteInativo, pagamentoInativo, LocalDate.of(2025, 3, 3)));
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @Test
+    void findByIdAndPacienteAtivoTrue_naoRetornaAulaDePacienteInativo() {
+        assertThat(repository.findByIdAndPacienteAtivoTrue(aulaAtiva.getId())).isPresent();
+        assertThat(repository.findByIdAndPacienteAtivoTrue(aulaInativa.getId())).isEmpty();
+    }
+
+    @Test
+    void findByPacienteIdOrderByData_naoRetornaAulasDePacienteInativo() {
+        assertThat(repository.findByPacienteIdOrderByData(pacienteAtivo.getId()))
+                .extracting(aula -> aula.getPaciente().getNome())
+                .containsExactly("Ana Ativa");
+
+        assertThat(repository.findByPacienteIdOrderByData(pacienteInativo.getId())).isEmpty();
+    }
+
+    @Test
+    void findByPagamentoIdOrderByData_naoRetornaAulasQuandoPacienteDoPagamentoEstaInativo() {
+        assertThat(repository.findByPagamentoIdOrderByData(pagamentoAtivo.getId()))
+                .extracting(Aula::getId)
+                .containsExactly(aulaAtiva.getId());
+
+        assertThat(repository.findByPagamentoIdOrderByData(pagamentoInativo.getId())).isEmpty();
+    }
+
+    @Test
+    void findByProfissionalIdAndRealizadaTrueAndDataBetweenOrderByData_naoRetornaPacienteInativo() {
+        var aulas = repository.findByProfissionalIdAndRealizadaTrueAndDataBetweenOrderByData(
+                profissional.getId(),
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2025, 12, 31));
+
+        assertThat(aulas)
+                .extracting(aula -> aula.getPaciente().getNome())
+                .containsExactly("Ana Ativa");
+    }
+
+    @Test
+    void countGroupedByPagamentoId_naoContaAulasDePacienteInativo() {
+        var contagens = repository.countGroupedByPagamentoId(List.of(pagamentoAtivo.getId(), pagamentoInativo.getId()));
+
+        assertThat(contagens)
+                .singleElement()
+                .satisfies(row -> {
+                    assertThat(row[0]).isEqualTo(pagamentoAtivo.getId());
+                    assertThat(row[1]).isEqualTo(1L);
+                });
+    }
+
+    private Paciente paciente(String nome, String email, String cpf, boolean ativo) {
+        Paciente paciente = new Paciente();
+        paciente.setNome(nome);
+        paciente.setEmail(email);
+        paciente.setCpf(cpf);
+        paciente.setAtivo(ativo);
+        return paciente;
+    }
+
+    private Profissional profissional() {
+        Profissional profissional = new Profissional();
+        profissional.setNome("Paula Mendes");
+        profissional.setEmail("paula@email.com");
+        profissional.setCpf("12345678900");
+        profissional.setTipoContrato(TipoContrato.PJ);
+        profissional.setPercentualPagamentoAula(new BigDecimal("45.00"));
+        profissional.setDataInicio(LocalDate.of(2024, 1, 15));
+        return profissional;
+    }
+
+    private Plano plano(Paciente paciente) {
+        Plano plano = new Plano();
+        plano.setPaciente(paciente);
+        plano.setTipo(TipoPagamento.MENSAL);
+        plano.setValor(new BigDecimal("200.00"));
+        plano.setFrequenciaSemanal(FrequenciaSemanal.UMA_VEZ);
+        plano.setDiasSemana(List.of(DayOfWeek.MONDAY));
+        plano.setDataInicio(LocalDate.of(2025, 1, 1));
+        return plano;
+    }
+
+    private Pagamento pagamento(Paciente paciente, Plano plano, LocalDate periodoInicio) {
+        Pagamento pagamento = new Pagamento();
+        pagamento.setPaciente(paciente);
+        pagamento.setPlano(plano);
+        pagamento.setValor(new BigDecimal("200.00"));
+        pagamento.setStatus(StatusPagamento.PAGO);
+        pagamento.setDataVencimento(periodoInicio.plusDays(10));
+        pagamento.setPeriodoInicio(periodoInicio);
+        pagamento.setPeriodoFim(periodoInicio.plusMonths(1).minusDays(1));
+        return pagamento;
+    }
+
+    private Aula aula(Paciente paciente, Pagamento pagamento, LocalDate data) {
+        Aula aula = new Aula();
+        aula.setPaciente(paciente);
+        aula.setPagamento(pagamento);
+        aula.setProfissional(profissional);
+        aula.setData(data);
+        aula.setRealizada(true);
+        return aula;
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/service/AulaServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/AulaServiceTest.java
@@ -202,10 +202,28 @@ class AulaServiceTest {
     }
 
     @Test
+    void realizarAula_pacienteInativo_lancaEntityNotFound() {
+        when(aulaRepository.findByIdAndPacienteAtivoTrue(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.realizarAula(1L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("Aula não encontrada: 1");
+    }
+
+    @Test
     void buscarPorId_naoEncontrado_lancaExcecao() {
         when(aulaRepository.findByIdAndPacienteAtivoTrue(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.buscarPorId(99L))
                 .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    void buscarPorId_pacienteInativo_lancaEntityNotFound() {
+        when(aulaRepository.findByIdAndPacienteAtivoTrue(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.buscarPorId(1L))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("Aula não encontrada: 1");
     }
 }

--- a/src/test/java/com/carlesso/pilatesapi/service/AulaServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/AulaServiceTest.java
@@ -136,7 +136,7 @@ class AulaServiceTest {
         aula.setPagamento(pagamentoPago);
         aula.setData(LocalDate.of(2025, 2, 3));
 
-        when(aulaRepository.findById(1L)).thenReturn(Optional.of(aula));
+        when(aulaRepository.findByIdAndPacienteAtivoTrue(1L)).thenReturn(Optional.of(aula));
 
         var response = service.realizarAula(1L);
 
@@ -159,7 +159,7 @@ class AulaServiceTest {
         profissional.setPercentualPagamentoAula(new BigDecimal("45.00"));
         profissional.setDataInicio(LocalDate.of(2024, 1, 15));
 
-        when(aulaRepository.findById(1L)).thenReturn(Optional.of(aula));
+        when(aulaRepository.findByIdAndPacienteAtivoTrue(1L)).thenReturn(Optional.of(aula));
         when(profissionalRepository.findById(1L)).thenReturn(Optional.of(profissional));
 
         service.realizarAula(1L, 1L);
@@ -178,7 +178,7 @@ class AulaServiceTest {
         Profissional profissional = new Profissional();
         profissional.setAtivo(false);
 
-        when(aulaRepository.findById(1L)).thenReturn(Optional.of(aula));
+        when(aulaRepository.findByIdAndPacienteAtivoTrue(1L)).thenReturn(Optional.of(aula));
         when(profissionalRepository.findById(1L)).thenReturn(Optional.of(profissional));
 
         assertThatThrownBy(() -> service.realizarAula(1L, 1L))
@@ -194,7 +194,7 @@ class AulaServiceTest {
         aula.setData(LocalDate.of(2025, 2, 3));
         aula.setRealizada(true);
 
-        when(aulaRepository.findById(1L)).thenReturn(Optional.of(aula));
+        when(aulaRepository.findByIdAndPacienteAtivoTrue(1L)).thenReturn(Optional.of(aula));
 
         assertThatThrownBy(() -> service.realizarAula(1L))
                 .isInstanceOf(IllegalStateException.class)
@@ -203,7 +203,7 @@ class AulaServiceTest {
 
     @Test
     void buscarPorId_naoEncontrado_lancaExcecao() {
-        when(aulaRepository.findById(99L)).thenReturn(Optional.empty());
+        when(aulaRepository.findByIdAndPacienteAtivoTrue(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.buscarPorId(99L))
                 .isInstanceOf(EntityNotFoundException.class);


### PR DESCRIPTION
## Resumo
- Filtra consultas do AulaRepository por paciente ativo em buscas por ID, paciente, pagamento, contagem por pagamento e relatório por profissional.
- Ajusta AulaService para tratar aula de paciente inativo como não encontrada.
- Adiciona AulaRepositoryTest com cobertura JPA para o soft-delete e atualiza README/docs.

## Testes
- mvn test

Closes #25