### PR TITLE
refactor: padroniza tratamento de exceções com exceções customizadas

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,12 @@ src/
 ├── main/
 │   ├── java/com/carlesso/pilatesapi/
 │   │   ├── config/
-│   │   │   ├── GlobalExceptionHandler.java  # Handler 404 para EntityNotFoundException
+│   │   │   ├── GlobalExceptionHandler.java  # Mapeia exceções customizadas para HTTP (404/409/422)
 │   │   │   └── OpenApiConfig.java           # Configuração do Swagger/OpenAPI
+│   │   ├── exception/
+│   │   │   ├── ResourceNotFoundException.java  # 404 — recurso não encontrado
+│   │   │   ├── ConflictException.java          # 409 — conflito de estado/duplicidade
+│   │   │   └── BusinessException.java          # 422 — violação de regra de negócio
 │   │   ├── controller/
 │   │   │   ├── PacienteController.java      # Endpoints REST de pacientes
 │   │   │   ├── ProfissionalController.java  # Endpoints REST de profissionais
@@ -502,27 +506,46 @@ curl -s -X PATCH http://localhost:8080/pagamentos/1/pagar \
 ### Boas práticas Spring
 - Métodos de leitura em services usam `@Transactional(readOnly = true)` para reduzir flush desnecessário e preparar a aplicação para roteamento futuro de leituras.
 
+### Tratamento de erros
+
+A API utiliza exceções customizadas mapeadas pelo `GlobalExceptionHandler` para retornar o status HTTP semanticamente correto:
+
+| Exceção | HTTP | Quando é lançada |
+|---|---|---|
+| `ResourceNotFoundException` | `404 Not Found` | Recurso solicitado não existe (ex.: paciente, plano, pagamento ou aula não encontrada) |
+| `ConflictException` | `409 Conflict` | Conflito de estado ou duplicidade (ex.: e-mail/CPF já cadastrado, pagamento já confirmado, aula já realizada) |
+| `BusinessException` | `422 Unprocessable Entity` | Regra de negócio violada (ex.: paciente inativo não pode receber cobrança, profissional inativo não pode ser vinculado a aula) |
+| `IllegalArgumentException` | `400 Bad Request` | Parâmetros de entrada inválidos (ex.: período inicial maior que o final, valor menor que o do plano) |
+| `DataIntegrityViolationException` | `409 Conflict` | Violação de constraint do banco (ex.: registro duplicado ao salvar) |
+
+Formato da resposta de erro:
+
+```json
+{ "erro": "Mensagem descritiva do problema" }
+```
+
 ---
 
 ## Testes
 
-O projeto possui **132 testes** organizados em quinze suítes:
+O projeto possui **142 testes** organizados em dezesseis suítes:
 
 | Suíte | Tipo | Testes |
 |---|---|---|
 | `PacienteServiceTest` | Unitário (Mockito) | 12 |
 | `PlanoServiceTest` | Unitário (Mockito) | 9 |
 | `PagamentoServiceTest` | Unitário (Mockito) | 8 |
-| `AulaServiceTest` | Unitário (Mockito) | 13 |
+| `AulaServiceTest` | Unitário (Mockito) | 14 |
 | `ProfissionalServiceTest` | Unitário (Mockito) | 13 |
 | `PacienteServiceIntegrationTest` | JPA (`@DataJpaTest`) | 4 |
 | `ProfissionalServiceIntegrationTest` | JPA (`@DataJpaTest`) | 5 |
 | `AulaRepositoryTest` | JPA (`@DataJpaTest`) | 5 |
 | `PacienteControllerTest` | Controller (`@WebMvcTest`) | 16 |
 | `PlanoControllerTest` | Controller (`@WebMvcTest`) | 11 |
