### PR TITLE
Perf: marcar leituras de services como read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,18 +499,21 @@ curl -s -X PATCH http://localhost:8080/pagamentos/1/pagar \
 | 06:00 todo dia | Marca como `VENCIDO` pagamentos `PENDENTE` com data de vencimento passada |
 | 07:00 todo dia | Gera cobranças futuras para planos ativos a partir de 7 dias antes do fim do período |
 
+### Boas práticas Spring
+- Métodos de leitura em services usam `@Transactional(readOnly = true)` para reduzir flush desnecessário e preparar a aplicação para roteamento futuro de leituras.
+
 ---
 
 ## Testes
 
-O projeto possui **130 testes** organizados em quinze suítes:
+O projeto possui **132 testes** organizados em quinze suítes:
 
 | Suíte | Tipo | Testes |
 |---|---|---|
 | `PacienteServiceTest` | Unitário (Mockito) | 12 |
-| `PlanoServiceTest` | Unitário (Mockito) | 8 |
+| `PlanoServiceTest` | Unitário (Mockito) | 9 |
 | `PagamentoServiceTest` | Unitário (Mockito) | 8 |
-| `AulaServiceTest` | Unitário (Mockito) | 12 |
+| `AulaServiceTest` | Unitário (Mockito) | 13 |
 | `ProfissionalServiceTest` | Unitário (Mockito) | 13 |
 | `PacienteServiceIntegrationTest` | JPA (`@DataJpaTest`) | 4 |
 | `ProfissionalServiceIntegrationTest` | JPA (`@DataJpaTest`) | 5 |

--- a/docs/context.md
+++ b/docs/context.md
@@ -253,6 +253,7 @@ CPF não pode ser alterado após o cadastro.
 - **Factory method**: `*ResponseDTO.from(Entity)` centraliza o mapeamento entidade → DTO.
 - **Tratamento de 404**: `GlobalExceptionHandler` captura `EntityNotFoundException` e retorna `{"erro": "..."}`.
 - **DDL via Flyway**: `spring.jpa.hibernate.ddl-auto=validate` — o Flyway gerencia o schema; o Hibernate apenas valida.
+- **Transações de leitura**: métodos de consulta nos services usam `@Transactional(readOnly = true)` para evitar flush desnecessário e permitir otimizações de conexão.
 
 ---
 
@@ -327,9 +328,9 @@ JAVA_HOME=~/jdk mvn spring-boot:run
 |---|---|---|
 | `PacienteServiceTest` | Unitário (Mockito, sem Spring) | 12 |
 | `ProfissionalServiceTest` | Unitário (Mockito, sem Spring) | 13 |
-| `PlanoServiceTest` | Unitário (Mockito, sem Spring) | 8 |
+| `PlanoServiceTest` | Unitário (Mockito, sem Spring) | 9 |
 | `PagamentoServiceTest` | Unitário (Mockito, sem Spring) | 8 |
-| `AulaServiceTest` | Unitário (Mockito, sem Spring) | 12 |
+| `AulaServiceTest` | Unitário (Mockito, sem Spring) | 13 |
 | `PacienteServiceIntegrationTest` | `@DataJpaTest` + H2 | 4 |
 | `ProfissionalServiceIntegrationTest` | `@DataJpaTest` + H2 | 5 |
 | `AulaRepositoryTest` | `@DataJpaTest` + H2 | 5 |

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -128,9 +128,9 @@ src/
     │   ├── PacienteServiceIntegrationTest.java  # 4 casos
     │   ├── ProfissionalServiceIntegrationTest.java # 5 casos
     │   ├── ProfissionalServiceTest.java         # 13 casos
-    │   ├── PlanoServiceTest.java                # 8 casos
+    │   ├── PlanoServiceTest.java                # 9 casos
     │   ├── PagamentoServiceTest.java            # 8 casos
-    │   └── AulaServiceTest.java                 # 12 casos
+    │   └── AulaServiceTest.java                 # 13 casos
     ├── repository/
     │   └── AulaRepositoryTest.java              # 5 casos
     └── controller/
@@ -191,6 +191,7 @@ src/
 - Não gera aulas duplicadas: se o paciente já tiver aula naquela data, ela é ignorada
 - Requer: paciente ativo + pagamento com status `PAGO`
 - Consultas por ID, paciente, pagamento e relatório filtram `paciente.ativo = true`
+- Métodos de leitura nos services usam `@Transactional(readOnly = true)` para reduzir flush desnecessário e permitir otimizações de conexão.
 
 ### 4.7 Processos Automáticos (Scheduler)
 
@@ -775,15 +776,15 @@ O serviço `app` aguarda o `db` estar saudável (healthcheck via `pg_isready`) a
 
 ### Visão geral
 
-A suíte de testes possui **130 casos** distribuídos em quinze classes:
+A suíte de testes possui **132 casos** distribuídos em quinze classes:
 
 | Classe | Tipo | Casos |
 |---|---|---|
 | `PacienteServiceTest` | Unitário (Mockito) | 12 |
 | `ProfissionalServiceTest` | Unitário (Mockito) | 13 |
-| `PlanoServiceTest` | Unitário (Mockito) | 8 |
+| `PlanoServiceTest` | Unitário (Mockito) | 9 |
 | `PagamentoServiceTest` | Unitário (Mockito) | 8 |
