### PR TITLE
Security: receber dataPagamento no corpo da requisição

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ src/
 │   │   │   ├── PlanoRequestDTO.java
 │   │   │   ├── PlanoResponseDTO.java
 │   │   │   ├── PagamentoRequestDTO.java
+│   │   │   ├── PagamentoPagarRequestDTO.java
 │   │   │   ├── PagamentoResponseDTO.java
 │   │   │   └── AulaResponseDTO.java
 │   │   └── scheduler/
@@ -159,7 +160,7 @@ Base URL: `http://localhost:8080`
 | `POST` | `/pagamentos` | Criar pagamento (PENDENTE) |
 | `GET` | `/pagamentos/{id}` | Buscar pagamento por ID |
 | `GET` | `/pagamentos/paciente/{id}` | Listar pagamentos do paciente |
-| `PATCH` | `/pagamentos/{id}/pagar` | Confirmar pagamento e gerar aulas |
+| `PATCH` | `/pagamentos/{id}/pagar` | Confirmar pagamento e gerar aulas; aceita `dataPagamento` opcional no corpo |
 
 ### Aulas
 
@@ -444,6 +445,13 @@ curl -s -X PATCH http://localhost:8080/pacientes/1/ativar -w "%{http_code}"
 curl -s -X PATCH http://localhost:8080/pacientes/1/inativar -w "%{http_code}"
 ```
 
+### Confirmar pagamento
+```bash
+curl -s -X PATCH http://localhost:8080/pagamentos/1/pagar \
+  -H "Content-Type: application/json" \
+  -d '{"dataPagamento": "2025-02-10"}' | jq
+```
+
 ---
 
 ## Regras de Negócio
@@ -476,6 +484,7 @@ curl -s -X PATCH http://localhost:8080/pacientes/1/inativar -w "%{http_code}"
 - Valor não pode ser menor que o valor do plano
 - Não pode haver dois pagamentos para o mesmo plano no mesmo período
 - Ao confirmar (`PAGO`), as aulas do período são geradas automaticamente
+- A confirmação de pagamento recebe `dataPagamento` no corpo da requisição; se omitida, usa a data atual
 
 ### Geração de Aulas
 - Aulas geradas com base nos dias da semana do plano e no período do pagamento
@@ -494,7 +503,7 @@ curl -s -X PATCH http://localhost:8080/pacientes/1/inativar -w "%{http_code}"
 
 ## Testes
 
-O projeto possui **129 testes** organizados em quinze suítes:
+O projeto possui **130 testes** organizados em quinze suítes:
 
 | Suíte | Tipo | Testes |
 |---|---|---|
@@ -508,7 +517,7 @@ O projeto possui **129 testes** organizados em quinze suítes:
 | `AulaRepositoryTest` | JPA (`@DataJpaTest`) | 5 |
 | `PacienteControllerTest` | Controller (`@WebMvcTest`) | 16 |
 | `PlanoControllerTest` | Controller (`@WebMvcTest`) | 11 |
-| `PagamentoControllerTest` | Controller (`@WebMvcTest`) | 9 |
+| `PagamentoControllerTest` | Controller (`@WebMvcTest`) | 10 |
 | `AulaControllerTest` | Controller (`@WebMvcTest`) | 9 |
 | `ProfissionalControllerTest` | Controller (`@WebMvcTest`) | 13 |
 | `ActuatorTest` | Integração (`@SpringBootTest`) | 3 |

--- a/docs/context.md
+++ b/docs/context.md
@@ -75,6 +75,7 @@ com.carlesso.pilatesapi
 │   ├── PlanoRequestDTO.java
 │   ├── PlanoResponseDTO.java
 │   ├── PagamentoRequestDTO.java
+│   ├── PagamentoPagarRequestDTO.java — payload opcional para confirmar pagamento
 │   ├── PagamentoResponseDTO.java
 │   └── AulaResponseDTO.java
 └── scheduler
@@ -189,7 +190,7 @@ Constraint: `UNIQUE (paciente_id, data)`
 | POST | `/pagamentos` | Criar pagamento (PENDENTE) | 201 |
 | GET | `/pagamentos/{id}` | Buscar pagamento | 200 / 404 |
 | GET | `/pagamentos/paciente/{id}` | Listar pagamentos | 200 |
-| PATCH | `/pagamentos/{id}/pagar` | Confirmar e gerar aulas | 200 |
+| PATCH | `/pagamentos/{id}/pagar` | Confirmar e gerar aulas; aceita `dataPagamento` opcional no corpo | 200 |
 | GET | `/aulas/{id}` | Buscar aula | 200 / 404 |
 | GET | `/aulas/paciente/{id}` | Listar aulas do paciente | 200 |
 | GET | `/aulas/pagamento/{id}` | Listar aulas do pagamento | 200 |
@@ -227,6 +228,7 @@ CPF não pode ser alterado após o cadastro.
 - Valor não pode ser menor que o valor do plano
 - Sem duplicidade por período (`UNIQUE plano_id + periodo_inicio`)
 - Ao confirmar (`PAGO`), as aulas são geradas automaticamente
+- A confirmação recebe `dataPagamento` no corpo da requisição; se omitida, usa a data atual
 
 ### Aulas
 - Geradas percorrendo dia a dia entre `periodoInicio` e `periodoFim`
@@ -334,7 +336,7 @@ JAVA_HOME=~/jdk mvn spring-boot:run
 | `PacienteControllerTest` | `@WebMvcTest` + MockMvc | 16 |
 | `ProfissionalControllerTest` | `@WebMvcTest` + MockMvc | 13 |
 | `PlanoControllerTest` | `@WebMvcTest` + MockMvc | 11 |
-| `PagamentoControllerTest` | `@WebMvcTest` + MockMvc | 9 |
+| `PagamentoControllerTest` | `@WebMvcTest` + MockMvc | 10 |
 | `AulaControllerTest` | `@WebMvcTest` + MockMvc | 9 |
 | `ActuatorTest` | `@SpringBootTest` + H2 | 3 |
 | `PilatesApiApplicationTests` | `@SpringBootTest` + H2 | 1 |

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -101,6 +101,7 @@ src/
 │   │   │   ├── PlanoRequestDTO.java
 │   │   │   ├── PlanoResponseDTO.java
 │   │   │   ├── PagamentoRequestDTO.java
+│   │   │   ├── PagamentoPagarRequestDTO.java
 │   │   │   ├── PagamentoResponseDTO.java
 │   │   │   └── AulaResponseDTO.java
 │   │   └── scheduler/
@@ -136,7 +137,7 @@ src/
         ├── PacienteControllerTest.java          # 16 casos
         ├── ProfissionalControllerTest.java      # 13 casos
         ├── PlanoControllerTest.java             # 11 casos
-        ├── PagamentoControllerTest.java         # 9 casos
+        ├── PagamentoControllerTest.java         # 10 casos
         └── AulaControllerTest.java              # 9 casos
 ```
 
