### PR TITLE
test: ampliar cobertura do relatório de pagamento do profissional (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,7 +829,7 @@ Formato da resposta de erro:
 
 ## Testes
 
-O projeto possui **210 testes** organizados em vinte e seis suítes:
+O projeto possui **214 testes** organizados em vinte e seis suítes:
 
 | Suíte | Tipo | Testes |
 |---|---|---|
@@ -844,7 +844,7 @@ O projeto possui **210 testes** organizados em vinte e seis suítes:
 | `AppPropertiesTest` | Unitário (ApplicationContextRunner) | 3 |
 | `GlobalExceptionHandlerTest` | Unitário | 6 |
 | `PacienteServiceIntegrationTest` | JPA (`@DataJpaTest`) | 4 |
-| `ProfissionalServiceIntegrationTest` | JPA (`@DataJpaTest`) | 5 |
+| `ProfissionalServiceIntegrationTest` | JPA (`@DataJpaTest`) | 8 |
 | `CobrancaSchedulerIntegrationTest` | JPA (`@DataJpaTest`) | 11 |
 | `AulaRepositoryTest` | JPA (`@DataJpaTest`) | 6 |
 | `PagamentoRepositoryTest` | JPA (`@DataJpaTest`) | 2 |
@@ -852,7 +852,7 @@ O projeto possui **210 testes** organizados em vinte e seis suítes:
 | `PlanoControllerTest` | Controller (`@WebMvcTest`) | 11 |
 | `PagamentoControllerTest` | Controller (`@WebMvcTest`) | 11 |
 | `AulaControllerTest` | Controller (`@WebMvcTest`) | 10 |
-| `ProfissionalControllerTest` | Controller (`@WebMvcTest`) | 17 |
+| `ProfissionalControllerTest` | Controller (`@WebMvcTest`) | 18 |
 | `RelatorioNfseControllerTest` | Controller (`@WebMvcTest`) | 6 |
 | `DashboardControllerTest` | Controller (`@WebMvcTest`) | 2 |
 | `DashboardServiceTest` | Unitário (Mockito) | 3 |

--- a/docs/context.md
+++ b/docs/context.md
@@ -449,12 +449,12 @@ JAVA_HOME=~/jdk mvn spring-boot:run
 | `PagamentoServiceTest` | Unitário (Mockito, sem Spring) | 9 |
 | `AulaServiceTest` | Unitário (Mockito, sem Spring) | 14 |
 | `PacienteServiceIntegrationTest` | `@DataJpaTest` + H2 | 4 |
-| `ProfissionalServiceIntegrationTest` | `@DataJpaTest` + H2 | 5 |
+| `ProfissionalServiceIntegrationTest` | `@DataJpaTest` + H2 | 8 |
 | `CobrancaSchedulerIntegrationTest` | `@DataJpaTest` + H2 | 11 |
 | `AulaRepositoryTest` | `@DataJpaTest` + H2 | 6 |
 | `PagamentoRepositoryTest` | `@DataJpaTest` + H2 | 2 |
 | `PacienteControllerTest` | `@WebMvcTest` + MockMvc | 16 |
-| `ProfissionalControllerTest` | `@WebMvcTest` + MockMvc | 17 |
+| `ProfissionalControllerTest` | `@WebMvcTest` + MockMvc | 18 |
 | `PlanoControllerTest` | `@WebMvcTest` + MockMvc | 11 |
 | `PagamentoControllerTest` | `@WebMvcTest` + MockMvc | 11 |
 | `AulaControllerTest` | `@WebMvcTest` + MockMvc | 10 |

--- a/src/test/java/com/carlesso/pilatesapi/controller/ProfissionalControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/ProfissionalControllerTest.java
@@ -308,4 +308,15 @@ class ProfissionalControllerTest {
                         .param("fim", "2025-02-28"))
                 .andExpect(status().isBadRequest());
     }
+
+    @Test
+    void exportarRelatorioPagamentoXlsx_periodoInvalido_deveRetornar400() throws Exception {
+        when(service.gerarRelatorioPagamento(1L, LocalDate.of(2025, 3, 1), LocalDate.of(2025, 2, 28)))
+                .thenThrow(new IllegalArgumentException("Período inicial não pode ser maior que o período final"));
+
+        mvc.perform(get("/profissionais/1/relatorio-pagamento/xlsx")
+                        .param("inicio", "2025-03-01")
+                        .param("fim", "2025-02-28"))
+                .andExpect(status().isBadRequest());
+    }
 }

--- a/src/test/java/com/carlesso/pilatesapi/service/ProfissionalServiceIntegrationTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/ProfissionalServiceIntegrationTest.java
@@ -1,19 +1,30 @@
 package com.carlesso.pilatesapi.service;
 
+import com.carlesso.pilatesapi.entity.Aula;
+import com.carlesso.pilatesapi.entity.Paciente;
+import com.carlesso.pilatesapi.entity.Pagamento;
+import com.carlesso.pilatesapi.entity.Plano;
 import com.carlesso.pilatesapi.entity.Profissional;
