### PR TITLE
Feat: Gerar relatório de emissão de NFSEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ src/
 │   │   │   ├── AulaController.java          # /aulas
 │   │   │   ├── AuthController.java          # /auth/register e /auth/login
 │   │   │   ├── UserController.java          # /users/me e CRUD administrativo de usuários
-│   │   │   └── AdminController.java         # /admin/health
+│   │   │   ├── AdminController.java         # /admin/health
+│   │   │   └── RelatorioNfseController.java # /api/relatorios/nfse
 │   │   ├── service/
 │   │   │   ├── PacienteService.java                    # Regras de negócio de pacientes
 │   │   │   ├── ProfissionalService.java                # Regras de negócio de profissionais
@@ -57,6 +58,8 @@ src/
 │   │   │   ├── PagamentoService.java                   # Cobranças, confirmação, vencimentos
 │   │   │   ├── AulaService.java                        # Geração e controle de aulas
 │   │   │   ├── RelatorioPagamentoExporterService.java  # Exportação do relatório em PDF e XLSX
+│   │   │   ├── RelatorioNfseService.java               # Relatório de emissão de NFSEs por competência
+│   │   │   ├── RelatorioNfseExporterService.java       # Exportação do relatório de NFSEs em CSV e XLSX
 │   │   │   ├── AuthService.java                       # Registro/login, emissão de JWT e rate limiting
 │   │   │   ├── UserService.java                       # CRUD administrativo de usuários e perfis
 │   │   │   ├── JwtService.java                        # Geração (com claims role/userId) e validação de JWT
@@ -99,6 +102,7 @@ src/
 │   │   │   ├── PagamentoResumoDTO.java
 │   │   │   ├── ProfissionalPagamentoRelatorioDTO.java
 │   │   │   ├── ProfissionalPagamentoAulaDTO.java
+│   │   │   ├── RelatorioNfseResponseDTO.java
 │   │   │   ├── PlanoRequestDTO.java
 │   │   │   ├── PlanoResponseDTO.java
 │   │   │   ├── PagamentoRequestDTO.java
@@ -230,6 +234,12 @@ As demais rotas de negócio exigem `Authorization: Bearer <accessToken>`. Tokens
 | `GET` | `/aulas/pagamento/{id}` | Listar aulas de um pagamento |
 | `PATCH` | `/aulas/{id}/realizar` | Marcar aula como realizada, opcionalmente com `profissionalId` |
 
+### Relatórios
+
+| Método | Endpoint | Descrição |
+|---|---|---|
+| `GET` | `/api/relatorios/nfse` | Gerar relatório de emissão de NFSEs por competência (JSON, CSV ou XLSX) |
+
 ### Paginação
 
 Os endpoints de listagem suportam os query params padrão do Spring:
@@ -254,6 +264,8 @@ GET /profissionais?ativo=false
 GET /profissionais/1/relatorio-pagamento?inicio=2025-02-01&fim=2025-02-28
 GET /profissionais/1/relatorio-pagamento/pdf?inicio=2025-02-01&fim=2025-02-28
 GET /profissionais/1/relatorio-pagamento/xlsx?inicio=2025-02-01&fim=2025-02-28
+GET /api/relatorios/nfse?competencia=04/2026
+GET /api/relatorios/nfse?competencia=04/2026&notaAnteriorEmitida=false&formato=XLSX
 ```
 
 ### Relatório de pagamento — contrato JSON (Angular-friendly)
@@ -317,6 +329,29 @@ Os endpoints `GET /profissionais/{id}/relatorio-pagamento/pdf` e `GET /profissio
 | `/relatorio-pagamento/xlsx` | `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` | `attachment; filename="relatorio-pagamento-profissional-{id}-{inicio}-{fim}.xlsx"` |
 
 O XLSX possui três abas: `Resumo`, `Pagamentos` e `Aulas`. O PDF apresenta as mesmas informações em layout único, com tabelas para pagamentos e aulas.
+
+### Relatório de emissão de NFSEs
+
+O endpoint `GET /api/relatorios/nfse` exige `competencia` no formato `MM/AAAA` e aceita os filtros opcionais `notaAnteriorEmitida` e `formato` (`JSON`, `CSV` ou `XLSX`). Ele retorna apenas pagamentos confirmados (`PAGO`) com `dataPagamento` dentro da competência informada e pacientes ativos.
+
+Contrato JSON:
+
+```json
+[
+  {
+    "nome": "Ana Souza",
+    "cpfCnpj": "11122233344",
+    "valorPago": 250.00,
+    "competencia": "04/2026",
+    "descricaoServico": "Aulas de Pilates - Competência 04/2026",
+    "notaAnteriorEmitida": false,
+    "dataPagamento": "2026-04-10",
+    "observacoes": ""
+  }
+]
+```
+
+Para o modelo atual, `notaAnteriorEmitida` é inferido pela existência de pagamento confirmado anterior para o mesmo paciente. CSV e XLSX são retornados como anexo com nome `relatorio-nfse-{MM-AAAA}.{ext}`.
 
 ---
 
@@ -650,6 +685,14 @@ curl -s -OJ "http://localhost:8080/profissionais/1/relatorio-pagamento/xlsx?inic
   -H "Authorization: Bearer $TOKEN"
 ```
 
+### Gerar relatório de NFSE
+```bash
+curl -s "http://localhost:8080/api/relatorios/nfse?competencia=04/2026" \
+  -H "Authorization: Bearer $TOKEN" | jq
+curl -s -OJ "http://localhost:8080/api/relatorios/nfse?competencia=04/2026&formato=CSV" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
 ---
 
 ## Regras de Negócio
@@ -686,6 +729,14 @@ curl -s -OJ "http://localhost:8080/profissionais/1/relatorio-pagamento/xlsx?inic
 - Não pode haver dois pagamentos para o mesmo plano no mesmo período
 - Ao confirmar (`PAGO`), as aulas do período são geradas automaticamente
 - A confirmação de pagamento recebe `dataPagamento` no corpo da requisição; se omitida, usa a data atual
+
+### NFSE
+- O relatório de NFSE considera apenas pagamentos `PAGO` com `dataPagamento` dentro da competência `MM/AAAA`
+- Pacientes inativos são ignorados
+- `Nome`, `CPF/CNPJ`, `ValorPago` e `DataPagamento` vêm do paciente e do pagamento confirmado
+- `DescricaoServico` é gerada automaticamente como `Aulas de Pilates - Competência MM/AAAA`
+- `NotaAnteriorEmitida` é inferida por pagamento confirmado anterior do mesmo paciente
+- Registros sem nome, CPF/CNPJ, valor positivo ou data de pagamento retornam erro de regra de negócio (`422`)
 
 ### Geração de Aulas
 - Aulas geradas com base nos dias da semana do plano e no período do pagamento

--- a/docs/context.md
+++ b/docs/context.md
@@ -2,7 +2,7 @@
 
 ## Objetivo
 
-API REST para gerenciar pacientes e profissionais de um estúdio de pilates. Permite cadastro, consulta, atualização parcial e inativação (soft delete) de pacientes e profissionais, com gestão de planos de pagamento, cobranças, geração automática de aulas e relatório de pagamento de profissionais.
+API REST para gerenciar pacientes e profissionais de um estúdio de pilates. Permite cadastro, consulta, atualização parcial e inativação (soft delete) de pacientes e profissionais, com gestão de planos de pagamento, cobranças, geração automática de aulas, relatório de pagamento de profissionais e relatório de emissão de NFSEs.
 
 ---
 
@@ -50,7 +50,8 @@ com.carlesso.pilatesapi
 │   ├── AulaController.java           — endpoints REST de aulas
 │   ├── AuthController.java           — registro/login com JWT
 │   ├── UserController.java           — endpoint do usuário autenticado e CRUD administrativo