-| `PagamentoControllerTest` | Controller (`@WebMvcTest`) | 10 |
-| `AulaControllerTest` | Controller (`@WebMvcTest`) | 9 |
-| `ProfissionalControllerTest` | Controller (`@WebMvcTest`) | 13 |
+| `PagamentoControllerTest` | Controller (`@WebMvcTest`) | 11 |
+| `AulaControllerTest` | Controller (`@WebMvcTest`) | 10 |
+| `ProfissionalControllerTest` | Controller (`@WebMvcTest`) | 14 |
+| `GlobalExceptionHandlerTest` | Unitário | 6 |
 | `ActuatorTest` | Integração (`@SpringBootTest`) | 3 |
 | `PilatesApiApplicationTests` | Integração (`@SpringBootTest`) | 1 |
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -30,8 +30,12 @@ API REST para gerenciar pacientes e profissionais de um estúdio de pilates. Per
 ```
 com.carlesso.pilatesapi
 ├── config
-│   ├── GlobalExceptionHandler.java   — captura EntityNotFoundException → 404
+│   ├── GlobalExceptionHandler.java   — mapeia exceções customizadas para HTTP (404/409/422)
 │   └── OpenApiConfig.java            — configuração do Swagger/OpenAPI
+├── exception
+│   ├── ResourceNotFoundException.java — 404 (recurso não encontrado)
+│   ├── ConflictException.java         — 409 (conflito de estado/duplicidade)
+│   └── BusinessException.java         — 422 (violação de regra de negócio)
 ├── controller
 │   ├── PacienteController.java       — endpoints REST de pacientes
 │   ├── ProfissionalController.java   — endpoints REST de profissionais
@@ -251,7 +255,7 @@ CPF não pode ser alterado após o cadastro.
 - **Atualização parcial via PUT**: DTOs de update têm todos os campos opcionais; o service só sobrescreve os campos não-nulos.
 - **DTOs como records**: todos os DTOs de request e response são Java records.
 - **Factory method**: `*ResponseDTO.from(Entity)` centraliza o mapeamento entidade → DTO.
-- **Tratamento de 404**: `GlobalExceptionHandler` captura `EntityNotFoundException` e retorna `{"erro": "..."}`.
+- **Tratamento de erros**: `GlobalExceptionHandler` mapeia exceções customizadas (`ResourceNotFoundException` → 404, `ConflictException` → 409, `BusinessException` → 422) e retorna `{"erro": "..."}`. `IllegalArgumentException` segue como 400 e `DataIntegrityViolationException` como 409.
 - **DDL via Flyway**: `spring.jpa.hibernate.ddl-auto=validate` — o Flyway gerencia o schema; o Hibernate apenas valida.
 - **Transações de leitura**: métodos de consulta nos services usam `@Transactional(readOnly = true)` para evitar flush desnecessário e permitir otimizações de conexão.
 
@@ -330,15 +334,16 @@ JAVA_HOME=~/jdk mvn spring-boot:run
 | `ProfissionalServiceTest` | Unitário (Mockito, sem Spring) | 13 |
 | `PlanoServiceTest` | Unitário (Mockito, sem Spring) | 9 |
 | `PagamentoServiceTest` | Unitário (Mockito, sem Spring) | 8 |
-| `AulaServiceTest` | Unitário (Mockito, sem Spring) | 13 |
+| `AulaServiceTest` | Unitário (Mockito, sem Spring) | 14 |
 | `PacienteServiceIntegrationTest` | `@DataJpaTest` + H2 | 4 |
 | `ProfissionalServiceIntegrationTest` | `@DataJpaTest` + H2 | 5 |
 | `AulaRepositoryTest` | `@DataJpaTest` + H2 | 5 |
 | `PacienteControllerTest` | `@WebMvcTest` + MockMvc | 16 |
-| `ProfissionalControllerTest` | `@WebMvcTest` + MockMvc | 13 |
+| `ProfissionalControllerTest` | `@WebMvcTest` + MockMvc | 14 |
 | `PlanoControllerTest` | `@WebMvcTest` + MockMvc | 11 |
-| `PagamentoControllerTest` | `@WebMvcTest` + MockMvc | 10 |
-| `AulaControllerTest` | `@WebMvcTest` + MockMvc | 9 |
+| `PagamentoControllerTest` | `@WebMvcTest` + MockMvc | 11 |
+| `AulaControllerTest` | `@WebMvcTest` + MockMvc | 10 |
+| `GlobalExceptionHandlerTest` | Unitário | 6 |
 | `ActuatorTest` | `@SpringBootTest` + H2 | 3 |
 | `PilatesApiApplicationTests` | `@SpringBootTest` + H2 | 1 |
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -186,19 +186,19 @@ Constraint: `UNIQUE (paciente_id, data)`
 | PATCH | `/profissionais/{id}/ativar` | Reativar profissional | 204 / 404 |
 | PATCH | `/profissionais/{id}/inativar` | Soft delete (inativar) | 204 / 404 |
 | GET | `/profissionais/{id}/relatorio-pagamento?inicio=YYYY-MM-DD&fim=YYYY-MM-DD` | Gerar relatório de pagamento do profissional | 200 / 400 / 404 |
-| POST | `/planos` | Criar plano para paciente | 201 |
+| POST | `/planos` | Criar plano para paciente | 201 / 400 / 404 / 422 |
 | GET | `/planos/{id}` | Buscar plano por ID | 200 / 404 |
 | GET | `/planos/paciente/{id}` | Listar planos do paciente | 200 |
-| GET | `/planos/paciente/{id}/ativo` | Buscar plano ativo | 200 / 404 |
-| DELETE | `/planos/{id}` | Inativar plano | 204 |
-| POST | `/pagamentos` | Criar pagamento (PENDENTE) | 201 |
+| GET | `/planos/paciente/{id}/ativo` | Buscar plano ativo | 200 / 204 |
+| DELETE | `/planos/{id}` | Inativar plano | 204 / 404 / 409 |
+| POST | `/pagamentos` | Criar pagamento (PENDENTE) | 201 / 400 / 404 / 409 / 422 |
 | GET | `/pagamentos/{id}` | Buscar pagamento | 200 / 404 |
 | GET | `/pagamentos/paciente/{id}` | Listar pagamentos | 200 |
-| PATCH | `/pagamentos/{id}/pagar` | Confirmar e gerar aulas; aceita `dataPagamento` opcional no corpo | 200 |
+| PATCH | `/pagamentos/{id}/pagar` | Confirmar e gerar aulas; aceita `dataPagamento` opcional no corpo | 200 / 404 / 409 / 422 |
 | GET | `/aulas/{id}` | Buscar aula | 200 / 404 |
 | GET | `/aulas/paciente/{id}` | Listar aulas do paciente | 200 |
 | GET | `/aulas/pagamento/{id}` | Listar aulas do pagamento | 200 |
-| PATCH | `/aulas/{id}/realizar?profissionalId={id}` | Marcar como realizada e opcionalmente vincular profissional | 200 / 404 |
+| PATCH | `/aulas/{id}/realizar?profissionalId={id}` | Marcar como realizada e opcionalmente vincular profissional | 200 / 404 / 409 / 422 |
 
 Campos obrigatórios no cadastro de pacientes: `nome`, `email`, `cpf`.  
 Campos obrigatórios no cadastro de profissionais: `nome`, `email`, `cpf`, `tipoContrato`, `percentualPagamentoAula`, `dataInicio`.  

--- a/src/main/java/com/carlesso/pilatesapi/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/carlesso/pilatesapi/config/GlobalExceptionHandler.java
@@ -1,5 +1,8 @@
 package com.carlesso.pilatesapi.config;
 
+import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.exception.ConflictException;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
@@ -12,9 +15,9 @@ import java.util.Map;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(EntityNotFoundException.class)
+    @ExceptionHandler({ResourceNotFoundException.class, EntityNotFoundException.class})
     @ResponseStatus(HttpStatus.NOT_FOUND)
-    public Map<String, String> handleNotFound(EntityNotFoundException e) {
+    public Map<String, String> handleNotFound(RuntimeException e) {
         return Map.of("erro", e.getMessage());
     }
 
@@ -24,9 +27,15 @@ public class GlobalExceptionHandler {
         return Map.of("erro", e.getMessage());
     }
 
-    @ExceptionHandler(IllegalStateException.class)
+    @ExceptionHandler(ConflictException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
-    public Map<String, String> handleConflict(IllegalStateException e) {
+    public Map<String, String> handleConflict(ConflictException e) {
+        return Map.of("erro", e.getMessage());
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    public Map<String, String> handleBusiness(BusinessException e) {
         return Map.of("erro", e.getMessage());
     }
 

--- a/src/main/java/com/carlesso/pilatesapi/controller/AulaController.java
+++ b/src/main/java/com/carlesso/pilatesapi/controller/AulaController.java
@@ -53,8 +53,9 @@ public class AulaController {
     @Operation(summary = "Marcar aula como realizada")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Aula marcada como realizada"),
-            @ApiResponse(responseCode = "404", description = "Aula não encontrada"),
-            @ApiResponse(responseCode = "409", description = "Aula já marcada como realizada")
+            @ApiResponse(responseCode = "404", description = "Aula ou profissional não encontrado"),
+            @ApiResponse(responseCode = "409", description = "Aula já marcada como realizada"),
+            @ApiResponse(responseCode = "422", description = "Profissional inativo")
     })
     @PatchMapping("/{id}/realizar")
     public ResponseEntity<AulaResponseDTO> realizar(

--- a/src/main/java/com/carlesso/pilatesapi/controller/PagamentoController.java
+++ b/src/main/java/com/carlesso/pilatesapi/controller/PagamentoController.java
@@ -32,7 +32,8 @@ public class PagamentoController {
             @ApiResponse(responseCode = "201", description = "Pagamento criado com sucesso"),
             @ApiResponse(responseCode = "400", description = "Dados inválidos ou valor abaixo do plano"),
             @ApiResponse(responseCode = "404", description = "Paciente ou plano não encontrado"),
-            @ApiResponse(responseCode = "409", description = "Paciente inativo ou pagamento duplicado para o período")
+            @ApiResponse(responseCode = "409", description = "Pagamento duplicado para o período"),
+            @ApiResponse(responseCode = "422", description = "Paciente inativo")
     })
     @PostMapping
     public ResponseEntity<PagamentoResponseDTO> criar(
@@ -66,7 +67,8 @@ public class PagamentoController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Pagamento confirmado e aulas geradas"),
             @ApiResponse(responseCode = "404", description = "Pagamento não encontrado"),
-            @ApiResponse(responseCode = "409", description = "Pagamento já confirmado")
+            @ApiResponse(responseCode = "409", description = "Pagamento já confirmado"),
+            @ApiResponse(responseCode = "422", description = "Pagamento não está PAGO ou paciente está inativo")
     })
     @PatchMapping("/{id}/pagar")
     public ResponseEntity<PagamentoResponseDTO> pagar(

--- a/src/main/java/com/carlesso/pilatesapi/controller/PlanoController.java
+++ b/src/main/java/com/carlesso/pilatesapi/controller/PlanoController.java
@@ -34,7 +34,7 @@ public class PlanoController {
             @ApiResponse(responseCode = "201", description = "Plano criado com sucesso"),
             @ApiResponse(responseCode = "400", description = "Dados inválidos ou frequência incompatível com os dias informados"),
             @ApiResponse(responseCode = "404", description = "Paciente não encontrado"),
-            @ApiResponse(responseCode = "409", description = "Paciente inativo")
+            @ApiResponse(responseCode = "422", description = "Paciente inativo")
     })
     @PostMapping
     public ResponseEntity<PlanoResponseDTO> criar(

--- a/src/main/java/com/carlesso/pilatesapi/exception/BusinessException.java
+++ b/src/main/java/com/carlesso/pilatesapi/exception/BusinessException.java
@@ -1,0 +1,8 @@
+package com.carlesso.pilatesapi.exception;
+
+public class BusinessException extends RuntimeException {
+
+    public BusinessException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/exception/ConflictException.java
+++ b/src/main/java/com/carlesso/pilatesapi/exception/ConflictException.java
@@ -1,0 +1,8 @@
+package com.carlesso.pilatesapi.exception;
+
+public class ConflictException extends RuntimeException {
+
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/carlesso/pilatesapi/exception/ResourceNotFoundException.java
@@ -1,0 +1,8 @@
+package com.carlesso.pilatesapi.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/service/AulaService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/AulaService.java
@@ -5,9 +5,11 @@ import com.carlesso.pilatesapi.entity.Aula;
 import com.carlesso.pilatesapi.entity.Pagamento;
 import com.carlesso.pilatesapi.entity.Profissional;
 import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
+import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.exception.ConflictException;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.repository.AulaRepository;
 import com.carlesso.pilatesapi.repository.ProfissionalRepository;
-import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,10 +31,10 @@ public class AulaService {
     @Transactional
     public List<Aula> gerarAulas(Pagamento pagamento) {
         if (pagamento.getStatus() != StatusPagamento.PAGO) {
-            throw new IllegalStateException("Aulas só podem ser geradas para pagamentos com status PAGO");
+            throw new BusinessException("Aulas só podem ser geradas para pagamentos com status PAGO");
         }
         if (!pagamento.getPaciente().isAtivo()) {
-            throw new IllegalStateException("Paciente inativo não pode ter aulas geradas");
+            throw new BusinessException("Paciente inativo não pode ter aulas geradas");
         }
 
         var diasSemana = pagamento.getPlano().getDiasSemana();
@@ -87,13 +89,13 @@ public class AulaService {
     public AulaResponseDTO realizarAula(Long id, Long profissionalId) {
         Aula aula = encontrar(id);
         if (aula.isRealizada()) {
-            throw new IllegalStateException("Aula já foi marcada como realizada");
+            throw new ConflictException("Aula já foi marcada como realizada");
         }
         if (profissionalId != null) {
             Profissional profissional = profissionalRepository.findById(profissionalId)
-                    .orElseThrow(() -> new EntityNotFoundException("Profissional não encontrado: " + profissionalId));
+                    .orElseThrow(() -> new ResourceNotFoundException("Profissional não encontrado: " + profissionalId));
             if (!profissional.isAtivo()) {
-                throw new IllegalStateException("Profissional inativo não pode ser vinculado à aula");
+                throw new BusinessException("Profissional inativo não pode ser vinculado à aula");
             }
             aula.setProfissional(profissional);
         }
@@ -103,6 +105,6 @@ public class AulaService {
 
     private Aula encontrar(Long id) {
         return aulaRepository.findByIdAndPacienteAtivoTrue(id)
-                .orElseThrow(() -> new EntityNotFoundException("Aula não encontrada: " + id));
+                .orElseThrow(() -> new ResourceNotFoundException("Aula não encontrada: " + id));
     }
 }

--- a/src/main/java/com/carlesso/pilatesapi/service/PacienteService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/PacienteService.java
@@ -5,8 +5,8 @@ import com.carlesso.pilatesapi.dto.PacienteResponseDTO;
 import com.carlesso.pilatesapi.dto.PacienteUpdateDTO;
 import com.carlesso.pilatesapi.entity.Endereco;
 import com.carlesso.pilatesapi.entity.Paciente;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.repository.PacienteRepository;
-import jakarta.persistence.EntityNotFoundException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -95,7 +95,7 @@ public class PacienteService {
 
     private Paciente encontrar(Long id) {
         return repository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("Paciente não encontrado: " + id));
+                .orElseThrow(() -> new ResourceNotFoundException("Paciente não encontrado: " + id));
     }
 
     private Specification<Paciente> filtros(String nome, String email, String cpf, String telefone, Boolean ativo) {

--- a/src/main/java/com/carlesso/pilatesapi/service/PagamentoService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/PagamentoService.java
@@ -6,10 +6,12 @@ import com.carlesso.pilatesapi.entity.Paciente;
 import com.carlesso.pilatesapi.entity.Pagamento;
 import com.carlesso.pilatesapi.entity.Plano;
 import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
+import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.exception.ConflictException;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.repository.PacienteRepository;
 import com.carlesso.pilatesapi.repository.PagamentoRepository;
 import com.carlesso.pilatesapi.repository.PlanoRepository;
-import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,14 +39,14 @@ public class PagamentoService {
     @Transactional
     public PagamentoResponseDTO criar(PagamentoRequestDTO dto) {
         Paciente paciente = pacienteRepository.findById(dto.pacienteId())
-                .orElseThrow(() -> new EntityNotFoundException("Paciente não encontrado: " + dto.pacienteId()));
+                .orElseThrow(() -> new ResourceNotFoundException("Paciente não encontrado: " + dto.pacienteId()));
 
         if (!paciente.isAtivo()) {
-            throw new IllegalStateException("Paciente inativo não pode receber novas cobranças");
+            throw new BusinessException("Paciente inativo não pode receber novas cobranças");
         }
 
         Plano plano = planoRepository.findById(dto.planoId())
-                .orElseThrow(() -> new EntityNotFoundException("Plano não encontrado: " + dto.planoId()));
+                .orElseThrow(() -> new ResourceNotFoundException("Plano não encontrado: " + dto.planoId()));
 
         if (dto.valor().compareTo(plano.getValor()) < 0) {
             throw new IllegalArgumentException(
@@ -56,7 +58,7 @@ public class PagamentoService {
         LocalDate periodoFim = dto.periodoInicio().plusMonths(plano.getTipo().getMeses()).minusDays(1);
 
         if (pagamentoRepository.existsByPlanoAndPeriodoInicio(plano, dto.periodoInicio())) {
-            throw new IllegalStateException(
+            throw new ConflictException(
                     "Já existe um pagamento para este plano no período iniciado em " + dto.periodoInicio()
             );
         }
@@ -77,7 +79,7 @@ public class PagamentoService {
         Pagamento pagamento = encontrar(id);
 
         if (pagamento.getStatus() == StatusPagamento.PAGO) {
-            throw new IllegalStateException("Pagamento já foi confirmado");
+            throw new ConflictException("Pagamento já foi confirmado");
         }
 
         pagamento.setStatus(StatusPagamento.PAGO);
@@ -147,6 +149,6 @@ public class PagamentoService {
 
     private Pagamento encontrar(Long id) {
         return pagamentoRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("Pagamento não encontrado: " + id));
+                .orElseThrow(() -> new ResourceNotFoundException("Pagamento não encontrado: " + id));
     }
 }

--- a/src/main/java/com/carlesso/pilatesapi/service/PlanoService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/PlanoService.java
@@ -4,9 +4,11 @@ import com.carlesso.pilatesapi.dto.PlanoRequestDTO;
 import com.carlesso.pilatesapi.dto.PlanoResponseDTO;
 import com.carlesso.pilatesapi.entity.Paciente;
 import com.carlesso.pilatesapi.entity.Plano;
+import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.exception.ConflictException;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.repository.PacienteRepository;
 import com.carlesso.pilatesapi.repository.PlanoRepository;
-import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,10 +30,10 @@ public class PlanoService {
     @Transactional
     public PlanoResponseDTO criar(PlanoRequestDTO dto) {
         Paciente paciente = pacienteRepository.findById(dto.pacienteId())
-                .orElseThrow(() -> new EntityNotFoundException("Paciente não encontrado: " + dto.pacienteId()));
+                .orElseThrow(() -> new ResourceNotFoundException("Paciente não encontrado: " + dto.pacienteId()));
 
         if (!paciente.isAtivo()) {
-            throw new IllegalStateException("Paciente inativo não pode receber novo plano");
+            throw new BusinessException("Paciente inativo não pode receber novo plano");
         }
 
         if (dto.diasSemana().size() != dto.frequenciaSemanal().getVezesPorSemana()) {
@@ -85,13 +87,13 @@ public class PlanoService {
     public void inativar(Long id) {
         Plano plano = encontrar(id);
         if (!plano.isAtivo()) {
-            throw new IllegalStateException("Plano já está inativo");
+            throw new ConflictException("Plano já está inativo");
         }
         plano.setAtivo(false);
     }
 
     private Plano encontrar(Long id) {
         return planoRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("Plano não encontrado: " + id));
+                .orElseThrow(() -> new ResourceNotFoundException("Plano não encontrado: " + id));
     }
 }

--- a/src/main/java/com/carlesso/pilatesapi/service/ProfissionalService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/ProfissionalService.java
@@ -8,9 +8,11 @@ import com.carlesso.pilatesapi.dto.ProfissionalUpdateDTO;
 import com.carlesso.pilatesapi.entity.Aula;
 import com.carlesso.pilatesapi.entity.Profissional;
 import com.carlesso.pilatesapi.entity.enums.TipoContrato;
+import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.exception.ConflictException;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.repository.AulaRepository;
 import com.carlesso.pilatesapi.repository.ProfissionalRepository;
-import jakarta.persistence.EntityNotFoundException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -39,10 +41,10 @@ public class ProfissionalService {
     @Transactional
     public ProfissionalResponseDTO cadastrar(ProfissionalRequestDTO dto) {
         if (repository.existsByEmail(dto.email())) {
-            throw new IllegalStateException("E-mail já cadastrado: " + dto.email());
+            throw new ConflictException("E-mail já cadastrado: " + dto.email());
         }
         if (repository.existsByCpf(dto.cpf())) {
-            throw new IllegalStateException("CPF já cadastrado: " + dto.cpf());
+            throw new ConflictException("CPF já cadastrado: " + dto.cpf());
         }
         Profissional profissional = new Profissional();
         profissional.setNome(dto.nome());
@@ -138,13 +140,13 @@ public class ProfissionalService {
 
     private Profissional encontrar(Long id) {
         return repository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("Profissional não encontrado: " + id));
+                .orElseThrow(() -> new ResourceNotFoundException("Profissional não encontrado: " + id));
     }
 
     private ProfissionalPagamentoAulaDTO mapearAulaPagamento(Aula aula, BigDecimal percentualPagamentoAula, Map<Long, Long> contsPorPagamento) {
         long quantidadeAulasPagamento = contsPorPagamento.getOrDefault(aula.getPagamento().getId(), 0L);
         if (quantidadeAulasPagamento == 0) {
-            throw new IllegalStateException("Pagamento sem aulas geradas: " + aula.getPagamento().getId());
+            throw new BusinessException("Pagamento sem aulas geradas: " + aula.getPagamento().getId());
         }
 
         BigDecimal valorBaseAula = aula.getPagamento().getValor()

--- a/src/test/java/com/carlesso/pilatesapi/config/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/config/GlobalExceptionHandlerTest.java
@@ -1,0 +1,66 @@
+package com.carlesso.pilatesapi.config;
+
+import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.exception.ConflictException;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    void handleNotFound_resourceNotFound_retornaMensagemDoErro() {
+        Map<String, String> response = handler.handleNotFound(
+                new ResourceNotFoundException("Paciente não encontrado: 1"));
+
+        assertThat(response).containsEntry("erro", "Paciente não encontrado: 1");
+    }
+
+    @Test
+    void handleNotFound_entityNotFound_retornaMensagemDoErro() {
+        Map<String, String> response = handler.handleNotFound(
+                new EntityNotFoundException("Profissional não encontrado: 1"));
+
+        assertThat(response).containsEntry("erro", "Profissional não encontrado: 1");
+    }
+
+    @Test
+    void handleConflict_retornaMensagemDoErro() {
+        Map<String, String> response = handler.handleConflict(
+                new ConflictException("E-mail já cadastrado"));
+
+        assertThat(response).containsEntry("erro", "E-mail já cadastrado");
+    }
+
+    @Test
+    void handleBusiness_retornaMensagemDoErro() {
+        Map<String, String> response = handler.handleBusiness(
+                new BusinessException("Paciente inativo não pode receber novas cobranças"));
+
+        assertThat(response).containsEntry("erro", "Paciente inativo não pode receber novas cobranças");
+    }
+
+    @Test
+    void handleBadRequest_retornaMensagemDoErro() {
+        Map<String, String> response = handler.handleBadRequest(
+                new IllegalArgumentException("Período inicial é obrigatório"));
+
+        assertThat(response).containsEntry("erro", "Período inicial é obrigatório");
+    }
+
+    @Test
+    void handleDataIntegrity_retornaMensagemPadrao() {
+        Map<String, String> response = handler.handleDataIntegrity(
+                new DataIntegrityViolationException("violação"));
+
+        assertThat(response).containsEntry("erro",
+                "Violação de integridade: registro duplicado ou constraint violada");
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/controller/AulaControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/AulaControllerTest.java
@@ -1,8 +1,10 @@
 package com.carlesso.pilatesapi.controller;
 
 import com.carlesso.pilatesapi.dto.AulaResponseDTO;
+import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.exception.ConflictException;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.service.AulaService;
-import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -41,7 +43,7 @@ class AulaControllerTest {
     @Test
     void buscar_naoEncontrada_retorna404() throws Exception {
         when(aulaService.buscarPorId(99L))
-                .thenThrow(new EntityNotFoundException("Aula não encontrada: 99"));
+                .thenThrow(new ResourceNotFoundException("Aula não encontrada: 99"));
 
         mockMvc.perform(get("/aulas/99"))
                 .andExpect(status().isNotFound())
@@ -87,7 +89,7 @@ class AulaControllerTest {
     @Test
     void realizar_comProfissionalInexistente_retorna404() throws Exception {
         when(aulaService.realizarAula(eq(1L), eq(99L)))
-                .thenThrow(new EntityNotFoundException("Profissional não encontrado: 99"));
+                .thenThrow(new ResourceNotFoundException("Profissional não encontrado: 99"));
 
         mockMvc.perform(patch("/aulas/1/realizar").param("profissionalId", "99"))
                 .andExpect(status().isNotFound());
@@ -96,7 +98,7 @@ class AulaControllerTest {
     @Test
     void realizar_aaulaJaRealizada_retorna409() throws Exception {
         when(aulaService.realizarAula(eq(1L), isNull()))
-                .thenThrow(new IllegalStateException("Aula já foi marcada como realizada"));
+                .thenThrow(new ConflictException("Aula já foi marcada como realizada"));
 
         mockMvc.perform(patch("/aulas/1/realizar"))
                 .andExpect(status().isConflict())
@@ -104,9 +106,19 @@ class AulaControllerTest {
     }
 
     @Test
+    void realizar_profissionalInativo_retorna422() throws Exception {
+        when(aulaService.realizarAula(eq(1L), eq(2L)))
+                .thenThrow(new BusinessException("Profissional inativo não pode ser vinculado à aula"));
+
+        mockMvc.perform(patch("/aulas/1/realizar").param("profissionalId", "2"))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.erro").exists());
+    }
+
+    @Test
     void realizar_naoEncontrada_retorna404() throws Exception {
         when(aulaService.realizarAula(eq(99L), isNull()))
-                .thenThrow(new EntityNotFoundException("Aula não encontrada: 99"));
+                .thenThrow(new ResourceNotFoundException("Aula não encontrada: 99"));
 
         mockMvc.perform(patch("/aulas/99/realizar"))
                 .andExpect(status().isNotFound());

--- a/src/test/java/com/carlesso/pilatesapi/controller/PacienteControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/PacienteControllerTest.java
@@ -4,9 +4,9 @@ import com.carlesso.pilatesapi.dto.EnderecoDTO;
 import com.carlesso.pilatesapi.dto.PacienteRequestDTO;
 import com.carlesso.pilatesapi.dto.PacienteResponseDTO;
 import com.carlesso.pilatesapi.dto.PacienteUpdateDTO;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.service.PacienteService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -177,7 +177,7 @@ class PacienteControllerTest {
     @Test
     void buscar_quandoNaoExistente_deveRetornar404() throws Exception {
         when(service.buscarPorId(99L))
-                .thenThrow(new EntityNotFoundException("Paciente não encontrado: 99"));
+                .thenThrow(new ResourceNotFoundException("Paciente não encontrado: 99"));
 
         mvc.perform(get("/pacientes/99"))
                 .andExpect(status().isNotFound())
@@ -206,7 +206,7 @@ class PacienteControllerTest {
     @Test
     void atualizar_quandoNaoExistente_deveRetornar404() throws Exception {
         when(service.atualizar(eq(99L), any()))
-                .thenThrow(new EntityNotFoundException("Paciente não encontrado: 99"));
+                .thenThrow(new ResourceNotFoundException("Paciente não encontrado: 99"));
 
         mvc.perform(put("/pacientes/99")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -229,7 +229,7 @@ class PacienteControllerTest {
 
     @Test
     void inativar_quandoNaoExistente_deveRetornar404() throws Exception {
-        doThrow(new EntityNotFoundException("Paciente não encontrado: 99"))
+        doThrow(new ResourceNotFoundException("Paciente não encontrado: 99"))
                 .when(service).inativar(99L);
 
         mvc.perform(patch("/pacientes/99/inativar"))
@@ -247,7 +247,7 @@ class PacienteControllerTest {
 
     @Test
     void ativar_quandoNaoExistente_deveRetornar404() throws Exception {
-        doThrow(new EntityNotFoundException("Paciente não encontrado: 99"))
+        doThrow(new ResourceNotFoundException("Paciente não encontrado: 99"))
                 .when(service).ativar(99L);
 
         mvc.perform(patch("/pacientes/99/ativar"))

--- a/src/test/java/com/carlesso/pilatesapi/controller/PagamentoControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/PagamentoControllerTest.java
@@ -3,9 +3,11 @@ package com.carlesso.pilatesapi.controller;
 import com.carlesso.pilatesapi.dto.PagamentoRequestDTO;
 import com.carlesso.pilatesapi.dto.PagamentoResponseDTO;
 import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
+import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.exception.ConflictException;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.service.PagamentoService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -72,12 +74,27 @@ class PagamentoControllerTest {
     }
 
     @Test
-    void criar_pacienteInativo_retorna409() throws Exception {
+    void criar_pacienteInativo_retorna422() throws Exception {
         var dto = new PagamentoRequestDTO(1L, 1L, new BigDecimal("200.00"),
                 LocalDate.now().plusDays(10), LocalDate.now());
 
         when(pagamentoService.criar(any()))
-                .thenThrow(new IllegalStateException("Paciente inativo não pode receber novas cobranças"));
+                .thenThrow(new BusinessException("Paciente inativo não pode receber novas cobranças"));
+
+        mockMvc.perform(post("/pagamentos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.erro").exists());
+    }
+
+    @Test
+    void criar_pagamentoDuplicado_retorna409() throws Exception {
+        var dto = new PagamentoRequestDTO(1L, 1L, new BigDecimal("200.00"),
+                LocalDate.now().plusDays(10), LocalDate.now());
+
+        when(pagamentoService.criar(any()))
+                .thenThrow(new ConflictException("Já existe um pagamento para este plano no período"));
 
         mockMvc.perform(post("/pagamentos")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -113,7 +130,7 @@ class PagamentoControllerTest {
     @Test
     void buscar_naoEncontrado_retorna404() throws Exception {
         when(pagamentoService.buscarPorId(99L))
-                .thenThrow(new EntityNotFoundException("Pagamento não encontrado: 99"));
+                .thenThrow(new ResourceNotFoundException("Pagamento não encontrado: 99"));
 
         mockMvc.perform(get("/pagamentos/99"))
                 .andExpect(status().isNotFound());
@@ -158,7 +175,7 @@ class PagamentoControllerTest {
     @Test
     void pagar_jaConfirmado_retorna409() throws Exception {
         when(pagamentoService.pagar(eq(1L), isNull()))
-                .thenThrow(new IllegalStateException("Pagamento já foi confirmado"));
+                .thenThrow(new ConflictException("Pagamento já foi confirmado"));
 
         mockMvc.perform(patch("/pagamentos/1/pagar"))
                 .andExpect(status().isConflict())

--- a/src/test/java/com/carlesso/pilatesapi/controller/PlanoControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/PlanoControllerTest.java
@@ -4,9 +4,10 @@ import com.carlesso.pilatesapi.dto.PlanoRequestDTO;
 import com.carlesso.pilatesapi.dto.PlanoResponseDTO;
 import com.carlesso.pilatesapi.entity.enums.FrequenciaSemanal;
 import com.carlesso.pilatesapi.entity.enums.TipoPagamento;
+import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.service.PlanoService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -66,16 +67,16 @@ class PlanoControllerTest {
     }
 
     @Test
-    void criar_pacienteInativo_retorna409() throws Exception {
+    void criar_pacienteInativo_retorna422() throws Exception {
         var dto = new PlanoRequestDTO(1L, TipoPagamento.MENSAL, new BigDecimal("200.00"),
                 FrequenciaSemanal.UMA_VEZ, List.of(DayOfWeek.MONDAY), null);
 
-        when(planoService.criar(any())).thenThrow(new IllegalStateException("Paciente inativo"));
+        when(planoService.criar(any())).thenThrow(new BusinessException("Paciente inativo"));
 
         mockMvc.perform(post("/planos")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(dto)))
-                .andExpect(status().isConflict())
+                .andExpect(status().isUnprocessableEntity())
                 .andExpect(jsonPath("$.erro").value("Paciente inativo"));
     }
 
@@ -104,7 +105,7 @@ class PlanoControllerTest {
 
     @Test
     void buscar_naoEncontrado_retorna404() throws Exception {
-        when(planoService.buscarPorId(99L)).thenThrow(new EntityNotFoundException("Plano não encontrado: 99"));
+        when(planoService.buscarPorId(99L)).thenThrow(new ResourceNotFoundException("Plano não encontrado: 99"));
 
         mockMvc.perform(get("/planos/99"))
                 .andExpect(status().isNotFound())
@@ -147,7 +148,7 @@ class PlanoControllerTest {
 
     @Test
     void inativar_naoEncontrado_retorna404() throws Exception {
-        doThrow(new EntityNotFoundException("Plano não encontrado: 99")).when(planoService).inativar(99L);
+        doThrow(new ResourceNotFoundException("Plano não encontrado: 99")).when(planoService).inativar(99L);
 
         mockMvc.perform(delete("/planos/99"))
                 .andExpect(status().isNotFound());

--- a/src/test/java/com/carlesso/pilatesapi/controller/ProfissionalControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/ProfissionalControllerTest.java
@@ -5,9 +5,10 @@ import com.carlesso.pilatesapi.dto.ProfissionalRequestDTO;
 import com.carlesso.pilatesapi.dto.ProfissionalResponseDTO;
 import com.carlesso.pilatesapi.dto.ProfissionalUpdateDTO;
 import com.carlesso.pilatesapi.entity.enums.TipoContrato;
+import com.carlesso.pilatesapi.exception.ConflictException;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.service.ProfissionalService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -63,6 +64,19 @@ class ProfissionalControllerTest {
     }
 
     @Test
+    void cadastrar_emailDuplicado_deveRetornar409() throws Exception {
+        var request = new ProfissionalRequestDTO("Paula Mendes", "paula@email.com", "12345678900", "11999999999",
+                TipoContrato.PJ, new BigDecimal("45.00"), LocalDate.of(2024, 1, 15));
+        when(service.cadastrar(any())).thenThrow(new ConflictException("E-mail já cadastrado: paula@email.com"));
+
+        mvc.perform(post("/profissionais")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.erro").value("E-mail já cadastrado: paula@email.com"));
+    }
+
+    @Test
     void listar_deveRetornar200() throws Exception {
         when(service.listar(any(), any(), any(), any(), any(), any()))
                 .thenReturn(new PageImpl<>(List.of(response()), PageRequest.of(0, 10), 1));
@@ -108,7 +122,7 @@ class ProfissionalControllerTest {
 
     @Test
     void buscar_quandoNaoExistente_deveRetornar404() throws Exception {
-        when(service.buscarPorId(eq(99L))).thenThrow(new EntityNotFoundException("Profissional não encontrado: 99"));
+        when(service.buscarPorId(eq(99L))).thenThrow(new ResourceNotFoundException("Profissional não encontrado: 99"));
 
         mvc.perform(get("/profissionais/99"))
                 .andExpect(status().isNotFound())
@@ -131,7 +145,7 @@ class ProfissionalControllerTest {
     @Test
     void atualizar_quandoNaoExistente_deveRetornar404() throws Exception {
         when(service.atualizar(eq(99L), any()))
-                .thenThrow(new EntityNotFoundException("Profissional não encontrado: 99"));
+                .thenThrow(new ResourceNotFoundException("Profissional não encontrado: 99"));
 
         mvc.perform(put("/profissionais/99")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -150,7 +164,7 @@ class ProfissionalControllerTest {
 
     @Test
     void ativar_quandoNaoExistente_deveRetornar404() throws Exception {
-        doThrow(new EntityNotFoundException("Profissional não encontrado: 99"))
+        doThrow(new ResourceNotFoundException("Profissional não encontrado: 99"))
                 .when(service).ativar(99L);
 
         mvc.perform(patch("/profissionais/99/ativar"))
@@ -168,7 +182,7 @@ class ProfissionalControllerTest {
 
     @Test
     void inativar_quandoNaoExistente_deveRetornar404() throws Exception {
-        doThrow(new EntityNotFoundException("Profissional não encontrado: 99"))
+        doThrow(new ResourceNotFoundException("Profissional não encontrado: 99"))
                 .when(service).inativar(99L);
 
         mvc.perform(patch("/profissionais/99/inativar"))

--- a/src/test/java/com/carlesso/pilatesapi/service/AulaServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/AulaServiceTest.java
@@ -9,9 +9,11 @@ import com.carlesso.pilatesapi.entity.enums.FrequenciaSemanal;
 import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
 import com.carlesso.pilatesapi.entity.enums.TipoContrato;
 import com.carlesso.pilatesapi.entity.enums.TipoPagamento;
+import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.exception.ConflictException;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.repository.AulaRepository;
 import com.carlesso.pilatesapi.repository.ProfissionalRepository;
-import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -125,7 +127,7 @@ class AulaServiceTest {
         pagamentoPago.setStatus(StatusPagamento.PENDENTE);
 
         assertThatThrownBy(() -> service.gerarAulas(pagamentoPago))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("PAGO");
     }
 
@@ -134,7 +136,7 @@ class AulaServiceTest {
         paciente.setAtivo(false);
 
         assertThatThrownBy(() -> service.gerarAulas(pagamentoPago))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("inativo");
     }
 
@@ -191,7 +193,7 @@ class AulaServiceTest {
         when(profissionalRepository.findById(1L)).thenReturn(Optional.of(profissional));
 
         assertThatThrownBy(() -> service.realizarAula(1L, 1L))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("Profissional inativo");
     }
 
@@ -206,16 +208,16 @@ class AulaServiceTest {
         when(aulaRepository.findByIdAndPacienteAtivoTrue(1L)).thenReturn(Optional.of(aula));
 
         assertThatThrownBy(() -> service.realizarAula(1L))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(ConflictException.class)
                 .hasMessageContaining("já foi marcada");
     }
 
     @Test
-    void realizarAula_pacienteInativo_lancaEntityNotFound() {
+    void realizarAula_pacienteInativo_lancaResourceNotFound() {
         when(aulaRepository.findByIdAndPacienteAtivoTrue(1L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.realizarAula(1L))
-                .isInstanceOf(EntityNotFoundException.class)
+                .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining("Aula não encontrada: 1");
     }
 
@@ -224,16 +226,31 @@ class AulaServiceTest {
         when(aulaRepository.findByIdAndPacienteAtivoTrue(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.buscarPorId(99L))
-                .isInstanceOf(EntityNotFoundException.class);
+                .isInstanceOf(ResourceNotFoundException.class);
     }
 
     @Test
-    void buscarPorId_pacienteInativo_lancaEntityNotFound() {
+    void buscarPorId_pacienteInativo_lancaResourceNotFound() {
         when(aulaRepository.findByIdAndPacienteAtivoTrue(1L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.buscarPorId(1L))
-                .isInstanceOf(EntityNotFoundException.class)
+                .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining("Aula não encontrada: 1");
+    }
+
+    @Test
+    void realizarAula_profissionalNaoEncontrado_lancaResourceNotFound() {
+        Aula aula = new Aula();
+        aula.setPaciente(paciente);
+        aula.setPagamento(pagamentoPago);
+        aula.setData(LocalDate.of(2025, 2, 3));
+
+        when(aulaRepository.findByIdAndPacienteAtivoTrue(1L)).thenReturn(Optional.of(aula));
+        when(profissionalRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.realizarAula(1L, 99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Profissional não encontrado: 99");
     }
 
     private void assertReadOnly(String methodName, Class<?>... parameterTypes) throws Exception {

--- a/src/test/java/com/carlesso/pilatesapi/service/PacienteServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/PacienteServiceTest.java
@@ -6,8 +6,8 @@ import com.carlesso.pilatesapi.dto.PacienteResponseDTO;
 import com.carlesso.pilatesapi.dto.PacienteUpdateDTO;
 import com.carlesso.pilatesapi.entity.Endereco;
 import com.carlesso.pilatesapi.entity.Paciente;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.repository.PacienteRepository;
-import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -163,11 +163,11 @@ class PacienteServiceTest {
     }
 
     @Test
-    void buscarPorId_quandoNaoExistente_deveLancarEntityNotFoundException() {
+    void buscarPorId_quandoNaoExistente_deveLancarResourceNotFoundException() {
         when(repository.findById(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.buscarPorId(99L))
-                .isInstanceOf(EntityNotFoundException.class)
+                .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining("99");
     }
 
@@ -200,11 +200,11 @@ class PacienteServiceTest {
     }
 
     @Test
-    void atualizar_quandoNaoExistente_deveLancarEntityNotFoundException() {
+    void atualizar_quandoNaoExistente_deveLancarResourceNotFoundException() {
         when(repository.findById(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.atualizar(99L, new PacienteUpdateDTO(null, null, null, null, null)))
-                .isInstanceOf(EntityNotFoundException.class)
+                .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining("99");
     }
 
@@ -223,11 +223,11 @@ class PacienteServiceTest {
     }
 
     @Test
-    void inativar_quandoNaoExistente_deveLancarEntityNotFoundException() {
+    void inativar_quandoNaoExistente_deveLancarResourceNotFoundException() {
         when(repository.findById(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.inativar(99L))
-                .isInstanceOf(EntityNotFoundException.class)
+                .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining("99");
     }
 }

--- a/src/test/java/com/carlesso/pilatesapi/service/PagamentoServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/PagamentoServiceTest.java
@@ -8,10 +8,12 @@ import com.carlesso.pilatesapi.entity.Plano;
 import com.carlesso.pilatesapi.entity.enums.FrequenciaSemanal;
 import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
 import com.carlesso.pilatesapi.entity.enums.TipoPagamento;
+import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.exception.ConflictException;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.repository.PacienteRepository;
 import com.carlesso.pilatesapi.repository.PagamentoRepository;
 import com.carlesso.pilatesapi.repository.PlanoRepository;
-import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -91,7 +93,7 @@ class PagamentoServiceTest {
         when(pacienteRepository.findById(1L)).thenReturn(Optional.of(paciente));
 
         assertThatThrownBy(() -> service.criar(dto))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("inativo");
     }
 
@@ -118,7 +120,7 @@ class PagamentoServiceTest {
         when(pagamentoRepository.existsByPlanoAndPeriodoInicio(plano, dto.periodoInicio())).thenReturn(true);
 
         assertThatThrownBy(() -> service.criar(dto))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(ConflictException.class)
                 .hasMessageContaining("Já existe um pagamento");
     }
 
@@ -130,7 +132,7 @@ class PagamentoServiceTest {
         when(pacienteRepository.findById(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.criar(dto))
-                .isInstanceOf(EntityNotFoundException.class);
+                .isInstanceOf(ResourceNotFoundException.class);
     }
 
     @Test
@@ -167,7 +169,7 @@ class PagamentoServiceTest {
         when(pagamentoRepository.findById(1L)).thenReturn(Optional.of(pagamento));
 
         assertThatThrownBy(() -> service.pagar(1L, null))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(ConflictException.class)
                 .hasMessageContaining("já foi confirmado");
     }
 

--- a/src/test/java/com/carlesso/pilatesapi/service/PlanoServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/PlanoServiceTest.java
@@ -6,9 +6,11 @@ import com.carlesso.pilatesapi.entity.Paciente;
 import com.carlesso.pilatesapi.entity.Plano;
 import com.carlesso.pilatesapi.entity.enums.FrequenciaSemanal;
 import com.carlesso.pilatesapi.entity.enums.TipoPagamento;
+import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.exception.ConflictException;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.repository.PacienteRepository;
 import com.carlesso.pilatesapi.repository.PlanoRepository;
-import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -92,7 +94,7 @@ class PlanoServiceTest {
         when(pacienteRepository.findById(2L)).thenReturn(Optional.of(pacienteInativo));
 
         assertThatThrownBy(() -> service.criar(dto))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("inativo");
     }
 
@@ -144,7 +146,7 @@ class PlanoServiceTest {
         when(pacienteRepository.findById(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.criar(dto))
-                .isInstanceOf(EntityNotFoundException.class);
+                .isInstanceOf(ResourceNotFoundException.class);
     }
 
     @Test
@@ -195,7 +197,7 @@ class PlanoServiceTest {
         when(planoRepository.findById(1L)).thenReturn(Optional.of(plano));
 
         assertThatThrownBy(() -> service.inativar(1L))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(ConflictException.class)
                 .hasMessageContaining("já está inativo");
     }
 

--- a/src/test/java/com/carlesso/pilatesapi/service/ProfissionalServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/ProfissionalServiceTest.java
@@ -12,9 +12,10 @@ import com.carlesso.pilatesapi.entity.enums.FrequenciaSemanal;
 import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
 import com.carlesso.pilatesapi.entity.enums.TipoContrato;
 import com.carlesso.pilatesapi.entity.enums.TipoPagamento;
+import com.carlesso.pilatesapi.exception.ConflictException;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.repository.AulaRepository;
 import com.carlesso.pilatesapi.repository.ProfissionalRepository;
-import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -84,7 +85,7 @@ class ProfissionalServiceTest {
         when(repository.existsByEmail(dto.email())).thenReturn(true);
 
         assertThatThrownBy(() -> service.cadastrar(dto))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(ConflictException.class)
                 .hasMessageContaining("paula@email.com");
     }
 
@@ -96,7 +97,7 @@ class ProfissionalServiceTest {
         when(repository.existsByCpf(dto.cpf())).thenReturn(true);
 
         assertThatThrownBy(() -> service.cadastrar(dto))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(ConflictException.class)
                 .hasMessageContaining("12345678900");
     }
 
@@ -146,7 +147,7 @@ class ProfissionalServiceTest {
         when(repository.findById(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.buscarPorId(99L))
-                .isInstanceOf(EntityNotFoundException.class)
+                .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining("99");
     }
 
@@ -166,7 +167,7 @@ class ProfissionalServiceTest {
         when(repository.findById(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.ativar(99L))
-                .isInstanceOf(EntityNotFoundException.class)
+                .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining("99");
     }
 
@@ -185,7 +186,7 @@ class ProfissionalServiceTest {
         when(repository.findById(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.inativar(99L))
-                .isInstanceOf(EntityNotFoundException.class)
+                .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining("99");
     }
 


### PR DESCRIPTION
## Summary
- Cria as exceções customizadas `ResourceNotFoundException` (404), `ConflictException` (409) e `BusinessException` (422) em `com.carlesso.pilatesapi.exception`.
- Atualiza o `GlobalExceptionHandler` para mapear cada exceção ao status HTTP semanticamente correto e remove o handler genérico de `IllegalStateException`.
- Substitui os lançamentos de `EntityNotFoundException` e `IllegalStateException` nos services pelas novas exceções, distinguindo conflitos de estado/duplicidade (409) e violações de regra de negócio (422).
- Adiciona testes unitários para o `GlobalExceptionHandler` e novos cenários nos controller tests cobrindo 409 e 422.
- Atualiza `README.md` e `docs/context.md` documentando o novo tratamento de erros.

Closes #26

## Test plan
- [x] `JAVA_HOME=~/jdk mvn test` — 142 testes passando
- [x] Cobertura nova: `GlobalExceptionHandlerTest`, novos cenários em `ProfissionalControllerTest`, `PagamentoControllerTest`, `AulaControllerTest` e `AulaServiceTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)