-| `AulaServiceTest` | Unitário (Mockito) | 12 |
+| `AulaServiceTest` | Unitário (Mockito) | 13 |
 | `PacienteServiceIntegrationTest` | JPA (`@DataJpaTest`) | 4 |
 | `ProfissionalServiceIntegrationTest` | JPA (`@DataJpaTest`) | 5 |
 | `AulaRepositoryTest` | JPA (`@DataJpaTest`) | 5 |

--- a/src/main/java/com/carlesso/pilatesapi/service/AulaService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/AulaService.java
@@ -57,6 +57,7 @@ public class AulaService {
         return aulaRepository.saveAll(aulas);
     }
 
+    @Transactional(readOnly = true)
     public List<AulaResponseDTO> buscarPorPaciente(Long pacienteId) {
         return aulaRepository.findByPacienteIdOrderByData(pacienteId)
                 .stream()
@@ -64,6 +65,7 @@ public class AulaService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public List<AulaResponseDTO> buscarPorPagamento(Long pagamentoId) {
         return aulaRepository.findByPagamentoIdOrderByData(pagamentoId)
                 .stream()
@@ -71,6 +73,7 @@ public class AulaService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
     public AulaResponseDTO buscarPorId(Long id) {
         return AulaResponseDTO.from(encontrar(id));
     }

--- a/src/main/java/com/carlesso/pilatesapi/service/PlanoService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/PlanoService.java
@@ -62,15 +62,18 @@ public class PlanoService {
         return PlanoResponseDTO.from(planoRepository.save(plano));
     }
 
+    @Transactional(readOnly = true)
     public PlanoResponseDTO buscarPorId(Long id) {
         return PlanoResponseDTO.from(encontrar(id));
     }
 
+    @Transactional(readOnly = true)
     public Optional<PlanoResponseDTO> buscarAtivoPorPaciente(Long pacienteId) {
         return planoRepository.findByPacienteIdAndAtivoTrue(pacienteId)
                 .map(PlanoResponseDTO::from);
     }
 
+    @Transactional(readOnly = true)
     public List<PlanoResponseDTO> listarPorPaciente(Long pacienteId) {
         return planoRepository.findByPacienteId(pacienteId)
                 .stream()

--- a/src/test/java/com/carlesso/pilatesapi/service/AulaServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/AulaServiceTest.java
@@ -18,7 +18,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -66,6 +68,13 @@ class AulaServiceTest {
         pagamentoPago.setPeriodoInicio(LocalDate.of(2025, 2, 1));
         pagamentoPago.setPeriodoFim(LocalDate.of(2025, 2, 28));
         pagamentoPago.setDataVencimento(LocalDate.of(2025, 2, 10));
+    }
+
+    @Test
+    void metodosDeLeitura_saoTransacionaisReadOnly() throws Exception {
+        assertReadOnly("buscarPorId", Long.class);
+        assertReadOnly("buscarPorPaciente", Long.class);
+        assertReadOnly("buscarPorPagamento", Long.class);
     }
 
     @Test
@@ -225,5 +234,13 @@ class AulaServiceTest {
         assertThatThrownBy(() -> service.buscarPorId(1L))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessageContaining("Aula não encontrada: 1");
+    }
+
+    private void assertReadOnly(String methodName, Class<?>... parameterTypes) throws Exception {
+        Method method = AulaService.class.getMethod(methodName, parameterTypes);
+        Transactional transactional = method.getAnnotation(Transactional.class);
+
+        assertThat(transactional).isNotNull();
+        assertThat(transactional.readOnly()).isTrue();
     }
 }

--- a/src/test/java/com/carlesso/pilatesapi/service/PlanoServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/PlanoServiceTest.java
@@ -15,7 +15,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -49,6 +51,13 @@ class PlanoServiceTest {
         pacienteInativo.setEmail("inativo@email.com");
         pacienteInativo.setCpf("999.888.777-66");
         pacienteInativo.setAtivo(false);
+    }
+
+    @Test
+    void metodosDeLeitura_saoTransacionaisReadOnly() throws Exception {
+        assertReadOnly("buscarPorId", Long.class);
+        assertReadOnly("buscarAtivoPorPaciente", Long.class);
+        assertReadOnly("listarPorPaciente", Long.class);
     }
 
     @Test
@@ -188,5 +197,13 @@ class PlanoServiceTest {
         assertThatThrownBy(() -> service.inativar(1L))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("já está inativo");
+    }
+
+    private void assertReadOnly(String methodName, Class<?>... parameterTypes) throws Exception {
+        Method method = PlanoService.class.getMethod(methodName, parameterTypes);
+        Transactional transactional = method.getAnnotation(Transactional.class);
+
+        assertThat(transactional).isNotNull();
+        assertThat(transactional.readOnly()).isTrue();
     }
 }


### PR DESCRIPTION
## Resumo
- Adiciona `@Transactional(readOnly = true)` nos métodos de leitura de `AulaService` e `PlanoService` listados na issue.
- Adiciona testes de contrato para garantir que esses métodos permaneçam transacionais read-only.
- Atualiza README, `docs/context.md` e `docs/documentacao.md` com a prática e a nova contagem de testes.

## Testes
- `mvn test` — 132 testes, 0 falhas

Closes #18