### PR TITLE
perf: corrigir N+1 no relatório de pagamento

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ curl -s -X PATCH http://localhost:8080/pagamentos/1/pagar \
 - O `percentualPagamentoAula` representa o percentual recebido por aula ministrada
 - Profissionais inativos são mantidos no banco (soft delete)
 - O relatório de pagamento considera aulas realizadas vinculadas ao profissional no período informado e ignora aulas de pacientes inativos
+- O relatório de pagamento usa uma consulta consolidada com `JOIN` e `GROUP BY` para buscar os dados das aulas e a quantidade de aulas do pagamento sem round-trips adicionais
 - O valor devido por aula é calculado por `valor do pagamento / quantidade de aulas do pagamento * percentualPagamentoAula / 100`
 
 ### Planos de Pagamento
@@ -539,7 +540,7 @@ O projeto possui **142 testes** organizados em dezesseis suítes:
 | `ProfissionalServiceTest` | Unitário (Mockito) | 13 |
 | `PacienteServiceIntegrationTest` | JPA (`@DataJpaTest`) | 4 |
 | `ProfissionalServiceIntegrationTest` | JPA (`@DataJpaTest`) | 5 |
-| `AulaRepositoryTest` | JPA (`@DataJpaTest`) | 5 |
+| `AulaRepositoryTest` | JPA (`@DataJpaTest`) | 6 |
 | `PacienteControllerTest` | Controller (`@WebMvcTest`) | 16 |
 | `PlanoControllerTest` | Controller (`@WebMvcTest`) | 11 |
 | `PagamentoControllerTest` | Controller (`@WebMvcTest`) | 11 |

--- a/docs/context.md
+++ b/docs/context.md
@@ -219,6 +219,7 @@ CPF não pode ser alterado após o cadastro.
 - Tipos de contrato: `CLT`, `PJ`, `AUTONOMO`
 - Soft delete mantém o registro no banco
 - O relatório de pagamento considera apenas aulas `realizada = true` vinculadas ao profissional, dentro do período informado e associadas a pacientes ativos
+- A consulta do relatório de pagamento consolida dados da aula, paciente, pagamento e contagem de aulas por pagamento em um único `JOIN` com `GROUP BY`
 - Valor por aula no relatório: `valor do pagamento / quantidade de aulas do pagamento`
 - Valor devido ao profissional por aula: `valor por aula * percentualPagamentoAula / 100`
 
@@ -337,7 +338,7 @@ JAVA_HOME=~/jdk mvn spring-boot:run
 | `AulaServiceTest` | Unitário (Mockito, sem Spring) | 14 |
 | `PacienteServiceIntegrationTest` | `@DataJpaTest` + H2 | 4 |
 | `ProfissionalServiceIntegrationTest` | `@DataJpaTest` + H2 | 5 |
-| `AulaRepositoryTest` | `@DataJpaTest` + H2 | 5 |
+| `AulaRepositoryTest` | `@DataJpaTest` + H2 | 6 |
 | `PacienteControllerTest` | `@WebMvcTest` + MockMvc | 16 |
 | `ProfissionalControllerTest` | `@WebMvcTest` + MockMvc | 14 |
 | `PlanoControllerTest` | `@WebMvcTest` + MockMvc | 11 |

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -130,9 +130,9 @@ src/
     │   ├── ProfissionalServiceTest.java         # 13 casos
     │   ├── PlanoServiceTest.java                # 9 casos
     │   ├── PagamentoServiceTest.java            # 8 casos
-    │   └── AulaServiceTest.java                 # 13 casos
+    │   └── AulaServiceTest.java                 # 14 casos
     ├── repository/
-    │   └── AulaRepositoryTest.java              # 5 casos
+    │   └── AulaRepositoryTest.java              # 6 casos
     └── controller/
         ├── PacienteControllerTest.java          # 16 casos
         ├── ProfissionalControllerTest.java      # 13 casos
@@ -155,6 +155,7 @@ src/
 - O campo `percentualPagamentoAula` representa o percentual recebido por aula ministrada
 - Soft delete: profissionais inativos são mantidos no banco
 - O relatório de pagamento considera aulas realizadas vinculadas ao profissional dentro do período solicitado e associadas a pacientes ativos