-│   └── AdminController.java          — endpoints administrativos
+│   ├── AdminController.java          — endpoints administrativos
+│   └── RelatorioNfseController.java  — endpoint de relatório de emissão de NFSEs
 ├── service
 │   ├── PacienteService.java                    — lógica de negócio de pacientes
 │   ├── ProfissionalService.java                — lógica de negócio de profissionais
@@ -58,6 +59,8 @@ com.carlesso.pilatesapi
 │   ├── PagamentoService.java                   — cobranças, confirmação, vencimentos
 │   ├── AulaService.java                        — geração e controle de aulas
 │   ├── RelatorioPagamentoExporterService.java  — exporta o relatório em PDF (OpenPDF) e XLSX (Apache POI)
+│   ├── RelatorioNfseService.java               — monta relatório de NFSEs por competência
+│   ├── RelatorioNfseExporterService.java       — exporta relatório de NFSEs em CSV e XLSX
 │   ├── AuthService.java                        — registro/login, emissão de token e rate limiting
 │   ├── UserService.java                        — CRUD de usuários e definição de perfis de acesso
 │   ├── JwtService.java                         — geração (claims role/userId) e validação de JWT
@@ -100,6 +103,7 @@ com.carlesso.pilatesapi
 │   ├── PagamentoResumoDTO.java                — resumo agrupado por pagamento
 │   ├── ProfissionalPagamentoRelatorioDTO.java — relatório de pagamento do profissional (contrato Angular-friendly)
 │   ├── ProfissionalPagamentoAulaDTO.java      — detalhe de aula no relatório
+│   ├── RelatorioNfseResponseDTO.java          — item do relatório de emissão de NFSE
 │   ├── PlanoRequestDTO.java
 │   ├── PlanoResponseDTO.java
 │   ├── PagamentoRequestDTO.java
@@ -240,6 +244,7 @@ Constraint: `UNIQUE (paciente_id, data)`
 | GET | `/aulas/paciente/{id}` | Listar aulas do paciente | 200 |
 | GET | `/aulas/pagamento/{id}` | Listar aulas do pagamento | 200 |
 | PATCH | `/aulas/{id}/realizar?profissionalId={id}` | Marcar como realizada e opcionalmente vincular profissional | 200 / 404 / 409 / 422 |
+| GET | `/api/relatorios/nfse?competencia=MM/AAAA&notaAnteriorEmitida={true|false}&formato={JSON|CSV|XLSX}` | Gerar relatório de emissão de NFSEs por competência | 200 / 400 / 422 |
 
 Campos obrigatórios no cadastro de pacientes: `nome`, `email`, `cpf`.  
 Campos obrigatórios no cadastro de profissionais: `nome`, `email`, `cpf`, `tipoContrato`, `percentualPagamentoAula`, `dataInicio`.  
@@ -289,6 +294,16 @@ CPF não pode ser alterado após o cadastro.
 - Sem duplicidade por período (`UNIQUE plano_id + periodo_inicio`)
 - Ao confirmar (`PAGO`), as aulas são geradas automaticamente
 - A confirmação recebe `dataPagamento` no corpo da requisição; se omitida, usa a data atual
+
+### NFSE
+- O relatório de emissão de NFSEs considera apenas pagamentos `PAGO`, com `dataPagamento` dentro da competência informada e pacientes ativos
+- `competencia` é obrigatória no formato `MM/AAAA`; mês deve estar entre `01` e `12`
+- O relatório retorna `Nome`, `CPF/CNPJ`, `ValorPago`, `Competencia`, `DescricaoServico`, `NotaAnteriorEmitida`, `DataPagamento` e `Observacoes`
+- `DescricaoServico` é gerada automaticamente como `Aulas de Pilates - Competência MM/AAAA`
+- Como o modelo atual não possui entidade de nota fiscal, `NotaAnteriorEmitida` é inferida pela existência de pagamento confirmado anterior para o mesmo paciente
+- O filtro opcional `notaAnteriorEmitida` permite retornar apenas registros com ou sem nota anterior inferida
+- `formato` aceita `JSON`, `CSV` e `XLSX`; CSV e XLSX retornam `Content-Disposition: attachment` com nome `relatorio-nfse-{MM-AAAA}.{ext}`
+- Registros sem nome do paciente, CPF/CNPJ, valor positivo ou data de pagamento retornam `422 Unprocessable Entity`
 
 ### Aulas
 - Geradas percorrendo dia a dia entre `periodoInicio` e `periodoFim`

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -4,7 +4,7 @@
 
 A **Carlesso Pilates API** é uma API REST desenvolvida para gerenciar o cadastro de pacientes e profissionais de um estúdio de pilates. Ela expõe endpoints para criação, consulta, atualização e inativação de pacientes e profissionais, com gestão de planos de pagamento, cobranças e geração automática de aulas.
 
-A aplicação foi construída com **Spring Boot 3** e **Java 21**, utiliza **PostgreSQL** como banco de dados relacional, gerencia o schema com **Flyway**, conta com autenticação stateless via **Spring Security + JWT**, documentação interativa via **Swagger UI**, observabilidade com **Spring Boot Actuator**, processos automáticos via **Spring Scheduler** e possui suíte de testes cobrindo as camadas de serviço e controller.
+A aplicação foi construída com **Spring Boot 3** e **Java 21**, utiliza **PostgreSQL** como banco de dados relacional, gerencia o schema com **Flyway**, conta com autenticação stateless via **Spring Security + JWT**, documentação interativa via **Swagger UI**, observabilidade com **Spring Boot Actuator**, processos automáticos via **Spring Scheduler**, relatórios financeiros/fiscais e possui suíte de testes cobrindo as camadas de service, repository e controller.
 
 ---
 
@@ -76,7 +76,8 @@ src/
 │   │   │   ├── AulaController.java          # /aulas
 │   │   │   ├── AuthController.java          # /auth/register e /auth/login
 │   │   │   ├── UserController.java          # /users/me e CRUD administrativo
-│   │   │   └── AdminController.java         # /admin/health
+│   │   │   ├── AdminController.java         # /admin/health
+│   │   │   └── RelatorioNfseController.java # /api/relatorios/nfse
 │   │   ├── service/
 │   │   │   ├── PacienteService.java                    # Regras de negócio de pacientes
 │   │   │   ├── ProfissionalService.java                # Regras de negócio de profissionais
@@ -84,6 +85,8 @@ src/
 │   │   │   ├── PagamentoService.java                   # Cobranças, confirmação, vencimentos
 │   │   │   ├── AulaService.java                        # Geração e controle de aulas
 │   │   │   ├── RelatorioPagamentoExporterService.java  # Exportação do relatório em PDF e XLSX
+│   │   │   ├── RelatorioNfseService.java               # Relatório de emissão de NFSEs por competência
+│   │   │   ├── RelatorioNfseExporterService.java       # Exportação do relatório de NFSEs em CSV e XLSX
 │   │   │   ├── AuthService.java                        # Registro/login, emissão de JWT e rate limiting
 │   │   │   ├── UserService.java                        # CRUD administrativo de usuários e perfis
 │   │   │   ├── JwtService.java                         # Geração (claims role/userId) e validação de JWT
@@ -125,6 +128,7 @@ src/
 │   │   │   ├── PagamentoResumoDTO.java
 │   │   │   ├── ProfissionalPagamentoRelatorioDTO.java
 │   │   │   ├── ProfissionalPagamentoAulaDTO.java
+│   │   │   ├── RelatorioNfseResponseDTO.java
 │   │   │   ├── PlanoRequestDTO.java
 │   │   │   ├── PlanoResponseDTO.java
 │   │   │   ├── PagamentoRequestDTO.java