@@ -554,7 +555,7 @@ Retorna aulas realizadas no período e o total devido ao profissional.
 | `POST` | `/pagamentos` | Criar pagamento (PENDENTE) |
 | `GET` | `/pagamentos/{id}` | Buscar pagamento por ID |
 | `GET` | `/pagamentos/paciente/{id}` | Listar pagamentos do paciente |
-| `PATCH` | `/pagamentos/{id}/pagar` | Confirmar pagamento e gerar aulas |
+| `PATCH` | `/pagamentos/{id}/pagar` | Confirmar pagamento e gerar aulas; aceita `dataPagamento` opcional no corpo |
 | `GET` | `/aulas/{id}` | Buscar aula por ID |
 | `GET` | `/aulas/paciente/{id}` | Listar aulas do paciente |
 | `GET` | `/aulas/pagamento/{id}` | Listar aulas de um pagamento |
@@ -774,7 +775,7 @@ O serviço `app` aguarda o `db` estar saudável (healthcheck via `pg_isready`) a
 
 ### Visão geral
 
-A suíte de testes possui **129 casos** distribuídos em quinze classes:
+A suíte de testes possui **130 casos** distribuídos em quinze classes:
 
 | Classe | Tipo | Casos |
 |---|---|---|
@@ -789,7 +790,7 @@ A suíte de testes possui **129 casos** distribuídos em quinze classes:
 | `PacienteControllerTest` | Controller (`@WebMvcTest`) | 16 |
 | `ProfissionalControllerTest` | Controller (`@WebMvcTest`) | 13 |
 | `PlanoControllerTest` | Controller (`@WebMvcTest`) | 11 |
-| `PagamentoControllerTest` | Controller (`@WebMvcTest`) | 9 |
+| `PagamentoControllerTest` | Controller (`@WebMvcTest`) | 10 |
 | `AulaControllerTest` | Controller (`@WebMvcTest`) | 9 |
 | `ActuatorTest` | Integração (`@SpringBootTest`) | 3 |
 | `PilatesApiApplicationTests` | Integração (`@SpringBootTest` + H2) | 1 |