+- A consulta do relatório de pagamento consolida dados de aula, paciente, pagamento e contagem de aulas por pagamento em uma única query com `JOIN` e `GROUP BY`
 - O valor devido por aula é proporcional ao valor do pagamento (`valor / quantidade de aulas geradas`) multiplicado pelo `percentualPagamentoAula`
 
 ### 4.3 Planos de Pagamento
@@ -784,10 +785,10 @@ A suíte de testes possui **132 casos** distribuídos em quinze classes:
 | `ProfissionalServiceTest` | Unitário (Mockito) | 13 |
 | `PlanoServiceTest` | Unitário (Mockito) | 9 |
 | `PagamentoServiceTest` | Unitário (Mockito) | 8 |
-| `AulaServiceTest` | Unitário (Mockito) | 13 |
+| `AulaServiceTest` | Unitário (Mockito) | 14 |
 | `PacienteServiceIntegrationTest` | JPA (`@DataJpaTest`) | 4 |
 | `ProfissionalServiceIntegrationTest` | JPA (`@DataJpaTest`) | 5 |
-| `AulaRepositoryTest` | JPA (`@DataJpaTest`) | 5 |
+| `AulaRepositoryTest` | JPA (`@DataJpaTest`) | 6 |
 | `PacienteControllerTest` | Controller (`@WebMvcTest`) | 16 |
 | `ProfissionalControllerTest` | Controller (`@WebMvcTest`) | 13 |
 | `PlanoControllerTest` | Controller (`@WebMvcTest`) | 11 |