+import com.carlesso.pilatesapi.entity.enums.FrequenciaSemanal;
+import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
 import com.carlesso.pilatesapi.entity.enums.TipoContrato;
+import com.carlesso.pilatesapi.entity.enums.TipoPagamento;
 import com.carlesso.pilatesapi.repository.ProfissionalRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 
 import java.math.BigDecimal;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DataJpaTest(showSql = false)
 @Import(ProfissionalService.class)
@@ -25,12 +36,21 @@ class ProfissionalServiceIntegrationTest {
     @Autowired
     private ProfissionalService service;
 
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private Profissional profissionalSalvo;
+
     @BeforeEach
     void setUp() {
         repository.deleteAll();
         repository.save(profissional("Paula Mendes", "paula@email.com", "12345678900", TipoContrato.PJ, "45.00", true));
         repository.save(profissional("Ricardo Souza", "ricardo@email.com", "98765432100", TipoContrato.AUTONOMO, "40.00", true));
         repository.save(profissional("Fernanda Lima", "fernanda@email.com", "11122233344", TipoContrato.CLT, "35.00", false));
+        profissionalSalvo = repository.findAll().stream()
+                .filter(p -> "paula@email.com".equals(p.getEmail()))
+                .findFirst()
+                .orElseThrow();
     }
 
     @Test
@@ -92,6 +112,71 @@ class ProfissionalServiceIntegrationTest {
                 });
     }
 