@@ -248,7 +252,18 @@ src/
 - Consultas por ID, paciente, pagamento e relatório filtram `paciente.ativo = true`
 - Métodos de leitura nos services usam `@Transactional(readOnly = true)` para reduzir flush desnecessário e permitir otimizações de conexão.
 
-### 4.7 Processos Automáticos (Scheduler)
+### 4.7 Relatório de emissão de NFSEs
+
+- O relatório considera apenas pagamentos `PAGO` com `dataPagamento` dentro da competência informada e pacientes ativos
+- `competencia` é obrigatória no formato `MM/AAAA`; mês deve estar entre `01` e `12`
+- Campos retornados: `Nome`, `CPF/CNPJ`, `ValorPago`, `Competencia`, `DescricaoServico`, `NotaAnteriorEmitida`, `DataPagamento` e `Observacoes`
+- `DescricaoServico` é gerada automaticamente como `Aulas de Pilates - Competência MM/AAAA`
+- Como o modelo atual não possui entidade de nota fiscal, `NotaAnteriorEmitida` é inferida pela existência de pagamento confirmado anterior para o mesmo paciente
+- O filtro opcional `notaAnteriorEmitida` permite retornar apenas registros com ou sem nota anterior inferida
+- `formato` aceita `JSON`, `CSV` e `XLSX`; CSV e XLSX retornam anexo com nome `relatorio-nfse-{MM-AAAA}.{ext}`
+- Registros sem nome do paciente, CPF/CNPJ, valor positivo ou data de pagamento retornam `422 Unprocessable Entity`
+
+### 4.8 Processos Automáticos (Scheduler)
 
 | Cron | Ação |
 |---|---|
@@ -670,6 +685,42 @@ GET /profissionais/{id}/relatorio-pagamento/xlsx?inicio=2025-02-01&fim=2025-02-2
 | `GET` | `/aulas/pagamento/{id}` | Listar aulas de um pagamento |
 | `PATCH` | `/aulas/{id}/realizar` | Marcar aula como realizada; aceita `profissionalId` opcional |
 
+### 6.4 Relatórios fiscais
+
+#### Relatório de emissão de NFSEs
+
+```http
+GET /api/relatorios/nfse?competencia=04/2026
+GET /api/relatorios/nfse?competencia=04/2026&notaAnteriorEmitida=false&formato=XLSX
+```
+
+Parâmetros:
+
+| Nome | Obrigatório | Descrição |
+|---|---|---|
+| `competencia` | Sim | Competência no formato `MM/AAAA` |
+| `notaAnteriorEmitida` | Não | Filtra registros com ou sem nota anterior inferida |
+| `formato` | Não | `JSON`, `CSV` ou `XLSX`; padrão `JSON` |
+
+Contrato JSON:
+
+```json
+[
+  {
+    "nome": "Ana Souza",
+    "cpfCnpj": "11122233344",
+    "valorPago": 250.00,
+    "competencia": "04/2026",
+    "descricaoServico": "Aulas de Pilates - Competência 04/2026",
+    "notaAnteriorEmitida": false,
+    "dataPagamento": "2026-04-10",
+    "observacoes": ""
+  }
+]
+```
+
+CSV e XLSX retornam `Content-Disposition: attachment` com nome `relatorio-nfse-{MM-AAAA}.{ext}`.
+
 ---
 
 ## 7. Documentação Interativa
@@ -889,6 +940,15 @@ curl -s -X PATCH http://localhost:8080/pacientes/1/inativar \
 curl -s -OJ "http://localhost:8080/profissionais/1/relatorio-pagamento/pdf?inicio=2025-02-01&fim=2025-02-28" \
   -H "Authorization: Bearer $TOKEN"
 curl -s -OJ "http://localhost:8080/profissionais/1/relatorio-pagamento/xlsx?inicio=2025-02-01&fim=2025-02-28" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+### Gerar relatório de NFSE
+
+```bash
+curl -s "http://localhost:8080/api/relatorios/nfse?competencia=04/2026" \
+  -H "Authorization: Bearer $TOKEN" | jq
+curl -s -OJ "http://localhost:8080/api/relatorios/nfse?competencia=04/2026&formato=XLSX" \
   -H "Authorization: Bearer $TOKEN"
 ```
 

--- a/src/main/java/com/carlesso/pilatesapi/config/SecurityConfig.java
+++ b/src/main/java/com/carlesso/pilatesapi/config/SecurityConfig.java
@@ -82,7 +82,7 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(List.of(allowedOrigins.split(",")));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "Accept"));
-        configuration.setExposedHeaders(List.of("Location"));
+        configuration.setExposedHeaders(List.of("Location", "Content-Disposition"));
         configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/carlesso/pilatesapi/controller/RelatorioNfseController.java
+++ b/src/main/java/com/carlesso/pilatesapi/controller/RelatorioNfseController.java
@@ -1,0 +1,77 @@
+package com.carlesso.pilatesapi.controller;
+
+import com.carlesso.pilatesapi.dto.RelatorioNfseResponseDTO;
+import com.carlesso.pilatesapi.service.RelatorioNfseExporterService;
+import com.carlesso.pilatesapi.service.RelatorioNfseService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Locale;
+
+@Tag(name = "Relatórios", description = "Relatórios financeiros e fiscais")
+@RestController
+@RequestMapping("/api/relatorios/nfse")
+public class RelatorioNfseController {
+
+    private static final MediaType CSV_MEDIA_TYPE = MediaType.parseMediaType("text/csv");
+    private static final MediaType XLSX_MEDIA_TYPE = MediaType.parseMediaType(
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+
+    private final RelatorioNfseService service;
+    private final RelatorioNfseExporterService exporter;
+
+    public RelatorioNfseController(RelatorioNfseService service, RelatorioNfseExporterService exporter) {
+        this.service = service;
+        this.exporter = exporter;
+    }
+
+    @Operation(summary = "Gerar relatório de emissão de NFSEs",
+            description = "Retorna pacientes com pagamentos confirmados na competência informada, com dados para emissão manual de NFSE.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Relatório gerado com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Competência ou formato inválido"),
+            @ApiResponse(responseCode = "422", description = "Dados obrigatórios ausentes para emissão")
+    })
+    @GetMapping
+    public ResponseEntity<?> gerar(
+            @Parameter(description = "Competência no formato MM/AAAA", required = true)
+            @RequestParam String competencia,
+            @Parameter(description = "Filtra registros com ou sem nota anterior emitida")
+            @RequestParam(required = false) Boolean notaAnteriorEmitida,
+            @Parameter(description = "Formato de saída: JSON, CSV ou XLSX")
+            @RequestParam(defaultValue = "JSON") String formato) {
+        List<RelatorioNfseResponseDTO> relatorio = service.gerar(competencia, notaAnteriorEmitida);
+        String formatoNormalizado = formato.toUpperCase(Locale.ROOT);
+
+        return switch (formatoNormalizado) {
+            case "JSON" -> ResponseEntity.ok(relatorio);
+            case "CSV" -> arquivo(exporter.exportarCsv(relatorio), CSV_MEDIA_TYPE, nomeArquivo(competencia, "csv"));
+            case "XLSX" -> arquivo(exporter.exportarXlsx(relatorio), XLSX_MEDIA_TYPE, nomeArquivo(competencia, "xlsx"));
+            default -> throw new IllegalArgumentException("formato deve ser JSON, CSV ou XLSX");
+        };
+    }
+
+    private ResponseEntity<byte[]> arquivo(byte[] content, MediaType mediaType, String filename) {
+        return ResponseEntity.ok()
+                .contentType(mediaType)
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        ContentDisposition.attachment().filename(filename).build().toString())
+                .body(content);
+    }
+
+    private String nomeArquivo(String competencia, String extensao) {
+        return "relatorio-nfse-" + competencia.replace("/", "-") + "." + extensao;
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/dto/RelatorioNfseResponseDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/RelatorioNfseResponseDTO.java
@@ -1,0 +1,16 @@
+package com.carlesso.pilatesapi.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record RelatorioNfseResponseDTO(
+        String nome,
+        String cpfCnpj,
+        BigDecimal valorPago,
+        String competencia,
+        String descricaoServico,
+        Boolean notaAnteriorEmitida,
+        LocalDate dataPagamento,
+        String observacoes
+) {
+}

--- a/src/main/java/com/carlesso/pilatesapi/repository/PagamentoRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/PagamentoRepository.java
@@ -35,8 +35,15 @@ public interface PagamentoRepository extends JpaRepository<Pagamento, Long> {
             @Param("inicio") LocalDate inicio,
             @Param("fim") LocalDate fim);
 
-    boolean existsByPacienteIdAndStatusAndDataPagamentoBefore(
-            Long pacienteId,
-            StatusPagamento status,
-            LocalDate dataPagamento);
+    @Query("""
+            select distinct p.paciente.id
+            from Pagamento p
+            where p.status = :status
+              and p.dataPagamento < :dataPagamento
+              and p.paciente.id in :pacienteIds
+            """)
+    List<Long> findPacienteIdsComPagamentoConfirmadoAntes(
+            @Param("pacienteIds") List<Long> pacienteIds,
+            @Param("status") StatusPagamento status,
+            @Param("dataPagamento") LocalDate dataPagamento);
 }

