### PR TITLE
perf: adicionar índices nas foreign keys das tabelas principais (#21)

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -201,6 +201,20 @@ Constraint: `UNIQUE (plano_id, periodo_inicio)`
 
 Constraint: `UNIQUE (paciente_id, data)`
 
+### Índices
+
+| Índice | Tabela / Coluna | Motivação |
+|---|---|---|
+| `idx_planos_paciente_id` | `planos(paciente_id)` | FK sem cobertura de índice composto existente |
+| `idx_pagamentos_paciente_id` | `pagamentos(paciente_id)` | FK sem cobertura de índice composto existente |
+| `idx_aulas_pagamento_id` | `aulas(pagamento_id)` | FK sem cobertura de índice composto existente |
+| `idx_aulas_profissional_id` | `aulas(profissional_id)` | FK nullable; filtra aulas vinculadas a um profissional |
+| `idx_pagamentos_status` | `pagamentos(status)` | Scheduler diário e relatório NFSE filtram por `PENDENTE`/`VENCIDO`/`PAGO` |
+| `idx_pagamentos_data_vencimento` | `pagamentos(data_vencimento)` | Scheduler das 06:00 faz range scan diário nessa coluna |
+| `idx_aulas_realizada` | `aulas(realizada)` | Relatório de pagamento de profissional filtra `realizada = true` |
+
+> **Nota:** colunas `plano_dias_semana(plano_id)`, `pagamentos(plano_id)` e `aulas(paciente_id)` **não** possuem índice dedicado porque já são o prefixo esquerdo de índices compostos existentes (PK e UNIQUE criados em V3, V4 e V5), que o PostgreSQL pode usar para buscas na coluna isolada.
+
 ---
 
 ## Endpoints

--- a/src/main/resources/db/migration/V13__add_indexes_on_foreign_keys.sql
+++ b/src/main/resources/db/migration/V13__add_indexes_on_foreign_keys.sql
@@ -1,0 +1,7 @@
+CREATE INDEX idx_planos_paciente_id ON planos(paciente_id);
+CREATE INDEX idx_plano_dias_semana_plano_id ON plano_dias_semana(plano_id);
+CREATE INDEX idx_pagamentos_paciente_id ON pagamentos(paciente_id);
+CREATE INDEX idx_pagamentos_plano_id ON pagamentos(plano_id);
+CREATE INDEX idx_aulas_paciente_id ON aulas(paciente_id);
+CREATE INDEX idx_aulas_pagamento_id ON aulas(pagamento_id);
+CREATE INDEX idx_aulas_profissional_id ON aulas(profissional_id);

--- a/src/main/resources/db/migration/V13__add_indexes_on_foreign_keys.sql
+++ b/src/main/resources/db/migration/V13__add_indexes_on_foreign_keys.sql
@@ -1,7 +1,14 @@
-CREATE INDEX idx_planos_paciente_id ON planos(paciente_id);
-CREATE INDEX idx_plano_dias_semana_plano_id ON plano_dias_semana(plano_id);
-CREATE INDEX idx_pagamentos_paciente_id ON pagamentos(paciente_id);
-CREATE INDEX idx_pagamentos_plano_id ON pagamentos(plano_id);
-CREATE INDEX idx_aulas_paciente_id ON aulas(paciente_id);
-CREATE INDEX idx_aulas_pagamento_id ON aulas(pagamento_id);
-CREATE INDEX idx_aulas_profissional_id ON aulas(profissional_id);
+-- FK indexes: PostgreSQL does not create indexes on FK columns automatically.
+-- Indexes on plano_dias_semana(plano_id), pagamentos(plano_id) and aulas(paciente_id)
+-- are intentionally omitted: those columns are already covered as the leftmost prefix
+-- of existing composite PK/UNIQUE indexes (V3, V4, V5).
+
+CREATE INDEX IF NOT EXISTS idx_planos_paciente_id ON planos(paciente_id);
+CREATE INDEX IF NOT EXISTS idx_pagamentos_paciente_id ON pagamentos(paciente_id);
+CREATE INDEX IF NOT EXISTS idx_aulas_pagamento_id ON aulas(pagamento_id);
+CREATE INDEX IF NOT EXISTS idx_aulas_profissional_id ON aulas(profissional_id);
+
+-- High-frequency filter columns used by the scheduler and reports.
+CREATE INDEX IF NOT EXISTS idx_pagamentos_status ON pagamentos(status);
+CREATE INDEX IF NOT EXISTS idx_pagamentos_data_vencimento ON pagamentos(data_vencimento);
+CREATE INDEX IF NOT EXISTS idx_aulas_realizada ON aulas(realizada);


### PR DESCRIPTION
### Motivation
- Melhorar a performance de consultas e joins nas tabelas centrais reduzindo custo de busca em colunas de relacionamento.
- Evitar full table scans e acelerar filtros e junções que utilizam colunas de foreign key.

### Description
- Adicionada migration Flyway `V13__add_indexes_on_foreign_keys.sql` em `src/main/resources/db/migration` com índices nas colunas de foreign key principais.
- Criados os índices: `planos(paciente_id)`, `plano_dias_semana(plano_id)`, `pagamentos(paciente_id)`, `pagamentos(plano_id)`, `aulas(paciente_id)`, `aulas(pagamento_id)` e `aulas(profissional_id)`.
- Mudança é apenas a nova migration SQL; nenhum outro código da aplicação foi alterado.

### Testing
- Executada tentativa de testes com `mvn test -q` para validar a build e os testes automatizados.
- Os testes não foram concluídos devido a erro de resolução de dependência no ambiente (HTTP 403 ao baixar `org.springframework.boot:spring-boot-starter-parent:3.4.5`), portanto não foi possível verificar resultados dos testes aqui.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f16b822cb88328b44219218125ef8c)