--- a/src/main/java/com/carlesso/pilatesapi/controller/PagamentoController.java
+++ b/src/main/java/com/carlesso/pilatesapi/controller/PagamentoController.java
@@ -1,5 +1,6 @@
 package com.carlesso.pilatesapi.controller;
 
+import com.carlesso.pilatesapi.dto.PagamentoPagarRequestDTO;
 import com.carlesso.pilatesapi.dto.PagamentoRequestDTO;
 import com.carlesso.pilatesapi.dto.PagamentoResponseDTO;
 import com.carlesso.pilatesapi.service.PagamentoService;
@@ -13,7 +14,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Tag(name = "Pagamentos", description = "Gerenciamento de pagamentos e cobranças")
@@ -62,7 +62,7 @@ public class PagamentoController {
         return ResponseEntity.ok(service.listarPorPaciente(pacienteId));
     }
 
-    @Operation(summary = "Confirmar pagamento", description = "Marca o pagamento como PAGO e gera automaticamente as aulas do período.")
+    @Operation(summary = "Confirmar pagamento", description = "Marca o pagamento como PAGO e gera automaticamente as aulas do período. A data de pagamento pode ser enviada no corpo da requisição.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Pagamento confirmado e aulas geradas"),
             @ApiResponse(responseCode = "404", description = "Pagamento não encontrado"),
@@ -71,7 +71,7 @@ public class PagamentoController {
     @PatchMapping("/{id}/pagar")
     public ResponseEntity<PagamentoResponseDTO> pagar(
             @Parameter(description = "ID do pagamento") @PathVariable Long id,
-            @RequestParam(required = false) LocalDate dataPagamento) {
-        return ResponseEntity.ok(service.pagar(id, dataPagamento));
+            @RequestBody(required = false) PagamentoPagarRequestDTO dto) {
+        return ResponseEntity.ok(service.pagar(id, dto != null ? dto.dataPagamento() : null));
     }
 }

--- a/src/main/java/com/carlesso/pilatesapi/dto/PagamentoPagarRequestDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/PagamentoPagarRequestDTO.java
@@ -1,0 +1,7 @@
+package com.carlesso.pilatesapi.dto;
+
+import java.time.LocalDate;
+
+public record PagamentoPagarRequestDTO(
+        LocalDate dataPagamento
+) {}

--- a/src/test/java/com/carlesso/pilatesapi/controller/PagamentoControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/PagamentoControllerTest.java
@@ -19,6 +19,8 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -128,16 +130,34 @@ class PagamentoControllerTest {
 
     @Test
     void pagar_retorna200ComStatusPago() throws Exception {
-        when(pagamentoService.pagar(eq(1L), any())).thenReturn(pagamentoPago());
+        when(pagamentoService.pagar(eq(1L), isNull())).thenReturn(pagamentoPago());
 
         mockMvc.perform(patch("/pagamentos/1/pagar"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("PAGO"));
+
+        verify(pagamentoService).pagar(1L, null);
+    }
+
+    @Test
+    void pagar_comDataPagamentoNoBody_repassaDataParaService() throws Exception {
+        LocalDate dataPagamento = LocalDate.of(2025, 2, 10);
+        when(pagamentoService.pagar(eq(1L), eq(dataPagamento))).thenReturn(pagamentoPago());
+
+        mockMvc.perform(patch("/pagamentos/1/pagar")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"dataPagamento":"2025-02-10"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("PAGO"));
+
+        verify(pagamentoService).pagar(1L, dataPagamento);
     }
 
     @Test
     void pagar_jaConfirmado_retorna409() throws Exception {
-        when(pagamentoService.pagar(eq(1L), any()))
+        when(pagamentoService.pagar(eq(1L), isNull()))
                 .thenThrow(new IllegalStateException("Pagamento já foi confirmado"));
 
         mockMvc.perform(patch("/pagamentos/1/pagar"))


### PR DESCRIPTION
## Resumo
- Move a leitura de `dataPagamento` do endpoint `PATCH /pagamentos/{id}/pagar` para o corpo da requisição.
- Adiciona `PagamentoPagarRequestDTO` para o payload opcional de confirmação de pagamento.
- Atualiza testes do controller para cobrir confirmação sem body e com `dataPagamento` no JSON.
- Atualiza README, `docs/context.md` e `docs/documentacao.md` com o novo contrato e contagem de testes.

## Testes
- `mvn test` — 130 testes, 0 falhas

Closes #28