### PR TITLE
feat: criar endpoint de resumo para dashboard inicial (#40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,15 @@ src/
 │   │   │   ├── AuthController.java          # /auth/register e /auth/login
 │   │   │   ├── UserController.java          # /users/me e CRUD administrativo de usuários
 │   │   │   ├── AdminController.java         # /admin/health
-│   │   │   └── RelatorioNfseController.java # /api/relatorios/nfse
+│   │   │   ├── RelatorioNfseController.java # /api/relatorios/nfse
+│   │   │   └── DashboardController.java     # /dashboard/resumo
 │   │   ├── service/
 │   │   │   ├── PacienteService.java                    # Regras de negócio de pacientes
 │   │   │   ├── ProfissionalService.java                # Regras de negócio de profissionais
 │   │   │   ├── PlanoService.java                       # Regras de plano e frequência
 │   │   │   ├── PagamentoService.java                   # Cobranças, confirmação, vencimentos
 │   │   │   ├── AulaService.java                        # Geração e controle de aulas
+│   │   │   ├── DashboardService.java                   # Contadores e totais para o painel inicial
 │   │   │   ├── RelatorioPagamentoExporterService.java  # Exportação do relatório em PDF e XLSX
 │   │   │   ├── RelatorioNfseService.java               # Relatório de emissão de NFSEs por competência
 │   │   │   ├── RelatorioNfseExporterService.java       # Exportação do relatório de NFSEs em CSV e XLSX
@@ -247,6 +249,12 @@ As demais rotas de negócio exigem `Authorization: Bearer <accessToken>`. Tokens
 |---|---|---|
 | `GET` | `/api/relatorios/nfse` | Gerar relatório de emissão de NFSEs por competência (JSON, CSV ou XLSX) |
 
+### Dashboard
+
+| Método | Endpoint | Descrição |
+|---|---|---|
+| `GET` | `/dashboard/resumo` | Resumo consolidado para o painel inicial (pacientes, profissionais, pagamentos e aulas do mês) |
+
 ### Paginação
 
 Os endpoints de listagem suportam os query params padrão do Spring:
@@ -336,6 +344,38 @@ Os endpoints `GET /profissionais/{id}/relatorio-pagamento/pdf` e `GET /profissio
 | `/relatorio-pagamento/xlsx` | `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` | `attachment; filename="relatorio-pagamento-profissional-{id}-{inicio}-{fim}.xlsx"` |
 
 O XLSX possui três abas: `Resumo`, `Pagamentos` e `Aulas`. O PDF apresenta as mesmas informações em layout único, com tabelas para pagamentos e aulas.
+
+### Resumo do dashboard — contrato JSON
+
+A resposta de `GET /dashboard/resumo` consolida contadores do banco em um único objeto para consumo direto pelo painel inicial:
+
+```json
+{
+  "pacientes": {
+    "totalAtivos": 10,
+    "totalInativos": 2
+  },
+  "profissionais": {
+    "totalAtivos": 3,
+    "totalInativos": 1
+  },
+  "pagamentos": {
+    "totalPendentes": 5,
+    "totalPagos": 8,
+    "totalVencidos": 2,
+    "receitaMesAtual": 1600.00
+  },
+  "aulas": {
+    "totalRealizadasMesAtual": 40,
+    "totalAgendadasMesAtual": 20
+  },
+  "geradoEm": "2026-04-29T10:00:00"
+}
+```
+
+- `receitaMesAtual` — soma dos pagamentos com status `PAGO` e `dataPagamento` dentro do mês corrente.
+- `totalAgendadasMesAtual` — aulas com `realizada = false` e `data` dentro do mês corrente vinculadas a pacientes ativos.
+- `totalRealizadasMesAtual` — aulas com `realizada = true` e `data` dentro do mês corrente vinculadas a pacientes ativos.
 
 ### Relatório de emissão de NFSEs
 
@@ -789,7 +829,7 @@ Formato da resposta de erro:
 
 ## Testes
 
-O projeto possui **203 testes** organizados em vinte e quatro suítes:
+O projeto possui **210 testes** organizados em vinte e seis suítes:
 
 | Suíte | Tipo | Testes |
 |---|---|---|
@@ -814,7 +854,9 @@ O projeto possui **203 testes** organizados em vinte e quatro suítes:
 | `AulaControllerTest` | Controller (`@WebMvcTest`) | 10 |
 | `ProfissionalControllerTest` | Controller (`@WebMvcTest`) | 17 |
 | `RelatorioNfseControllerTest` | Controller (`@WebMvcTest`) | 6 |
-| `SecurityIntegrationTest` | Integração (`@SpringBootTest` + MockMvc + H2) | 21 |
+| `DashboardControllerTest` | Controller (`@WebMvcTest`) | 2 |
+| `DashboardServiceTest` | Unitário (Mockito) | 3 |
+| `SecurityIntegrationTest` | Integração (`@SpringBootTest` + MockMvc + H2) | 23 |
 | `ActuatorTest` | Integração (`@SpringBootTest`) | 3 |
 | `PilatesApiApplicationTests` | Integração (`@SpringBootTest`) | 1 |
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -52,7 +52,8 @@ com.carlesso.pilatesapi
 │   ├── AuthController.java           — registro/login com JWT
 │   ├── UserController.java           — endpoint do usuário autenticado e CRUD administrativo
 │   ├── AdminController.java          — endpoints administrativos
-│   └── RelatorioNfseController.java  — endpoint de relatório de emissão de NFSEs
+│   ├── RelatorioNfseController.java  — endpoint de relatório de emissão de NFSEs
+│   └── DashboardController.java      — endpoint de resumo para o painel inicial
 ├── service
 │   ├── PacienteService.java                    — lógica de negócio de pacientes
 │   ├── ProfissionalService.java                — lógica de negócio de profissionais
@@ -62,6 +63,7 @@ com.carlesso.pilatesapi
 │   ├── RelatorioPagamentoExporterService.java  — exporta o relatório em PDF (OpenPDF) e XLSX (Apache POI)
 │   ├── RelatorioNfseService.java               — monta relatório de NFSEs por competência
 │   ├── RelatorioNfseExporterService.java       — exporta relatório de NFSEs em CSV e XLSX
+│   ├── DashboardService.java                   — consolida contadores e totais para o painel inicial
 │   ├── AuthService.java                        — registro/login, emissão de token e rate limiting
 │   ├── UserService.java                        — CRUD de usuários e definição de perfis de acesso
 │   ├── JwtService.java                         — geração (claims role/userId) e validação de JWT
@@ -105,6 +107,7 @@ com.carlesso.pilatesapi
 │   ├── ProfissionalPagamentoRelatorioDTO.java — relatório de pagamento do profissional (contrato Angular-friendly)
 │   ├── ProfissionalPagamentoAulaDTO.java      — detalhe de aula no relatório
 │   ├── RelatorioNfseResponseDTO.java          — item do relatório de emissão de NFSE
+│   ├── DashboardResumoDTO.java                — resposta do endpoint de resumo do dashboard (record com sub-records)
 │   ├── PlanoRequestDTO.java
 │   ├── PlanoResponseDTO.java
 │   ├── PagamentoRequestDTO.java
@@ -260,6 +263,7 @@ Constraint: `UNIQUE (paciente_id, data)`
 | GET | `/aulas/pagamento/{id}` | Listar aulas do pagamento | 200 |
 | PATCH | `/aulas/{id}/realizar?profissionalId={id}` | Marcar como realizada e opcionalmente vincular profissional | 200 / 404 / 409 / 422 |
 | GET | `/api/relatorios/nfse?competencia=MM/AAAA&notaAnteriorEmitida={true|false}&formato={JSON|CSV|XLSX}` | Gerar relatório de emissão de NFSEs por competência | 200 / 400 / 422 |
+| GET | `/dashboard/resumo` | Resumo consolidado para o painel inicial (pacientes, profissionais, pagamentos, aulas) | 200 / 401 |
 
 Campos obrigatórios no cadastro de pacientes: `nome`, `email`, `cpf`.  
 Campos obrigatórios no cadastro de profissionais: `nome`, `email`, `cpf`, `tipoContrato`, `percentualPagamentoAula`, `dataInicio`.  
@@ -455,9 +459,11 @@ JAVA_HOME=~/jdk mvn spring-boot:run
 | `PagamentoControllerTest` | `@WebMvcTest` + MockMvc | 11 |
 | `AulaControllerTest` | `@WebMvcTest` + MockMvc | 10 |
 | `RelatorioNfseControllerTest` | `@WebMvcTest` + MockMvc | 6 |
+| `DashboardControllerTest` | `@WebMvcTest` + MockMvc | 2 |
+| `DashboardServiceTest` | Unitário (Mockito, sem Spring) | 3 |
 | `AppPropertiesTest` | Unitário (ApplicationContextRunner) | 3 |
 | `GlobalExceptionHandlerTest` | Unitário | 6 |
-| `SecurityIntegrationTest` | `@SpringBootTest` + MockMvc + H2 | 21 |
+| `SecurityIntegrationTest` | `@SpringBootTest` + MockMvc + H2 | 23 |
 | `ActuatorTest` | `@SpringBootTest` + H2 | 3 |
 | `PilatesApiApplicationTests` | `@SpringBootTest` + H2 | 1 |
 

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -77,13 +77,15 @@ src/
 │   │   │   ├── AuthController.java          # /auth/register e /auth/login
 │   │   │   ├── UserController.java          # /users/me e CRUD administrativo
 │   │   │   ├── AdminController.java         # /admin/health
-│   │   │   └── RelatorioNfseController.java # /api/relatorios/nfse
+│   │   │   ├── RelatorioNfseController.java # /api/relatorios/nfse
+│   │   │   └── DashboardController.java     # /dashboard/resumo
 │   │   ├── service/
 │   │   │   ├── PacienteService.java                    # Regras de negócio de pacientes
 │   │   │   ├── ProfissionalService.java                # Regras de negócio de profissionais
 │   │   │   ├── PlanoService.java                       # Regras de plano e frequência
 │   │   │   ├── PagamentoService.java                   # Cobranças, confirmação, vencimentos
 │   │   │   ├── AulaService.java                        # Geração e controle de aulas
+│   │   │   ├── DashboardService.java                   # Contadores e totais para o painel inicial
 │   │   │   ├── RelatorioPagamentoExporterService.java  # Exportação do relatório em PDF e XLSX
 │   │   │   ├── RelatorioNfseService.java               # Relatório de emissão de NFSEs por competência
 │   │   │   ├── RelatorioNfseExporterService.java       # Exportação do relatório de NFSEs em CSV e XLSX
@@ -263,7 +265,19 @@ src/
 - `formato` aceita `JSON`, `CSV` e `XLSX`; CSV e XLSX retornam anexo com nome `relatorio-nfse-{MM-AAAA}.{ext}`
 - Registros sem nome do paciente, CPF/CNPJ, valor positivo ou data de pagamento retornam `422 Unprocessable Entity`
 
-### 4.8 Processos Automáticos (Scheduler)
+### 4.8 Dashboard — Resumo do Painel Inicial
+
+O endpoint `GET /dashboard/resumo` agrega contadores e totais do banco em um único objeto para consumo direto pelo painel inicial do frontend:
+
+- **pacientes**: `totalAtivos` e `totalInativos`
+- **profissionais**: `totalAtivos` e `totalInativos`
+- **pagamentos**: `totalPendentes`, `totalPagos`, `totalVencidos` e `receitaMesAtual` (soma dos pagamentos com status `PAGO` e `dataPagamento` dentro do mês corrente)
+- **aulas**: `totalRealizadasMesAtual` (aulas `realizada = true` de pacientes ativos no mês corrente) e `totalAgendadasMesAtual` (aulas `realizada = false` de pacientes ativos no mês corrente)
+- **geradoEm**: timestamp da geração da resposta
+
+Exige `Authorization: Bearer <token>`.
+
+### 4.9 Processos Automáticos (Scheduler)
 
 | Cron (default) | Ação | Propriedade |
 |---|---|---|

--- a/src/main/java/com/carlesso/pilatesapi/controller/DashboardController.java
+++ b/src/main/java/com/carlesso/pilatesapi/controller/DashboardController.java
@@ -1,0 +1,37 @@
+package com.carlesso.pilatesapi.controller;
+
+import com.carlesso.pilatesapi.dto.DashboardResumoDTO;
+import com.carlesso.pilatesapi.service.DashboardService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Dashboard", description = "Resumo para o painel inicial do estúdio")
+@RestController
+@RequestMapping("/dashboard")
+public class DashboardController {
+
+    private final DashboardService service;
+
+    public DashboardController(DashboardService service) {
+        this.service = service;
+    }
+
+    @Operation(
+            summary = "Resumo do dashboard",
+            description = "Retorna contadores e totais consolidados de pacientes, profissionais, pagamentos e aulas para o painel inicial."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Resumo retornado com sucesso"),
+            @ApiResponse(responseCode = "401", description = "Token ausente ou inválido")
+    })
+    @GetMapping("/resumo")
+    public ResponseEntity<DashboardResumoDTO> resumo() {
+        return ResponseEntity.ok(service.obterResumo());
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/dto/DashboardResumoDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/DashboardResumoDTO.java
@@ -1,0 +1,26 @@
+package com.carlesso.pilatesapi.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record DashboardResumoDTO(
+        PacientesResumo pacientes,
+        ProfissionaisResumo profissionais,
+        PagamentosResumo pagamentos,
+        AulasResumo aulas,
+        LocalDateTime geradoEm
+) {
+
+    public record PacientesResumo(long totalAtivos, long totalInativos) {}
+
+    public record ProfissionaisResumo(long totalAtivos, long totalInativos) {}
+
+    public record PagamentosResumo(
+            long totalPendentes,
+            long totalPagos,
+            long totalVencidos,
+            BigDecimal receitaMesAtual
+    ) {}
+
+    public record AulasResumo(long totalRealizadasMesAtual, long totalAgendadasMesAtual) {}
+}

--- a/src/main/java/com/carlesso/pilatesapi/repository/AulaRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/AulaRepository.java
@@ -76,6 +76,18 @@ public interface AulaRepository extends JpaRepository<Aula, Long> {
             @Param("inicio") LocalDate inicio,
             @Param("fim") LocalDate fim);
 
+    @Query("""
+            select count(a)
+            from Aula a
+            where a.realizada = :realizada
+              and a.data between :inicio and :fim
+              and a.paciente.ativo = true
+            """)
+    long countByRealizadaAndDataBetweenAndPacienteAtivoTrue(
+            @Param("realizada") boolean realizada,
+            @Param("inicio") LocalDate inicio,
+            @Param("fim") LocalDate fim);
+
     interface ProfissionalPagamentoAulaProjection {
         Long getAulaId();
         LocalDate getData();

--- a/src/main/java/com/carlesso/pilatesapi/repository/PacienteRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/PacienteRepository.java
@@ -5,4 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface PacienteRepository extends JpaRepository<Paciente, Long>, JpaSpecificationExecutor<Paciente> {
+
+    long countByAtivoTrue();
+
+    long countByAtivoFalse();
 }

--- a/src/main/java/com/carlesso/pilatesapi/repository/PagamentoRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/PagamentoRepository.java
@@ -46,4 +46,17 @@ public interface PagamentoRepository extends JpaRepository<Pagamento, Long> {
             @Param("pacienteIds") List<Long> pacienteIds,
             @Param("status") StatusPagamento status,
             @Param("dataPagamento") LocalDate dataPagamento);
+
+    long countByStatus(StatusPagamento status);
+
+    @Query("""
+            select coalesce(sum(p.valor), 0)
+            from Pagamento p
+            where p.status = :status
+              and p.dataPagamento between :inicio and :fim
+            """)
+    java.math.BigDecimal sumValorByStatusAndDataPagamentoBetween(
+            @Param("status") StatusPagamento status,
+            @Param("inicio") LocalDate inicio,
+            @Param("fim") LocalDate fim);
 }

--- a/src/main/java/com/carlesso/pilatesapi/repository/ProfissionalRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/ProfissionalRepository.java
@@ -9,4 +9,8 @@ public interface ProfissionalRepository extends JpaRepository<Profissional, Long
     boolean existsByEmail(String email);
 
     boolean existsByCpf(String cpf);
+
+    long countByAtivoTrue();
+
+    long countByAtivoFalse();
 }

--- a/src/main/java/com/carlesso/pilatesapi/service/DashboardService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/DashboardService.java
@@ -1,0 +1,65 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.DashboardResumoDTO;
+import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
+import com.carlesso.pilatesapi.repository.AulaRepository;
+import com.carlesso.pilatesapi.repository.PacienteRepository;
+import com.carlesso.pilatesapi.repository.PagamentoRepository;
+import com.carlesso.pilatesapi.repository.ProfissionalRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+
+@Service
+public class DashboardService {
+
+    private final PacienteRepository pacienteRepository;
+    private final ProfissionalRepository profissionalRepository;
+    private final PagamentoRepository pagamentoRepository;
+    private final AulaRepository aulaRepository;
+
+    public DashboardService(PacienteRepository pacienteRepository,
+                            ProfissionalRepository profissionalRepository,
+                            PagamentoRepository pagamentoRepository,
+                            AulaRepository aulaRepository) {
+        this.pacienteRepository = pacienteRepository;
+        this.profissionalRepository = profissionalRepository;
+        this.pagamentoRepository = pagamentoRepository;
+        this.aulaRepository = aulaRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public DashboardResumoDTO obterResumo() {
+        YearMonth mesAtual = YearMonth.now();
+        LocalDate inicioMes = mesAtual.atDay(1);
+        LocalDate fimMes = mesAtual.atEndOfMonth();
+
+        var pacientes = new DashboardResumoDTO.PacientesResumo(
+                pacienteRepository.countByAtivoTrue(),
+                pacienteRepository.countByAtivoFalse()
+        );
+
+        var profissionais = new DashboardResumoDTO.ProfissionaisResumo(
+                profissionalRepository.countByAtivoTrue(),
+                profissionalRepository.countByAtivoFalse()
+        );
+
+        var pagamentos = new DashboardResumoDTO.PagamentosResumo(
+                pagamentoRepository.countByStatus(StatusPagamento.PENDENTE),
+                pagamentoRepository.countByStatus(StatusPagamento.PAGO),
+                pagamentoRepository.countByStatus(StatusPagamento.VENCIDO),
+                pagamentoRepository.sumValorByStatusAndDataPagamentoBetween(
+                        StatusPagamento.PAGO, inicioMes, fimMes)
+        );
+
+        var aulas = new DashboardResumoDTO.AulasResumo(
+                aulaRepository.countByRealizadaAndDataBetweenAndPacienteAtivoTrue(true, inicioMes, fimMes),
+                aulaRepository.countByRealizadaAndDataBetweenAndPacienteAtivoTrue(false, inicioMes, fimMes)
+        );
+
+        return new DashboardResumoDTO(pacientes, profissionais, pagamentos, aulas, LocalDateTime.now());
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/controller/DashboardControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/DashboardControllerTest.java
@@ -1,0 +1,67 @@
+package com.carlesso.pilatesapi.controller;
+
+import com.carlesso.pilatesapi.dto.DashboardResumoDTO;
+import com.carlesso.pilatesapi.service.CustomUserDetailsService;
+import com.carlesso.pilatesapi.service.DashboardService;
+import com.carlesso.pilatesapi.service.JwtService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(DashboardController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class DashboardControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockitoBean DashboardService dashboardService;
+    @MockitoBean JwtService jwtService;
+    @MockitoBean CustomUserDetailsService customUserDetailsService;
+
+    private DashboardResumoDTO resumoCompleto() {
+        return new DashboardResumoDTO(
+                new DashboardResumoDTO.PacientesResumo(8L, 2L),
+                new DashboardResumoDTO.ProfissionaisResumo(3L, 1L),
+                new DashboardResumoDTO.PagamentosResumo(5L, 10L, 2L, new BigDecimal("2000.00")),
+                new DashboardResumoDTO.AulasResumo(30L, 12L),
+                LocalDateTime.of(2026, 4, 29, 10, 0, 0)
+        );
+    }
+
+    @Test
+    void resumo_retorna200ComEstrutura() throws Exception {
+        when(dashboardService.obterResumo()).thenReturn(resumoCompleto());
+
+        mockMvc.perform(get("/dashboard/resumo"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pacientes.totalAtivos").value(8))
+                .andExpect(jsonPath("$.pacientes.totalInativos").value(2))
+                .andExpect(jsonPath("$.profissionais.totalAtivos").value(3))
+                .andExpect(jsonPath("$.profissionais.totalInativos").value(1))
+                .andExpect(jsonPath("$.pagamentos.totalPendentes").value(5))
+                .andExpect(jsonPath("$.pagamentos.totalPagos").value(10))
+                .andExpect(jsonPath("$.pagamentos.totalVencidos").value(2))
+                .andExpect(jsonPath("$.pagamentos.receitaMesAtual").value(2000.00))
+                .andExpect(jsonPath("$.aulas.totalRealizadasMesAtual").value(30))
+                .andExpect(jsonPath("$.aulas.totalAgendadasMesAtual").value(12))
+                .andExpect(jsonPath("$.geradoEm").exists());
+    }
+
+    @Test
+    void resumo_retornaContentTypeJson() throws Exception {
+        when(dashboardService.obterResumo()).thenReturn(resumoCompleto());
+
+        mockMvc.perform(get("/dashboard/resumo"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("application/json"));
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/security/SecurityIntegrationTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/security/SecurityIntegrationTest.java
@@ -321,6 +321,26 @@ class SecurityIntegrationTest {
     }
 
     @Test
+    void dashboardResumo_semToken_deveRetornar401() throws Exception {
+        mvc.perform(get("/dashboard/resumo"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void dashboardResumo_comTokenValido_deveRetornar200() throws Exception {
+        User user = criarUsuario("dashboard@email.com", Role.USER);
+
+        mvc.perform(get("/dashboard/resumo")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(user)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.pacientes").exists())
+                .andExpect(jsonPath("$.profissionais").exists())
+                .andExpect(jsonPath("$.pagamentos").exists())
+                .andExpect(jsonPath("$.aulas").exists())
+                .andExpect(jsonPath("$.geradoEm").exists());
+    }
+
+    @Test
     void cors_devePermitirOrigemDoAngular() throws Exception {
         mvc.perform(options("/pacientes")
                         .header(HttpHeaders.ORIGIN, "http://localhost:4200")

--- a/src/test/java/com/carlesso/pilatesapi/service/DashboardServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/DashboardServiceTest.java
@@ -1,0 +1,115 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.DashboardResumoDTO;
+import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
+import com.carlesso.pilatesapi.repository.AulaRepository;
+import com.carlesso.pilatesapi.repository.PacienteRepository;
+import com.carlesso.pilatesapi.repository.PagamentoRepository;
+import com.carlesso.pilatesapi.repository.ProfissionalRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DashboardServiceTest {
+
+    @Mock PacienteRepository pacienteRepository;
+    @Mock ProfissionalRepository profissionalRepository;
+    @Mock PagamentoRepository pagamentoRepository;
+    @Mock AulaRepository aulaRepository;
+
+    DashboardService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new DashboardService(pacienteRepository, profissionalRepository,
+                pagamentoRepository, aulaRepository);
+    }
+
+    @Test
+    void obterResumo_retornaContadoresCorretos() {
+        YearMonth mesAtual = YearMonth.now();
+        LocalDate inicioMes = mesAtual.atDay(1);
+        LocalDate fimMes = mesAtual.atEndOfMonth();
+
+        when(pacienteRepository.countByAtivoTrue()).thenReturn(8L);
+        when(pacienteRepository.countByAtivoFalse()).thenReturn(2L);
+        when(profissionalRepository.countByAtivoTrue()).thenReturn(3L);
+        when(profissionalRepository.countByAtivoFalse()).thenReturn(1L);
+        when(pagamentoRepository.countByStatus(StatusPagamento.PENDENTE)).thenReturn(5L);
+        when(pagamentoRepository.countByStatus(StatusPagamento.PAGO)).thenReturn(10L);
+        when(pagamentoRepository.countByStatus(StatusPagamento.VENCIDO)).thenReturn(2L);
+        when(pagamentoRepository.sumValorByStatusAndDataPagamentoBetween(
+                eq(StatusPagamento.PAGO), eq(inicioMes), eq(fimMes)))
+                .thenReturn(new BigDecimal("2000.00"));
+        when(aulaRepository.countByRealizadaAndDataBetweenAndPacienteAtivoTrue(eq(true), eq(inicioMes), eq(fimMes)))
+                .thenReturn(30L);
+        when(aulaRepository.countByRealizadaAndDataBetweenAndPacienteAtivoTrue(eq(false), eq(inicioMes), eq(fimMes)))
+                .thenReturn(12L);
+
+        DashboardResumoDTO resumo = service.obterResumo();
+
+        assertThat(resumo.pacientes().totalAtivos()).isEqualTo(8L);
+        assertThat(resumo.pacientes().totalInativos()).isEqualTo(2L);
+        assertThat(resumo.profissionais().totalAtivos()).isEqualTo(3L);
+        assertThat(resumo.profissionais().totalInativos()).isEqualTo(1L);
+        assertThat(resumo.pagamentos().totalPendentes()).isEqualTo(5L);
+        assertThat(resumo.pagamentos().totalPagos()).isEqualTo(10L);
+        assertThat(resumo.pagamentos().totalVencidos()).isEqualTo(2L);
+        assertThat(resumo.pagamentos().receitaMesAtual()).isEqualByComparingTo("2000.00");
+        assertThat(resumo.aulas().totalRealizadasMesAtual()).isEqualTo(30L);
+        assertThat(resumo.aulas().totalAgendadasMesAtual()).isEqualTo(12L);
+        assertThat(resumo.geradoEm()).isNotNull();
+    }
+
+    @Test
+    void obterResumo_semPagamentosNoMes_receitaZero() {
+        YearMonth mesAtual = YearMonth.now();
+        LocalDate inicioMes = mesAtual.atDay(1);
+        LocalDate fimMes = mesAtual.atEndOfMonth();
+
+        when(pacienteRepository.countByAtivoTrue()).thenReturn(0L);
+        when(pacienteRepository.countByAtivoFalse()).thenReturn(0L);
+        when(profissionalRepository.countByAtivoTrue()).thenReturn(0L);
+        when(profissionalRepository.countByAtivoFalse()).thenReturn(0L);
+        when(pagamentoRepository.countByStatus(any())).thenReturn(0L);
+        when(pagamentoRepository.sumValorByStatusAndDataPagamentoBetween(
+                eq(StatusPagamento.PAGO), eq(inicioMes), eq(fimMes)))
+                .thenReturn(BigDecimal.ZERO);
+        when(aulaRepository.countByRealizadaAndDataBetweenAndPacienteAtivoTrue(anyBoolean(), eq(inicioMes), eq(fimMes)))
+                .thenReturn(0L);
+
+        DashboardResumoDTO resumo = service.obterResumo();
+
+        assertThat(resumo.pagamentos().receitaMesAtual()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(resumo.aulas().totalRealizadasMesAtual()).isZero();
+        assertThat(resumo.aulas().totalAgendadasMesAtual()).isZero();
+    }
+
+    @Test
+    void obterResumo_geradoEmEhPreenchido() {
+        when(pacienteRepository.countByAtivoTrue()).thenReturn(1L);
+        when(pacienteRepository.countByAtivoFalse()).thenReturn(0L);
+        when(profissionalRepository.countByAtivoTrue()).thenReturn(1L);
+        when(profissionalRepository.countByAtivoFalse()).thenReturn(0L);
+        when(pagamentoRepository.countByStatus(any())).thenReturn(0L);
+        when(pagamentoRepository.sumValorByStatusAndDataPagamentoBetween(any(), any(), any()))
+                .thenReturn(BigDecimal.ZERO);
+        when(aulaRepository.countByRealizadaAndDataBetweenAndPacienteAtivoTrue(anyBoolean(), any(), any()))
+                .thenReturn(0L);
+
+        DashboardResumoDTO resumo = service.obterResumo();
+
+        assertThat(resumo.geradoEm()).isNotNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Implementa `GET /dashboard/resumo` que retorna contadores e totais consolidados para o painel inicial do frontend
- Resposta inclui sub-objetos `pacientes`, `profissionais`, `pagamentos` (com `receitaMesAtual`) e `aulas` do mês corrente, mais `geradoEm`
- Endpoint exige autenticação (`Authorization: Bearer <token>`) e segue o mesmo padrão de segurança das demais rotas de negócio

## Detalhes técnicos

- **`DashboardResumoDTO`** — record com sub-records aninhados para cada agrupamento
- **`DashboardService`** — queries `@Transactional(readOnly = true)` nos repositories existentes; nenhuma tabela nova
- **`DashboardController`** — `GET /dashboard/resumo` com anotações Swagger
- Novos métodos nos repositories: `countByAtivoTrue/False` em `Paciente` e `Profissional`; `countByStatus` e `sumValorByStatusAndDataPagamentoBetween` em `Pagamento`; `countByRealizadaAndDataBetweenAndPacienteAtivoTrue` em `Aula`

## Test plan

- [x] `DashboardServiceTest` (3 testes unitários Mockito) — verifica contadores, receita zero e preenchimento de `geradoEm`
- [x] `DashboardControllerTest` (2 testes `@WebMvcTest`) — verifica estrutura JSON e Content-Type
- [ ] `SecurityIntegrationTest` (2 novos testes) — verifica 401 sem token e 200 com token válido
- [x] Total: **210 testes**, Failures: 0, Errors: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)