--- a/src/main/java/com/carlesso/pilatesapi/repository/PagamentoRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/PagamentoRepository.java
@@ -4,6 +4,8 @@ import com.carlesso.pilatesapi.entity.Pagamento;
 import com.carlesso.pilatesapi.entity.Plano;
 import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -18,4 +20,23 @@ public interface PagamentoRepository extends JpaRepository<Pagamento, Long> {
     boolean existsByPlanoAndPeriodoInicio(Plano plano, LocalDate periodoInicio);
 
     Optional<Pagamento> findTopByPlanoOrderByPeriodoFimDesc(Plano plano);
+
+    @Query("""
+            select p
+            from Pagamento p
+            join fetch p.paciente paciente
+            where p.status = :status
+              and p.dataPagamento between :inicio and :fim
+              and paciente.ativo = true
+            order by paciente.nome asc, p.dataPagamento asc, p.id asc
+            """)
+    List<Pagamento> findPagamentosConfirmadosParaRelatorioNfse(
+            @Param("status") StatusPagamento status,
+            @Param("inicio") LocalDate inicio,
+            @Param("fim") LocalDate fim);
+
+    boolean existsByPacienteIdAndStatusAndDataPagamentoBefore(
+            Long pacienteId,
+            StatusPagamento status,
+            LocalDate dataPagamento);
 }

--- a/src/main/java/com/carlesso/pilatesapi/service/RelatorioNfseExporterService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/RelatorioNfseExporterService.java
@@ -101,7 +101,15 @@ public class RelatorioNfseExporterService {
         if (value == null) {
             return "";
         }
-        String escaped = value.replace("\"", "\"\"");
+        String escaped = neutralizarFormula(value).replace("\"", "\"\"");
         return "\"" + escaped + "\"";
+    }
+
+    private String neutralizarFormula(String value) {
+        String trimmed = value.stripLeading();
+        if (!trimmed.isEmpty() && "=+-@".indexOf(trimmed.charAt(0)) >= 0) {
+            return "'" + value;
+        }
+        return value;
     }
 }