+    @Test
+    void gerarRelatorioPagamento_retornaAulasRealizadasDoProfissionalNoPeriodo() {
+        Paciente paciente = entityManager.persist(paciente("Ana Souza", "ana@email.com", "44455566677"));
+        Plano plano = entityManager.persist(plano(paciente));
+        Pagamento pagamento = entityManager.persist(pagamento(paciente, plano,
+                LocalDate.of(2025, 2, 1), new BigDecimal("200.00")));
+        entityManager.persist(aula(paciente, pagamento, profissionalSalvo, LocalDate.of(2025, 2, 3)));
+        entityManager.persist(aula(paciente, pagamento, profissionalSalvo, LocalDate.of(2025, 2, 5)));
+        entityManager.flush();
+        entityManager.clear();
+
+        var relatorio = service.gerarRelatorioPagamento(
+                profissionalSalvo.getId(),
+                LocalDate.of(2025, 2, 1),
+                LocalDate.of(2025, 2, 28));
+
+        assertThat(relatorio.profissional().id()).isEqualTo(profissionalSalvo.getId());
+        assertThat(relatorio.profissional().nome()).isEqualTo("Paula Mendes");
+        assertThat(relatorio.resumo().totalAulas()).isEqualTo(2);
+        assertThat(relatorio.resumo().quantidadePagamentos()).isEqualTo(1);
+        assertThat(relatorio.resumo().totalPagamentosBruto()).isEqualByComparingTo("200.00");
+        assertThat(relatorio.resumo().totalProfissional()).isEqualByComparingTo("90.00");
+        assertThat(relatorio.aulas()).hasSize(2);
+        assertThat(relatorio.aulas().get(0).valorBaseAula()).isEqualByComparingTo("100.00");
+        assertThat(relatorio.aulas().get(0).valorProfissional()).isEqualByComparingTo("45.00");
+        assertThat(relatorio.pagamentos()).hasSize(1);
+        assertThat(relatorio.pagamentos().get(0).quantidadeAulasNoPeriodo()).isEqualTo(2);
+        assertThat(relatorio.pagamentos().get(0).totalProfissional()).isEqualByComparingTo("90.00");
+    }
+
+    @Test
+    void gerarRelatorioPagamento_ignoraAulasDePacienteInativo() {
+        Paciente ativo = entityManager.persist(paciente("Ana Ativa", "ana.ativa@email.com", "11100011100"));
+        Paciente inativo = entityManager.persist(pacienteInativo("Bia Inativa", "bia.inativa@email.com", "22200022200"));
+        Plano planoAtivo = entityManager.persist(plano(ativo));
+        Plano planoInativo = entityManager.persist(plano(inativo));
+        Pagamento pagAtivo = entityManager.persist(pagamento(ativo, planoAtivo,
+                LocalDate.of(2025, 2, 1), new BigDecimal("200.00")));
+        Pagamento pagInativo = entityManager.persist(pagamento(inativo, planoInativo,
+                LocalDate.of(2025, 2, 1), new BigDecimal("200.00")));
+        entityManager.persist(aula(ativo, pagAtivo, profissionalSalvo, LocalDate.of(2025, 2, 3)));
+        entityManager.persist(aula(inativo, pagInativo, profissionalSalvo, LocalDate.of(2025, 2, 5)));
+        entityManager.flush();
+        entityManager.clear();
+
+        var relatorio = service.gerarRelatorioPagamento(
+                profissionalSalvo.getId(),
+                LocalDate.of(2025, 2, 1),
+                LocalDate.of(2025, 2, 28));
+
+        assertThat(relatorio.resumo().totalAulas()).isEqualTo(1);
+        assertThat(relatorio.aulas()).extracting(a -> a.pacienteId())
+                .containsExactly(ativo.getId());
+    }
+
+    @Test
+    void gerarRelatorioPagamento_periodoInvalido_lancaExcecao() {
+        assertThatThrownBy(() -> service.gerarRelatorioPagamento(
+                profissionalSalvo.getId(),
+                LocalDate.of(2025, 3, 1),
+                LocalDate.of(2025, 2, 1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("não pode ser maior");
+    }
+
     private Profissional profissional(
             String nome,
             String email,
@@ -109,5 +194,53 @@ class ProfissionalServiceIntegrationTest {
         profissional.setDataInicio(LocalDate.of(2024, 1, 15));
         profissional.setAtivo(ativo);
         return profissional;
+    }
+
+    private Paciente paciente(String nome, String email, String cpf) {
+        Paciente p = new Paciente();
+        p.setNome(nome);
+        p.setEmail(email);
+        p.setCpf(cpf);
+        p.setAtivo(true);
+        return p;
+    }
+
+    private Paciente pacienteInativo(String nome, String email, String cpf) {
+        Paciente p = paciente(nome, email, cpf);
+        p.setAtivo(false);
+        return p;
+    }
+
+    private Plano plano(Paciente paciente) {
+        Plano plano = new Plano();
+        plano.setPaciente(paciente);
+        plano.setTipo(TipoPagamento.MENSAL);
+        plano.setValor(new BigDecimal("200.00"));
+        plano.setFrequenciaSemanal(FrequenciaSemanal.UMA_VEZ);
+        plano.setDiasSemana(List.of(DayOfWeek.MONDAY));
+        plano.setDataInicio(LocalDate.of(2025, 1, 1));
+        return plano;
+    }
+
+    private Pagamento pagamento(Paciente paciente, Plano plano, LocalDate periodoInicio, BigDecimal valor) {
+        Pagamento pagamento = new Pagamento();
+        pagamento.setPaciente(paciente);
+        pagamento.setPlano(plano);
+        pagamento.setValor(valor);
+        pagamento.setStatus(StatusPagamento.PAGO);
+        pagamento.setDataVencimento(periodoInicio.plusDays(10));
+        pagamento.setPeriodoInicio(periodoInicio);
+        pagamento.setPeriodoFim(periodoInicio.plusMonths(1).minusDays(1));
+        return pagamento;
+    }
+
+    private Aula aula(Paciente paciente, Pagamento pagamento, Profissional profissional, LocalDate data) {
+        Aula aula = new Aula();
+        aula.setPaciente(paciente);
+        aula.setPagamento(pagamento);
+        aula.setProfissional(profissional);
+        aula.setData(data);
+        aula.setRealizada(true);
+        return aula;
     }
 }


### PR DESCRIPTION
## Resumo da alteração

Amplia a cobertura de testes do relatório de pagamento do profissional (issue #7), adicionando testes de integração JPA e o caso de período inválido faltante no endpoint XLSX do controller.

## Motivo da mudança

A implementação do relatório de pagamento (`gerarRelatorioPagamento`) estava coberta apenas por testes unitários com Mockito. Dois gaps foram identificados:

1. **`ProfissionalServiceIntegrationTest`** não testava `gerarRelatorioPagamento` — apenas o filtro/listagem. Sem testes com banco H2 real, erros na query JPQL (`findRelatorioPagamentoByProfissionalIdAndPeriodo`) poderiam passar despercebidos.
2. **`ProfissionalControllerTest`** tinha o caminho de período inválido coberto para PDF mas não para XLSX, criando assimetria na cobertura.

## Arquivos principais alterados

| Arquivo | Alteração |
|---|---|
| `ProfissionalServiceIntegrationTest.java` | +3 testes `@DataJpaTest` com H2 cobrindo `gerarRelatorioPagamento` |
| `ProfissionalControllerTest.java` | +1 teste cobrindo período inválido no endpoint XLSX |
| `README.md` | Contagem de testes atualizada: 210 → 214 |
| `docs/context.md` | Contagem de testes atualizada |

## Novos testes

### `ProfissionalServiceIntegrationTest` (5 → 8 testes)

- `gerarRelatorioPagamento_retornaAulasRealizadasDoProfissionalNoPeriodo` — verifica cálculo completo (valorBaseAula, valorProfissional, totalProfissional) com dados reais em H2
- `gerarRelatorioPagamento_ignoraAulasDePacienteInativo` — confirma que aulas de pacientes inativos não entram no relatório
- `gerarRelatorioPagamento_periodoInvalido_lancaExcecao` — valida a regra de negócio de período inválido no nível do service integrado

### `ProfissionalControllerTest` (17 → 18 testes)

- `exportarRelatorioPagamentoXlsx_periodoInvalido_deveRetornar400` — simetria com o teste equivalente do PDF

## Testes executados

```
mvn test → 214 testes, 0 falhas, 0 erros
```

## Referência da issue

Closes #7

https://claude.ai/code/session_015wMjRmzBacMnNxHuaJXo5B

---
_Generated by [Claude Code](https://claude.ai/code/session_015wMjRmzBacMnNxHuaJXo5B)_