--- a/src/main/java/com/carlesso/pilatesapi/repository/AulaRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/AulaRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -32,6 +33,36 @@ public interface AulaRepository extends JpaRepository<Aula, Long> {
     List<Object[]> countGroupedByPagamentoId(@Param("ids") List<Long> ids);
 
     @Query("""
+            SELECT a.id AS aulaId,
+                   a.data AS data,
+                   paciente.id AS pacienteId,
+                   paciente.nome AS pacienteNome,
+                   pagamento.id AS pagamentoId,
+                   pagamento.valor AS valorPagamento,
+                   COUNT(aulaPagamento.id) AS quantidadeAulasPagamento
+            FROM Aula a
+            JOIN a.paciente paciente
+            JOIN a.pagamento pagamento
+            JOIN Aula aulaPagamento ON aulaPagamento.pagamento = pagamento
+                                  AND aulaPagamento.paciente.ativo = true
+            WHERE a.profissional.id = :profissionalId
+              AND a.realizada = true
+              AND a.data BETWEEN :inicio AND :fim
+              AND paciente.ativo = true
+            GROUP BY a.id,
+                     a.data,
+                     paciente.id,
+                     paciente.nome,
+                     pagamento.id,
+                     pagamento.valor
+            ORDER BY a.data
+            """)
+    List<ProfissionalPagamentoAulaProjection> findRelatorioPagamentoByProfissionalIdAndPeriodo(
+            @Param("profissionalId") Long profissionalId,
+            @Param("inicio") LocalDate inicio,
+            @Param("fim") LocalDate fim);
+
+    @Query("""
             SELECT a
             FROM Aula a
             WHERE a.profissional.id = :profissionalId
@@ -44,4 +75,14 @@ public interface AulaRepository extends JpaRepository<Aula, Long> {
             @Param("profissionalId") Long profissionalId,
             @Param("inicio") LocalDate inicio,
             @Param("fim") LocalDate fim);
+
+    interface ProfissionalPagamentoAulaProjection {
+        Long getAulaId();
+        LocalDate getData();
+        Long getPacienteId();
+        String getPacienteNome();
+        Long getPagamentoId();
+        BigDecimal getValorPagamento();
+        Long getQuantidadeAulasPagamento();
+    }
 }

--- a/src/main/java/com/carlesso/pilatesapi/service/ProfissionalService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/ProfissionalService.java
@@ -5,13 +5,13 @@ import com.carlesso.pilatesapi.dto.ProfissionalPagamentoRelatorioDTO;
 import com.carlesso.pilatesapi.dto.ProfissionalRequestDTO;
 import com.carlesso.pilatesapi.dto.ProfissionalResponseDTO;
 import com.carlesso.pilatesapi.dto.ProfissionalUpdateDTO;
-import com.carlesso.pilatesapi.entity.Aula;
 import com.carlesso.pilatesapi.entity.Profissional;
 import com.carlesso.pilatesapi.entity.enums.TipoContrato;
 import com.carlesso.pilatesapi.exception.BusinessException;
 import com.carlesso.pilatesapi.exception.ConflictException;
 import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.repository.AulaRepository;
+import com.carlesso.pilatesapi.repository.AulaRepository.ProfissionalPagamentoAulaProjection;
 import com.carlesso.pilatesapi.repository.ProfissionalRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,8 +24,6 @@ import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @Service
 public class ProfissionalService {
@@ -106,22 +104,10 @@ public class ProfissionalService {
         }
 
         Profissional profissional = encontrar(id);
-        List<Aula> aulasEntidade = aulaRepository
-                .findByProfissionalIdAndRealizadaTrueAndDataBetweenOrderByData(id, inicio, fim);
-
-        List<Long> pagamentoIds = aulasEntidade.stream()
-                .map(a -> a.getPagamento().getId())
-                .distinct()
-                .toList();
-
-        Map<Long, Long> contsPorPagamento = pagamentoIds.isEmpty()
-                ? Map.of()
-                : aulaRepository.countGroupedByPagamentoId(pagamentoIds)
-                        .stream()
-                        .collect(Collectors.toMap(row -> (Long) row[0], row -> (Long) row[1]));
-
-        List<ProfissionalPagamentoAulaDTO> aulas = aulasEntidade.stream()
-                .map(aula -> mapearAulaPagamento(aula, profissional.getPercentualPagamentoAula(), contsPorPagamento))
+        List<ProfissionalPagamentoAulaDTO> aulas = aulaRepository
+                .findRelatorioPagamentoByProfissionalIdAndPeriodo(id, inicio, fim)
+                .stream()
+                .map(aula -> mapearAulaPagamento(aula, profissional.getPercentualPagamentoAula()))
                 .toList();
 
         BigDecimal totalPagamento = aulas.stream()
@@ -143,25 +129,27 @@ public class ProfissionalService {
                 .orElseThrow(() -> new ResourceNotFoundException("Profissional não encontrado: " + id));
     }
 
-    private ProfissionalPagamentoAulaDTO mapearAulaPagamento(Aula aula, BigDecimal percentualPagamentoAula, Map<Long, Long> contsPorPagamento) {
-        long quantidadeAulasPagamento = contsPorPagamento.getOrDefault(aula.getPagamento().getId(), 0L);
+    private ProfissionalPagamentoAulaDTO mapearAulaPagamento(
+            ProfissionalPagamentoAulaProjection aula,
+            BigDecimal percentualPagamentoAula) {
+        long quantidadeAulasPagamento = aula.getQuantidadeAulasPagamento();
         if (quantidadeAulasPagamento == 0) {
-            throw new BusinessException("Pagamento sem aulas geradas: " + aula.getPagamento().getId());
+            throw new BusinessException("Pagamento sem aulas geradas: " + aula.getPagamentoId());
         }
 
-        BigDecimal valorBaseAula = aula.getPagamento().getValor()
+        BigDecimal valorBaseAula = aula.getValorPagamento()
                 .divide(BigDecimal.valueOf(quantidadeAulasPagamento), 6, RoundingMode.HALF_UP);
         BigDecimal valorProfissional = valorBaseAula
                 .multiply(percentualPagamentoAula)
                 .divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP);
 
         return new ProfissionalPagamentoAulaDTO(
-                aula.getId(),
+                aula.getAulaId(),
                 aula.getData(),
-                aula.getPaciente().getId(),
-                aula.getPaciente().getNome(),
-                aula.getPagamento().getId(),
-                aula.getPagamento().getValor(),
+                aula.getPacienteId(),
+                aula.getPacienteNome(),
+                aula.getPagamentoId(),
+                aula.getValorPagamento(),
                 quantidadeAulasPagamento,
                 valorBaseAula.setScale(2, RoundingMode.HALF_UP),
                 percentualPagamentoAula,

--- a/src/test/java/com/carlesso/pilatesapi/repository/AulaRepositoryTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/repository/AulaRepositoryTest.java
@@ -94,6 +94,29 @@ class AulaRepositoryTest {
     }
 
     @Test
+    void findRelatorioPagamentoByProfissionalIdAndPeriodo_retornaCamposEQuantidadeNaMesmaConsulta() {
+        entityManager.persist(aulaNaoRealizadaSemProfissional(pacienteAtivo, pagamentoAtivo, LocalDate.of(2025, 2, 10)));
+        entityManager.persist(aulaNaoRealizadaSemProfissional(pacienteAtivo, pagamentoAtivo, LocalDate.of(2025, 2, 17)));
+        entityManager.flush();
+        entityManager.clear();
+
+        var aulas = repository.findRelatorioPagamentoByProfissionalIdAndPeriodo(
+                profissional.getId(),
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2025, 12, 31));
+
+        assertThat(aulas)
+                .singleElement()
+                .satisfies(aula -> {
+                    assertThat(aula.getAulaId()).isEqualTo(aulaAtiva.getId());
+                    assertThat(aula.getPacienteNome()).isEqualTo("Ana Ativa");
+                    assertThat(aula.getPagamentoId()).isEqualTo(pagamentoAtivo.getId());
+                    assertThat(aula.getValorPagamento()).isEqualByComparingTo("200.00");
+                    assertThat(aula.getQuantidadeAulasPagamento()).isEqualTo(3L);
+                });
+    }
+
+    @Test
     void countGroupedByPagamentoId_naoContaAulasDePacienteInativo() {
         var contagens = repository.countGroupedByPagamentoId(List.of(pagamentoAtivo.getId(), pagamentoInativo.getId()));
 
@@ -155,6 +178,15 @@ class AulaRepositoryTest {
         aula.setProfissional(profissional);
         aula.setData(data);
         aula.setRealizada(true);
+        return aula;
+    }
+
+    private Aula aulaNaoRealizadaSemProfissional(Paciente paciente, Pagamento pagamento, LocalDate data) {
+        Aula aula = new Aula();
+        aula.setPaciente(paciente);
+        aula.setPagamento(pagamento);
+        aula.setData(data);
+        aula.setRealizada(false);
         return aula;
     }
 }

--- a/src/test/java/com/carlesso/pilatesapi/service/ProfissionalServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/ProfissionalServiceTest.java
@@ -1,20 +1,14 @@
 package com.carlesso.pilatesapi.service;
 
-import com.carlesso.pilatesapi.entity.Aula;
-import com.carlesso.pilatesapi.entity.Paciente;
-import com.carlesso.pilatesapi.entity.Pagamento;
-import com.carlesso.pilatesapi.entity.Plano;
 import com.carlesso.pilatesapi.dto.ProfissionalRequestDTO;
 import com.carlesso.pilatesapi.dto.ProfissionalResponseDTO;
 import com.carlesso.pilatesapi.dto.ProfissionalUpdateDTO;
 import com.carlesso.pilatesapi.entity.Profissional;
-import com.carlesso.pilatesapi.entity.enums.FrequenciaSemanal;
-import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
 import com.carlesso.pilatesapi.entity.enums.TipoContrato;
-import com.carlesso.pilatesapi.entity.enums.TipoPagamento;
 import com.carlesso.pilatesapi.exception.ConflictException;
 import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.repository.AulaRepository;
+import com.carlesso.pilatesapi.repository.AulaRepository.ProfissionalPagamentoAulaProjection;
 import com.carlesso.pilatesapi.repository.ProfissionalRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,9 +28,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class ProfissionalServiceTest {
@@ -193,14 +187,13 @@ class ProfissionalServiceTest {
     @Test
     void gerarRelatorioPagamento_deveSomarAulasRealizadasNoPeriodo() {
         Profissional profissional = profissional();
-        Aula aula = aula(profissional);
+        var aula = aulaRelatorio(10L, LocalDate.of(2025, 2, 3), 5L);
+        var outraAula = aulaRelatorio(11L, LocalDate.of(2025, 2, 5), 5L);
 
         when(repository.findById(1L)).thenReturn(Optional.of(profissional));
-        when(aulaRepository.findByProfissionalIdAndRealizadaTrueAndDataBetweenOrderByData(
+        when(aulaRepository.findRelatorioPagamentoByProfissionalIdAndPeriodo(
                 1L, LocalDate.of(2025, 2, 1), LocalDate.of(2025, 2, 28)))
-                .thenReturn(List.of(aula, aula));
-        when(aulaRepository.countGroupedByPagamentoId(List.of(5L)))
-                .thenReturn(List.<Object[]>of(new Object[]{5L, 8L}));
+                .thenReturn(List.of(aula, outraAula));
 
         var relatorio = service.gerarRelatorioPagamento(
                 1L,
@@ -211,6 +204,9 @@ class ProfissionalServiceTest {
         assertThat(relatorio.totalPagamento()).isEqualByComparingTo("22.50");
         assertThat(relatorio.aulas().getFirst().valorBaseAula()).isEqualByComparingTo("25.00");
         assertThat(relatorio.aulas().getFirst().valorProfissional()).isEqualByComparingTo("11.25");
+        verify(aulaRepository).findRelatorioPagamentoByProfissionalIdAndPeriodo(
+                1L, LocalDate.of(2025, 2, 1), LocalDate.of(2025, 2, 28));
+        verify(aulaRepository, never()).countGroupedByPagamentoId(any());
     }
 
     @Test
@@ -223,35 +219,42 @@ class ProfissionalServiceTest {
                 .hasMessageContaining("não pode ser maior");
     }
 
-    private Aula aula(Profissional profissional) {
-        Paciente paciente = new Paciente();
-        paciente.setNome("Ana");
-        paciente.setEmail("ana@email.com");
-        paciente.setCpf("11122233344");
+    private ProfissionalPagamentoAulaProjection aulaRelatorio(Long aulaId, LocalDate data, Long pagamentoId) {
+        return new ProfissionalPagamentoAulaProjection() {
+            @Override
+            public Long getAulaId() {
+                return aulaId;
+            }
 
-        Plano plano = new Plano();
-        plano.setPaciente(paciente);
-        plano.setTipo(TipoPagamento.MENSAL);
-        plano.setValor(new BigDecimal("200.00"));
-        plano.setFrequenciaSemanal(FrequenciaSemanal.DUAS_VEZES);
-        plano.setDataInicio(LocalDate.of(2025, 2, 1));
+            @Override
+            public LocalDate getData() {
+                return data;
+            }
 
-        Pagamento pagamento = new Pagamento();
-        pagamento.setPaciente(paciente);
-        pagamento.setPlano(plano);
-        pagamento.setValor(new BigDecimal("200.00"));
-        pagamento.setStatus(StatusPagamento.PAGO);
-        pagamento.setPeriodoInicio(LocalDate.of(2025, 2, 1));
-        pagamento.setPeriodoFim(LocalDate.of(2025, 2, 28));
-        pagamento.setDataVencimento(LocalDate.of(2025, 2, 10));
-        ReflectionTestUtils.setField(pagamento, "id", 5L);
+            @Override
+            public Long getPacienteId() {
+                return 2L;
+            }
 
-        Aula aula = new Aula();
-        aula.setPaciente(paciente);
-        aula.setPagamento(pagamento);
-        aula.setProfissional(profissional);
-        aula.setData(LocalDate.of(2025, 2, 3));
-        aula.setRealizada(true);
-        return aula;
+            @Override
+            public String getPacienteNome() {
+                return "Ana";
+            }
+
+            @Override
+            public Long getPagamentoId() {
+                return pagamentoId;
+            }
+
+            @Override
+            public BigDecimal getValorPagamento() {
+                return new BigDecimal("200.00");
+            }
+
+            @Override
+            public Long getQuantidadeAulasPagamento() {
+                return 8L;
+            }
+        };
     }
 }


### PR DESCRIPTION
## Resumo
- Consolida o relatório de pagamento do profissional em uma query com JOIN e GROUP BY
- Mapeia o relatório a partir de projeção, evitando buscar entidades de Aula e uma segunda consulta de contagem
- Adiciona cobertura unitária e JPA para a consulta consolidada
- Atualiza README e docs com a regra de performance e contagem de testes

## Testes
- mvn test

Closes #22