--- a/src/main/java/com/carlesso/pilatesapi/service/RelatorioNfseExporterService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/RelatorioNfseExporterService.java
@@ -1,0 +1,107 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.RelatorioNfseResponseDTO;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+public class RelatorioNfseExporterService {
+
+    private static final DateTimeFormatter DATE = DateTimeFormatter.ISO_LOCAL_DATE;
+    private static final String[] HEADERS = {
+            "Nome",
+            "CPF/CNPJ",
+            "ValorPago",
+            "Competencia",
+            "DescricaoServico",
+            "NotaAnteriorEmitida",
+            "DataPagamento",
+            "Observacoes"
+    };
+
+    public byte[] exportarCsv(List<RelatorioNfseResponseDTO> itens) {
+        StringBuilder csv = new StringBuilder();
+        csv.append(String.join(",", HEADERS)).append("\n");
+
+        for (RelatorioNfseResponseDTO item : itens) {
+            csv.append(Stream.of(
+                            item.nome(),
+                            item.cpfCnpj(),
+                            item.valorPago().toPlainString(),
+                            item.competencia(),
+                            item.descricaoServico(),
+                            item.notaAnteriorEmitida().toString(),
+                            item.dataPagamento().format(DATE),
+                            item.observacoes())
+                    .map(this::csv)
+                    .collect(Collectors.joining(",")));
+            csv.append("\n");
+        }
+
+        return csv.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    public byte[] exportarXlsx(List<RelatorioNfseResponseDTO> itens) {
+        try (Workbook workbook = new XSSFWorkbook();
+             ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            Sheet sheet = workbook.createSheet("NFSE");
+            CellStyle headerStyle = criarHeaderStyle(workbook);
+
+            Row header = sheet.createRow(0);
+            for (int i = 0; i < HEADERS.length; i++) {
+                header.createCell(i).setCellValue(HEADERS[i]);
+                header.getCell(i).setCellStyle(headerStyle);
+            }
+
+            int rowIndex = 1;
+            for (RelatorioNfseResponseDTO item : itens) {
+                Row row = sheet.createRow(rowIndex++);
+                row.createCell(0).setCellValue(item.nome());
+                row.createCell(1).setCellValue(item.cpfCnpj());
+                row.createCell(2).setCellValue(item.valorPago().doubleValue());
+                row.createCell(3).setCellValue(item.competencia());
+                row.createCell(4).setCellValue(item.descricaoServico());
+                row.createCell(5).setCellValue(item.notaAnteriorEmitida());
+                row.createCell(6).setCellValue(item.dataPagamento().format(DATE));
+                row.createCell(7).setCellValue(item.observacoes());
+            }
+
+            for (int i = 0; i < HEADERS.length; i++) {
+                sheet.autoSizeColumn(i);
+            }
+
+            workbook.write(out);
+            return out.toByteArray();
+        } catch (Exception e) {
+            throw new IllegalStateException("Falha ao gerar XLSX do relatório de NFSE", e);
+        }
+    }
+
+    private CellStyle criarHeaderStyle(Workbook workbook) {
+        CellStyle style = workbook.createCellStyle();
+        Font font = workbook.createFont();
+        font.setBold(true);
+        style.setFont(font);
+        return style;
+    }
+
+    private String csv(String value) {
+        if (value == null) {
+            return "";
+        }
+        String escaped = value.replace("\"", "\"\"");
+        return "\"" + escaped + "\"";
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/service/RelatorioNfseService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/RelatorioNfseService.java
@@ -14,7 +14,9 @@ import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Service
 public class RelatorioNfseService {
@@ -32,10 +34,14 @@ public class RelatorioNfseService {
         YearMonth periodo = parseCompetencia(competencia);
         LocalDate inicio = periodo.atDay(1);
         LocalDate fim = periodo.atEndOfMonth();
+        List<Pagamento> pagamentos = pagamentoRepository.findPagamentosConfirmadosParaRelatorioNfse(
+                StatusPagamento.PAGO,
+                inicio,
+                fim);
+        Set<Long> pacientesComPagamentoAnterior = buscarPacientesComPagamentoAnterior(pagamentos, inicio);
 
-        return pagamentoRepository.findPagamentosConfirmadosParaRelatorioNfse(StatusPagamento.PAGO, inicio, fim)
-                .stream()
-                .map(pagamento -> montarItem(pagamento, competencia))
+        return pagamentos.stream()
+                .map(pagamento -> montarItem(pagamento, competencia, pacientesComPagamentoAnterior))
                 .filter(item -> notaAnteriorEmitida == null
                         || Objects.equals(item.notaAnteriorEmitida(), notaAnteriorEmitida))
                 .toList();
@@ -54,14 +60,30 @@ public class RelatorioNfseService {
         return YearMonth.of(ano, mes);
     }
 
-    private RelatorioNfseResponseDTO montarItem(Pagamento pagamento, String competencia) {
+    private Set<Long> buscarPacientesComPagamentoAnterior(List<Pagamento> pagamentos, LocalDate inicioCompetencia) {
+        List<Long> pacienteIds = pagamentos.stream()
+                .map(pagamento -> pagamento.getPaciente().getId())
+                .distinct()
+                .toList();
+
+        if (pacienteIds.isEmpty()) {
+            return Set.of();
+        }
+
+        return pagamentoRepository.findPacienteIdsComPagamentoConfirmadoAntes(
+                        pacienteIds,
+                        StatusPagamento.PAGO,
+                        inicioCompetencia)
+                .stream()
+                .collect(Collectors.toSet());
+    }
+
+    private RelatorioNfseResponseDTO montarItem(
+            Pagamento pagamento,
+            String competencia,
+            Set<Long> pacientesComPagamentoAnterior) {
         Paciente paciente = pagamento.getPaciente();
         validarDadosParaEmissao(pagamento, paciente);
-
-        boolean notaAnteriorEmitida = pagamentoRepository.existsByPacienteIdAndStatusAndDataPagamentoBefore(
-                paciente.getId(),
-                StatusPagamento.PAGO,
-                competenciaInicio(competencia));
 
         return new RelatorioNfseResponseDTO(
                 paciente.getNome(),
@@ -69,16 +91,10 @@ public class RelatorioNfseService {
                 pagamento.getValor(),
                 competencia,
                 "Aulas de Pilates - Competência " + competencia,
-                notaAnteriorEmitida,
+                pacientesComPagamentoAnterior.contains(paciente.getId()),
                 pagamento.getDataPagamento(),
                 ""
         );
-    }
-
-    private LocalDate competenciaInicio(String competencia) {
-        int mes = Integer.parseInt(competencia.substring(0, 2));
-        int ano = Integer.parseInt(competencia.substring(3));
-        return YearMonth.of(ano, mes).atDay(1);
     }
 
     private void validarDadosParaEmissao(Pagamento pagamento, Paciente paciente) {

--- a/src/main/java/com/carlesso/pilatesapi/service/RelatorioNfseService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/RelatorioNfseService.java
@@ -1,0 +1,98 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.RelatorioNfseResponseDTO;
+import com.carlesso.pilatesapi.entity.Paciente;
+import com.carlesso.pilatesapi.entity.Pagamento;
+import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
+import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.repository.PagamentoRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+@Service
+public class RelatorioNfseService {
+
+    private static final Pattern COMPETENCIA_PATTERN = Pattern.compile("^(0[1-9]|1[0-2])/\\d{4}$");
+
+    private final PagamentoRepository pagamentoRepository;
+
+    public RelatorioNfseService(PagamentoRepository pagamentoRepository) {
+        this.pagamentoRepository = pagamentoRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public List<RelatorioNfseResponseDTO> gerar(String competencia, Boolean notaAnteriorEmitida) {
+        YearMonth periodo = parseCompetencia(competencia);
+        LocalDate inicio = periodo.atDay(1);
+        LocalDate fim = periodo.atEndOfMonth();
+
+        return pagamentoRepository.findPagamentosConfirmadosParaRelatorioNfse(StatusPagamento.PAGO, inicio, fim)
+                .stream()
+                .map(pagamento -> montarItem(pagamento, competencia))
+                .filter(item -> notaAnteriorEmitida == null
+                        || Objects.equals(item.notaAnteriorEmitida(), notaAnteriorEmitida))
+                .toList();
+    }
+
+    private YearMonth parseCompetencia(String competencia) {
+        if (competencia == null || competencia.isBlank()) {
+            throw new IllegalArgumentException("competencia é obrigatória");
+        }
+        if (!COMPETENCIA_PATTERN.matcher(competencia).matches()) {
+            throw new IllegalArgumentException("competencia deve estar no formato MM/AAAA");
+        }
+
+        int mes = Integer.parseInt(competencia.substring(0, 2));
+        int ano = Integer.parseInt(competencia.substring(3));
+        return YearMonth.of(ano, mes);
+    }
+
+    private RelatorioNfseResponseDTO montarItem(Pagamento pagamento, String competencia) {
+        Paciente paciente = pagamento.getPaciente();
+        validarDadosParaEmissao(pagamento, paciente);
+
+        boolean notaAnteriorEmitida = pagamentoRepository.existsByPacienteIdAndStatusAndDataPagamentoBefore(
+                paciente.getId(),
+                StatusPagamento.PAGO,
+                competenciaInicio(competencia));
+
+        return new RelatorioNfseResponseDTO(
+                paciente.getNome(),
+                paciente.getCpf(),
+                pagamento.getValor(),
+                competencia,
+                "Aulas de Pilates - Competência " + competencia,
+                notaAnteriorEmitida,
+                pagamento.getDataPagamento(),
+                ""
+        );
+    }
+
+    private LocalDate competenciaInicio(String competencia) {
+        int mes = Integer.parseInt(competencia.substring(0, 2));
+        int ano = Integer.parseInt(competencia.substring(3));
+        return YearMonth.of(ano, mes).atDay(1);
+    }
+
+    private void validarDadosParaEmissao(Pagamento pagamento, Paciente paciente) {
+        if (paciente.getNome() == null || paciente.getNome().isBlank()) {
+            throw new BusinessException("Nome do paciente deve estar preenchido para emissão da NFSE");
+        }
+        if (paciente.getCpf() == null || paciente.getCpf().isBlank()) {
+            throw new BusinessException("CPF/CNPJ deve estar preenchido para emissão da NFSE");
+        }
+        if (pagamento.getValor() == null || pagamento.getValor().compareTo(BigDecimal.ZERO) <= 0) {
+            throw new BusinessException("ValorPago deve ser maior que zero para emissão da NFSE");
+        }
+        if (pagamento.getDataPagamento() == null) {
+            throw new BusinessException("DataPagamento deve estar preenchida para emissão da NFSE");
+        }
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/controller/RelatorioNfseControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/RelatorioNfseControllerTest.java
@@ -1,0 +1,136 @@
+package com.carlesso.pilatesapi.controller;
+
+import com.carlesso.pilatesapi.dto.RelatorioNfseResponseDTO;
+import com.carlesso.pilatesapi.service.CustomUserDetailsService;
+import com.carlesso.pilatesapi.service.JwtService;
+import com.carlesso.pilatesapi.service.RelatorioNfseExporterService;
+import com.carlesso.pilatesapi.service.RelatorioNfseService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RelatorioNfseController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class RelatorioNfseControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    RelatorioNfseService service;
+
+    @MockitoBean
+    RelatorioNfseExporterService exporter;
+
+    @MockitoBean
+    JwtService jwtService;
+
+    @MockitoBean
+    CustomUserDetailsService customUserDetailsService;
+
+    @Test
+    void gerar_json_deveRetornarRelatorio() throws Exception {
+        when(service.gerar("04/2026", null)).thenReturn(List.of(item()));
+
+        mockMvc.perform(get("/api/relatorios/nfse")
+                        .param("competencia", "04/2026"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].nome").value("Ana Souza"))
+                .andExpect(jsonPath("$[0].cpfCnpj").value("11122233344"))
+                .andExpect(jsonPath("$[0].valorPago").value(250.00))
+                .andExpect(jsonPath("$[0].competencia").value("04/2026"))
+                .andExpect(jsonPath("$[0].notaAnteriorEmitida").value(false));
+
+        verify(service).gerar("04/2026", null);
+    }
+
+    @Test
+    void gerar_comFiltroNotaAnterior_deveRepassarParametro() throws Exception {
+        when(service.gerar("04/2026", true)).thenReturn(List.of(item()));
+
+        mockMvc.perform(get("/api/relatorios/nfse")
+                        .param("competencia", "04/2026")
+                        .param("notaAnteriorEmitida", "true"))
+                .andExpect(status().isOk());
+
+        verify(service).gerar("04/2026", true);
+    }
+
+    @Test
+    void gerar_csv_deveRetornarArquivo() throws Exception {
+        var relatorio = List.of(item());
+        when(service.gerar("04/2026", null)).thenReturn(relatorio);
+        when(exporter.exportarCsv(relatorio)).thenReturn("Nome\nAna".getBytes());
+
+        mockMvc.perform(get("/api/relatorios/nfse")
+                        .param("competencia", "04/2026")
+                        .param("formato", "CSV"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("text/csv"))
+                .andExpect(header().string("Content-Disposition",
+                        "attachment; filename=\"relatorio-nfse-04-2026.csv\""));
+    }
+
+    @Test
+    void gerar_xlsx_deveRetornarArquivo() throws Exception {
+        var relatorio = List.of(item());
+        when(service.gerar("04/2026", null)).thenReturn(relatorio);
+        when(exporter.exportarXlsx(relatorio)).thenReturn(new byte[]{1, 2, 3});
+
+        mockMvc.perform(get("/api/relatorios/nfse")
+                        .param("competencia", "04/2026")
+                        .param("formato", "XLSX"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+                .andExpect(header().string("Content-Disposition",
+                        "attachment; filename=\"relatorio-nfse-04-2026.xlsx\""));
+    }
+
+    @Test
+    void gerar_formatoInvalido_deveRetornar400() throws Exception {
+        when(service.gerar("04/2026", null)).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/relatorios/nfse")
+                        .param("competencia", "04/2026")
+                        .param("formato", "PDF"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.erro").value("formato deve ser JSON, CSV ou XLSX"));
+    }
+
+    @Test
+    void gerar_semCompetencia_deveRetornar400() throws Exception {
+        mockMvc.perform(get("/api/relatorios/nfse"))
+                .andExpect(status().isBadRequest());
+    }
+
+    private RelatorioNfseResponseDTO item() {
+        return new RelatorioNfseResponseDTO(
+                "Ana Souza",
+                "11122233344",
+                new BigDecimal("250.00"),
+                "04/2026",
+                "Aulas de Pilates - Competência 04/2026",
+                false,
+                LocalDate.of(2026, 4, 10),
+                ""
+        );
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/repository/PagamentoRepositoryTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/repository/PagamentoRepositoryTest.java
@@ -56,18 +56,22 @@ class PagamentoRepositoryTest {
     }
 
     @Test
-    void existsByPacienteIdAndStatusAndDataPagamentoBefore_indicaPagamentoAnterior() {
+    void findPacienteIdsComPagamentoConfirmadoAntes_retornaPacientesComPagamentoAnterior() {
         Paciente paciente = entityManager.persist(paciente("Ana Ativa", "ana@email.com", "11122233344", true));
+        Paciente pacienteSemAnterior = entityManager.persist(paciente("Bia Ativa", "bia@email.com", "55566677788", true));
         Plano plano = entityManager.persist(plano(paciente));
+        Plano planoSemAnterior = entityManager.persist(plano(pacienteSemAnterior));
         entityManager.persist(pagamento(paciente, plano, StatusPagamento.PAGO, LocalDate.of(2026, 3, 10)));
+        entityManager.persist(pagamento(pacienteSemAnterior, planoSemAnterior, StatusPagamento.PAGO,
+                LocalDate.of(2026, 4, 10)));
         entityManager.flush();
 
-        boolean existeAnterior = repository.existsByPacienteIdAndStatusAndDataPagamentoBefore(
-                paciente.getId(),
+        var pacienteIds = repository.findPacienteIdsComPagamentoConfirmadoAntes(
+                List.of(paciente.getId(), pacienteSemAnterior.getId()),
                 StatusPagamento.PAGO,
                 LocalDate.of(2026, 4, 1));
 
-        assertThat(existeAnterior).isTrue();
+        assertThat(pacienteIds).containsExactly(paciente.getId());
     }
 
     private Paciente paciente(String nome, String email, String cpf, boolean ativo) {

--- a/src/test/java/com/carlesso/pilatesapi/repository/PagamentoRepositoryTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/repository/PagamentoRepositoryTest.java
@@ -1,0 +1,105 @@
+package com.carlesso.pilatesapi.repository;
+
+import com.carlesso.pilatesapi.entity.Paciente;
+import com.carlesso.pilatesapi.entity.Pagamento;
+import com.carlesso.pilatesapi.entity.Plano;
+import com.carlesso.pilatesapi.entity.enums.FrequenciaSemanal;
+import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
+import com.carlesso.pilatesapi.entity.enums.TipoPagamento;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest(showSql = false)
+class PagamentoRepositoryTest {
+
+    @Autowired
+    PagamentoRepository repository;
+
+    @Autowired
+    TestEntityManager entityManager;
+
+    @Test
+    void findPagamentosConfirmadosParaRelatorioNfse_retornaApenasPagosAtivosNaCompetencia() {
+        Paciente pacienteAtivo = entityManager.persist(paciente("Ana Ativa", "ana@email.com", "11122233344", true));
+        Paciente pacienteInativo = entityManager.persist(paciente("Bia Inativa", "bia@email.com", "55566677788", false));
+        Plano planoAtivo = entityManager.persist(plano(pacienteAtivo));
+        Plano planoInativo = entityManager.persist(plano(pacienteInativo));
+
+        Pagamento pagoNaCompetencia = entityManager.persist(pagamento(pacienteAtivo, planoAtivo,
+                StatusPagamento.PAGO, LocalDate.of(2026, 4, 10)));
+        entityManager.persist(pagamento(pacienteAtivo, planoAtivo, StatusPagamento.PENDENTE,
+                LocalDate.of(2026, 4, 12)));
+        entityManager.persist(pagamento(pacienteAtivo, planoAtivo, StatusPagamento.PAGO,
+                LocalDate.of(2026, 3, 31)));
+        entityManager.persist(pagamento(pacienteInativo, planoInativo, StatusPagamento.PAGO,
+                LocalDate.of(2026, 4, 15)));
+        entityManager.flush();
+        entityManager.clear();
+
+        var pagamentos = repository.findPagamentosConfirmadosParaRelatorioNfse(
+                StatusPagamento.PAGO,
+                LocalDate.of(2026, 4, 1),
+                LocalDate.of(2026, 4, 30));
+
+        assertThat(pagamentos)
+                .extracting(Pagamento::getId)
+                .containsExactly(pagoNaCompetencia.getId());
+    }
+
+    @Test
+    void existsByPacienteIdAndStatusAndDataPagamentoBefore_indicaPagamentoAnterior() {
+        Paciente paciente = entityManager.persist(paciente("Ana Ativa", "ana@email.com", "11122233344", true));
+        Plano plano = entityManager.persist(plano(paciente));
+        entityManager.persist(pagamento(paciente, plano, StatusPagamento.PAGO, LocalDate.of(2026, 3, 10)));
+        entityManager.flush();
+
+        boolean existeAnterior = repository.existsByPacienteIdAndStatusAndDataPagamentoBefore(
+                paciente.getId(),
+                StatusPagamento.PAGO,
+                LocalDate.of(2026, 4, 1));
+
+        assertThat(existeAnterior).isTrue();
+    }
+
+    private Paciente paciente(String nome, String email, String cpf, boolean ativo) {
+        Paciente paciente = new Paciente();
+        paciente.setNome(nome);
+        paciente.setEmail(email);
+        paciente.setCpf(cpf);
+        paciente.setAtivo(ativo);
+        return paciente;
+    }
+
+    private Plano plano(Paciente paciente) {
+        Plano plano = new Plano();
+        plano.setPaciente(paciente);
+        plano.setTipo(TipoPagamento.MENSAL);
+        plano.setValor(new BigDecimal("250.00"));
+        plano.setFrequenciaSemanal(FrequenciaSemanal.UMA_VEZ);
+        plano.setDiasSemana(List.of(DayOfWeek.MONDAY));
+        plano.setDataInicio(LocalDate.of(2026, 1, 1));
+        return plano;
+    }
+
+    private Pagamento pagamento(Paciente paciente, Plano plano, StatusPagamento status, LocalDate dataPagamento) {
+        Pagamento pagamento = new Pagamento();
+        pagamento.setPaciente(paciente);
+        pagamento.setPlano(plano);
+        pagamento.setValor(new BigDecimal("250.00"));
+        pagamento.setStatus(status);
+        pagamento.setDataPagamento(dataPagamento);
+        pagamento.setDataVencimento(dataPagamento.plusDays(5));
+        pagamento.setPeriodoInicio(dataPagamento.withDayOfMonth(1));
+        pagamento.setPeriodoFim(dataPagamento.withDayOfMonth(dataPagamento.lengthOfMonth()));
+        return pagamento;
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/service/RelatorioNfseExporterServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/RelatorioNfseExporterServiceTest.java
@@ -26,6 +26,27 @@ class RelatorioNfseExporterServiceTest {
     }
 
     @Test
+    void exportarCsv_deveNeutralizarFormulaInjection() {
+        var itemMalicioso = new RelatorioNfseResponseDTO(
+                "=IMPORTDATA(\"https://example.com\")",
+                "+5511999999999",
+                new BigDecimal("250.00"),
+                "04/2026",
+                "@SUM(1,1)",
+                false,
+                LocalDate.of(2026, 4, 10),
+                "-observacao"
+        );
+
+        String content = new String(service.exportarCsv(List.of(itemMalicioso)));
+
+        assertThat(content).contains("\"'=IMPORTDATA(\"\"https://example.com\"\")\"");
+        assertThat(content).contains("\"'+5511999999999\"");
+        assertThat(content).contains("\"'@SUM(1,1)\"");
+        assertThat(content).contains("\"'-observacao\"");
+    }
+
+    @Test
     void exportarXlsx_deveGerarPlanilhaNfse() throws Exception {
         byte[] xlsx = service.exportarXlsx(List.of(item()));
 

--- a/src/test/java/com/carlesso/pilatesapi/service/RelatorioNfseExporterServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/RelatorioNfseExporterServiceTest.java
@@ -1,0 +1,57 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.RelatorioNfseResponseDTO;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RelatorioNfseExporterServiceTest {
+
+    private final RelatorioNfseExporterService service = new RelatorioNfseExporterService();
+
+    @Test
+    void exportarCsv_deveGerarCabecalhoEConteudo() {
+        byte[] csv = service.exportarCsv(List.of(item()));
+
+        String content = new String(csv);
+        assertThat(content).contains("Nome,CPF/CNPJ,ValorPago,Competencia");
+        assertThat(content).contains("\"Ana Souza\",\"11122233344\",\"250.00\",\"04/2026\"");
+    }
+
+    @Test
+    void exportarXlsx_deveGerarPlanilhaNfse() throws Exception {
+        byte[] xlsx = service.exportarXlsx(List.of(item()));
+
+        try (Workbook workbook = new XSSFWorkbook(new ByteArrayInputStream(xlsx))) {
+            assertThat(workbook.getNumberOfSheets()).isEqualTo(1);
+            assertThat(workbook.getSheetName(0)).isEqualTo("NFSE");
+            var sheet = workbook.getSheet("NFSE");
+
+            assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("Nome");
+            assertThat(sheet.getRow(0).getCell(5).getStringCellValue()).isEqualTo("NotaAnteriorEmitida");
+            assertThat(sheet.getRow(1).getCell(0).getStringCellValue()).isEqualTo("Ana Souza");
+            assertThat(sheet.getRow(1).getCell(2).getNumericCellValue()).isEqualTo(250.00d);
+            assertThat(sheet.getRow(1).getCell(5).getBooleanCellValue()).isFalse();
+        }
+    }
+
+    private RelatorioNfseResponseDTO item() {
+        return new RelatorioNfseResponseDTO(
+                "Ana Souza",
+                "11122233344",
+                new BigDecimal("250.00"),
+                "04/2026",
+                "Aulas de Pilates - Competência 04/2026",
+                false,
+                LocalDate.of(2026, 4, 10),
+                ""
+        );
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/service/RelatorioNfseServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/RelatorioNfseServiceTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -40,11 +41,11 @@ class RelatorioNfseServiceTest {
                 LocalDate.of(2026, 4, 1),
                 LocalDate.of(2026, 4, 30)))
                 .thenReturn(List.of(pagamento));
-        when(pagamentoRepository.existsByPacienteIdAndStatusAndDataPagamentoBefore(
-                1L,
+        when(pagamentoRepository.findPacienteIdsComPagamentoConfirmadoAntes(
+                List.of(1L),
                 StatusPagamento.PAGO,
                 LocalDate.of(2026, 4, 1)))
-                .thenReturn(true);
+                .thenReturn(List.of(1L));
 
         var relatorio = service.gerar("04/2026", null);
 
@@ -58,6 +59,10 @@ class RelatorioNfseServiceTest {
             assertThat(item.dataPagamento()).isEqualTo(LocalDate.of(2026, 4, 10));
             assertThat(item.observacoes()).isEmpty();
         });
+        verify(pagamentoRepository).findPacienteIdsComPagamentoConfirmadoAntes(
+                List.of(1L),
+                StatusPagamento.PAGO,
+                LocalDate.of(2026, 4, 1));
     }
 
     @Test
@@ -73,16 +78,11 @@ class RelatorioNfseServiceTest {
                 LocalDate.of(2026, 4, 1),
                 LocalDate.of(2026, 4, 30)))
                 .thenReturn(List.of(comNotaAnterior, semNotaAnterior));
-        when(pagamentoRepository.existsByPacienteIdAndStatusAndDataPagamentoBefore(
-                1L,
+        when(pagamentoRepository.findPacienteIdsComPagamentoConfirmadoAntes(
+                List.of(1L, 2L),
                 StatusPagamento.PAGO,
                 LocalDate.of(2026, 4, 1)))
-                .thenReturn(true);
-        when(pagamentoRepository.existsByPacienteIdAndStatusAndDataPagamentoBefore(
-                2L,
-                StatusPagamento.PAGO,
-                LocalDate.of(2026, 4, 1)))
-                .thenReturn(false);
+                .thenReturn(List.of(1L));
 
         var relatorio = service.gerar("04/2026", false);
 
@@ -90,6 +90,10 @@ class RelatorioNfseServiceTest {
                 .singleElement()
                 .extracting("nome")
                 .isEqualTo("Bia Lima");
+        verify(pagamentoRepository).findPacienteIdsComPagamentoConfirmadoAntes(
+                List.of(1L, 2L),
+                StatusPagamento.PAGO,
+                LocalDate.of(2026, 4, 1));
     }
 
     @Test
@@ -116,6 +120,11 @@ class RelatorioNfseServiceTest {
                 LocalDate.of(2026, 4, 1),
                 LocalDate.of(2026, 4, 30)))
                 .thenReturn(List.of(pagamento));
+        when(pagamentoRepository.findPacienteIdsComPagamentoConfirmadoAntes(
+                List.of(1L),
+                StatusPagamento.PAGO,
+                LocalDate.of(2026, 4, 1)))
+                .thenReturn(List.of());
 
         assertThatThrownBy(() -> service.gerar("04/2026", null))
                 .isInstanceOf(BusinessException.class)

--- a/src/test/java/com/carlesso/pilatesapi/service/RelatorioNfseServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/RelatorioNfseServiceTest.java
@@ -1,0 +1,148 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.entity.Paciente;
+import com.carlesso.pilatesapi.entity.Pagamento;
+import com.carlesso.pilatesapi.entity.Plano;
+import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
+import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.repository.PagamentoRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RelatorioNfseServiceTest {
+
+    @Mock
+    PagamentoRepository pagamentoRepository;
+
+    @InjectMocks
+    RelatorioNfseService service;
+
+    @Test
+    void gerar_deveRetornarPagamentosConfirmadosDaCompetencia() {
+        Pagamento pagamento = pagamento("Ana Souza", "11122233344", new BigDecimal("250.00"),
+                LocalDate.of(2026, 4, 10));
+
+        when(pagamentoRepository.findPagamentosConfirmadosParaRelatorioNfse(
+                StatusPagamento.PAGO,
+                LocalDate.of(2026, 4, 1),
+                LocalDate.of(2026, 4, 30)))
+                .thenReturn(List.of(pagamento));
+        when(pagamentoRepository.existsByPacienteIdAndStatusAndDataPagamentoBefore(
+                1L,
+                StatusPagamento.PAGO,
+                LocalDate.of(2026, 4, 1)))
+                .thenReturn(true);
+
+        var relatorio = service.gerar("04/2026", null);
+
+        assertThat(relatorio).singleElement().satisfies(item -> {
+            assertThat(item.nome()).isEqualTo("Ana Souza");
+            assertThat(item.cpfCnpj()).isEqualTo("11122233344");
+            assertThat(item.valorPago()).isEqualByComparingTo("250.00");
+            assertThat(item.competencia()).isEqualTo("04/2026");
+            assertThat(item.descricaoServico()).isEqualTo("Aulas de Pilates - Competência 04/2026");
+            assertThat(item.notaAnteriorEmitida()).isTrue();
+            assertThat(item.dataPagamento()).isEqualTo(LocalDate.of(2026, 4, 10));
+            assertThat(item.observacoes()).isEmpty();
+        });
+    }
+
+    @Test
+    void gerar_comFiltroNotaAnteriorEmitida_deveFiltrarResultado() {
+        Pagamento comNotaAnterior = pagamento("Ana Souza", "11122233344", new BigDecimal("250.00"),
+                LocalDate.of(2026, 4, 10));
+        Pagamento semNotaAnterior = pagamento("Bia Lima", "55566677788", new BigDecimal("300.00"),
+                LocalDate.of(2026, 4, 12));
+        ReflectionTestUtils.setField(semNotaAnterior.getPaciente(), "id", 2L);
+
+        when(pagamentoRepository.findPagamentosConfirmadosParaRelatorioNfse(
+                StatusPagamento.PAGO,
+                LocalDate.of(2026, 4, 1),
+                LocalDate.of(2026, 4, 30)))
+                .thenReturn(List.of(comNotaAnterior, semNotaAnterior));
+        when(pagamentoRepository.existsByPacienteIdAndStatusAndDataPagamentoBefore(
+                1L,
+                StatusPagamento.PAGO,
+                LocalDate.of(2026, 4, 1)))
+                .thenReturn(true);
+        when(pagamentoRepository.existsByPacienteIdAndStatusAndDataPagamentoBefore(
+                2L,
+                StatusPagamento.PAGO,
+                LocalDate.of(2026, 4, 1)))
+                .thenReturn(false);
+
+        var relatorio = service.gerar("04/2026", false);
+
+        assertThat(relatorio)
+                .singleElement()
+                .extracting("nome")
+                .isEqualTo("Bia Lima");
+    }
+
+    @Test
+    void gerar_competenciaObrigatoria_deveLancarErro() {
+        assertThatThrownBy(() -> service.gerar(null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("obrigatória");
+    }
+
+    @Test
+    void gerar_competenciaForaDoFormato_deveLancarErro() {
+        assertThatThrownBy(() -> service.gerar("13/2026", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("MM/AAAA");
+    }
+
+    @Test
+    void gerar_semCpf_deveLancarErroDeNegocio() {
+        Pagamento pagamento = pagamento("Ana Souza", "", new BigDecimal("250.00"),
+                LocalDate.of(2026, 4, 10));
+
+        when(pagamentoRepository.findPagamentosConfirmadosParaRelatorioNfse(
+                StatusPagamento.PAGO,
+                LocalDate.of(2026, 4, 1),
+                LocalDate.of(2026, 4, 30)))
+                .thenReturn(List.of(pagamento));
+
+        assertThatThrownBy(() -> service.gerar("04/2026", null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("CPF/CNPJ");
+    }
+
+    private Pagamento pagamento(String nome, String cpf, BigDecimal valor, LocalDate dataPagamento) {
+        Paciente paciente = new Paciente();
+        ReflectionTestUtils.setField(paciente, "id", 1L);
+        paciente.setNome(nome);
+        paciente.setCpf(cpf);
+        paciente.setEmail(nome.toLowerCase().replace(" ", ".") + "@email.com");
+
+        Plano plano = new Plano();
+        ReflectionTestUtils.setField(plano, "id", 1L);
+        plano.setPaciente(paciente);
+
+        Pagamento pagamento = new Pagamento();
+        ReflectionTestUtils.setField(pagamento, "id", 10L);
+        pagamento.setPaciente(paciente);
+        pagamento.setPlano(plano);
+        pagamento.setValor(valor);
+        pagamento.setStatus(StatusPagamento.PAGO);
+        pagamento.setDataPagamento(dataPagamento);
+        pagamento.setDataVencimento(dataPagamento.plusDays(5));
+        pagamento.setPeriodoInicio(dataPagamento.withDayOfMonth(1));
+        pagamento.setPeriodoFim(dataPagamento.withDayOfMonth(dataPagamento.lengthOfMonth()));
+        return pagamento;
+    }
+}


### PR DESCRIPTION
## Resumo
- Adiciona endpoint `GET /api/relatorios/nfse` com `competencia`, filtro opcional `notaAnteriorEmitida` e formatos `JSON`, `CSV` e `XLSX`.
- Gera contrato com Nome, CPF/CNPJ, ValorPago, Competencia, DescricaoServico, NotaAnteriorEmitida, DataPagamento e Observacoes a partir de pagamentos confirmados.
- Infere `notaAnteriorEmitida` pela existência de pagamento confirmado anterior do mesmo paciente, já que o modelo atual não possui entidade de NFSE.
- Atualiza README e documentação técnica/contexto.

## Testes
- `mvn test` (187 testes, 0 falhas)