### PR TITLE
Implementa avaliação fisioterapêutica do paciente

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ src/
 │   │   │   ├── PlanoController.java         # /planos
 │   │   │   ├── PagamentoController.java     # /pagamentos
 │   │   │   ├── AulaController.java          # /aulas
+│   │   │   ├── AnamneseController.java      # /anamneses
+│   │   │   ├── AvaliacaoFisioterapeuticaController.java # /avaliacoes-fisioterapeuticas
 │   │   │   ├── AuthController.java          # /auth/register e /auth/login
 │   │   │   ├── UserController.java          # /users/me e CRUD administrativo de usuários
 │   │   │   ├── AdminController.java         # /admin/health
@@ -58,6 +60,8 @@ src/
 │   │   │   ├── PlanoService.java                       # Regras de plano e frequência
 │   │   │   ├── PagamentoService.java                   # Cobranças, confirmação, vencimentos
 │   │   │   ├── AulaService.java                        # Geração e controle de aulas
+│   │   │   ├── AnamneseService.java                    # Anamnese clínica do paciente
+│   │   │   ├── AvaliacaoFisioterapeuticaService.java   # Avaliação fisioterapêutica do paciente
 │   │   │   ├── DashboardService.java                   # Contadores e totais para o painel inicial
 │   │   │   ├── RelatorioPagamentoExporterService.java  # Exportação do relatório em PDF e XLSX
 │   │   │   ├── RelatorioNfseService.java               # Relatório de emissão de NFSEs por competência
@@ -73,6 +77,8 @@ src/
 │   │   │   ├── PlanoRepository.java
 │   │   │   ├── PagamentoRepository.java
 │   │   │   ├── AulaRepository.java
+│   │   │   ├── AnamneseRepository.java
+│   │   │   ├── AvaliacaoFisioterapeuticaRepository.java
 │   │   │   └── UserRepository.java
 │   │   ├── entity/
 │   │   │   ├── Paciente.java                # Entidade JPA
@@ -81,6 +87,8 @@ src/
 │   │   │   ├── Plano.java                   # Plano de pagamento do paciente
 │   │   │   ├── Pagamento.java               # Cobrança por período
 │   │   │   ├── Aula.java                    # Aula agendada (com presença)
+│   │   │   ├── Anamnese.java                # Anamnese clínica do paciente
+│   │   │   ├── AvaliacaoFisioterapeutica.java # Avaliação técnica do paciente
 │   │   │   └── User.java                    # Usuário autenticável da API
 │   │   ├── security/
 │   │   │   └── JwtAuthenticationFilter.java # Validação do Bearer token por requisição
@@ -111,6 +119,12 @@ src/
 │   │   │   ├── PagamentoPagarRequestDTO.java
 │   │   │   ├── PagamentoResponseDTO.java
 │   │   │   ├── AulaResponseDTO.java
+│   │   │   ├── AnamneseRequestDTO.java
+│   │   │   ├── AnamneseUpdateDTO.java
+│   │   │   ├── AnamneseResponseDTO.java
+│   │   │   ├── AvaliacaoFisioterapeuticaRequestDTO.java
+│   │   │   ├── AvaliacaoFisioterapeuticaUpdateDTO.java
+│   │   │   ├── AvaliacaoFisioterapeuticaResponseDTO.java
 │   │   │   ├── AuthRegisterRequestDTO.java
 │   │   │   ├── AuthLoginRequestDTO.java
 │   │   │   ├── AuthResponseDTO.java
@@ -133,7 +147,10 @@ src/
 │           ├── V9__alter_profissionais_percentual_precision.sql
 │           ├── V10__add_profissional_to_aulas.sql
 │           ├── V11__create_users_table.sql
-│           └── V12__insert_users_perfis_acesso.sql
+│           ├── V12__insert_users_perfis_acesso.sql
+│           ├── V13__add_indexes_on_foreign_keys.sql
+│           ├── V14__create_anamneses_table.sql
+│           └── V15__create_avaliacoes_fisioterapeuticas_table.sql
 └── test/java/com/carlesso/pilatesapi/
     ├── PilatesApiApplicationTests.java
     ├── actuator/
@@ -146,6 +163,7 @@ src/
     ├── security/
     │   └── SecurityIntegrationTest.java
     ├── service/
+    │   ├── AvaliacaoFisioterapeuticaServiceTest.java
     │   ├── PacienteServiceTest.java
     │   ├── PacienteServiceIntegrationTest.java
     │   ├── ProfissionalServiceIntegrationTest.java
@@ -160,6 +178,7 @@ src/
     │   ├── AulaRepositoryTest.java
     │   └── PagamentoRepositoryTest.java
     └── controller/
+        ├── AvaliacaoFisioterapeuticaControllerTest.java
         ├── PacienteControllerTest.java
         ├── ProfissionalControllerTest.java
         ├── PlanoControllerTest.java
@@ -242,6 +261,15 @@ As demais rotas de negócio exigem `Authorization: Bearer <accessToken>`. Tokens
 | `GET` | `/aulas/paciente/{id}` | Listar aulas do paciente |
 | `GET` | `/aulas/pagamento/{id}` | Listar aulas de um pagamento |
 | `PATCH` | `/aulas/{id}/realizar` | Marcar aula como realizada, opcionalmente com `profissionalId` |
+
+### Avaliações Fisioterapêuticas
+
+| Método | Endpoint | Descrição |
+|---|---|---|
+| `POST` | `/avaliacoes-fisioterapeuticas` | Criar avaliação fisioterapêutica para um paciente |
+| `GET` | `/avaliacoes-fisioterapeuticas/{id}` | Buscar avaliação fisioterapêutica por ID |
+| `GET` | `/avaliacoes-fisioterapeuticas/paciente/{pacienteId}` | Listar avaliações fisioterapêuticas do paciente |
+| `PUT` | `/avaliacoes-fisioterapeuticas/{id}` | Atualizar dados da avaliação fisioterapêutica |
 
 ### Relatórios
 
@@ -483,6 +511,29 @@ Todos os campos são opcionais. Apenas os campos enviados serão atualizados.
 }
 ```
 
+### POST /avaliacoes-fisioterapeuticas — corpo da requisição
+
+```json
+{
+  "pacienteId": 1,
+  "dataAvaliacao": "2026-04-20",
+  "queixaFuncional": "Dor ao agachar",
+  "avaliacaoPostural": "Anteriorização de cabeça",
+  "mobilidadeArticular": "Restrição em quadril direito",
+  "forcaMuscular": "Glúteo médio grau 4",
+  "flexibilidade": "Encurtamento de cadeia posterior",
+  "equilibrio": "Instável em apoio unipodal",
+  "coordenacaoMotora": "Boa coordenação",
+  "padraoRespiratorio": "Respiração apical",
+  "escalaDor": 6,
+  "testesFuncionaisRealizados": "Agachamento, ponte, apoio unipodal",
+  "diagnosticoFisioterapeutico": "Disfunção lombopélvica",
+  "observacoesGerais": "Reavaliar em 30 dias"
+}
+```
+
+> Campos obrigatórios: `pacienteId`, `dataAvaliacao`, `queixaFuncional`, `escalaDor` e `diagnosticoFisioterapeutico`. `escalaDor` deve estar entre 0 e 10.
+
 ---
 
 ## Como rodar
@@ -591,6 +642,9 @@ O projeto utiliza **Flyway** para versionamento e execução automática das mig
 | `V10__add_profissional_to_aulas.sql` | Vincula profissional às aulas realizadas |
 | `V11__create_users_table.sql` | Cria tabela `users` para autenticação e autorização |
 | `V12__insert_users_perfis_acesso.sql` | Insere 5 usuários iniciais com perfis `ADMIN` e `USER` |
+| `V13__add_indexes_on_foreign_keys.sql` | Adiciona índices para FKs e filtros recorrentes |
+| `V14__create_anamneses_table.sql` | Cria tabela `anamneses` vinculada a pacientes |
+| `V15__create_avaliacoes_fisioterapeuticas_table.sql` | Cria histórico de avaliações fisioterapêuticas do paciente |
 
 > Nos testes automatizados o Flyway fica desabilitado (`spring.flyway.enabled=false`), pois o banco H2 é gerenciado pelo Hibernate com `ddl-auto=create-drop`.
 
@@ -718,6 +772,24 @@ curl -s -X PATCH http://localhost:8080/pagamentos/1/pagar \
   -d '{"dataPagamento": "2025-02-10"}' | jq
 ```
 
+### Criar avaliação fisioterapêutica
+```bash
+curl -s -X POST http://localhost:8080/avaliacoes-fisioterapeuticas \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{
+    "pacienteId": 1,
+    "dataAvaliacao": "2026-04-20",
+    "queixaFuncional": "Dor ao agachar",
+    "escalaDor": 6,
+    "diagnosticoFisioterapeutico": "Disfunção lombopélvica",
+    "observacoesGerais": "Reavaliar em 30 dias"
+  }' | jq
+
+curl -s http://localhost:8080/avaliacoes-fisioterapeuticas/paciente/1 \
+  -H "Authorization: Bearer $TOKEN" | jq
+```
+
 ### Gerar relatório de pagamento (JSON)
 ```bash
 curl -s "http://localhost:8080/profissionais/1/relatorio-pagamento?inicio=2025-02-01&fim=2025-02-28" \
@@ -796,6 +868,14 @@ curl -s -OJ "http://localhost:8080/api/relatorios/nfse?competencia=04/2026&forma
 - Consultas de aulas por ID, paciente, pagamento e relatório retornam apenas aulas associadas a pacientes ativos
 - Ao marcar uma aula como realizada, `profissionalId` pode ser informado para alimentar o relatório de pagamento do profissional
 
+### Avaliações Fisioterapêuticas
+- Um paciente pode ter múltiplas avaliações fisioterapêuticas para manter histórico clínico
+- Criar avaliação para paciente inexistente ou inativo retorna `404`
+- Campos obrigatórios: `dataAvaliacao`, `queixaFuncional`, `escalaDor` e `diagnosticoFisioterapeutico`
+- `escalaDor` aceita valores inteiros de 0 a 10
+- Consultas e atualizações filtram avaliações vinculadas a pacientes ativos
+- Atualização parcial: apenas campos não-nulos do DTO de update são aplicados
+
 ### Scheduler (processos automáticos)
 | Horário | Ação | Configuração |
 |---|---|---|
@@ -829,14 +909,16 @@ Formato da resposta de erro:
 
 ## Testes
 
-O projeto possui **210 testes** organizados em vinte e seis suítes:
+O projeto possui testes unitários, de controller e de integração organizados por camada:
 
 | Suíte | Tipo | Testes |
 |---|---|---|
 | `PacienteServiceTest` | Unitário (Mockito) | 12 |
 | `PlanoServiceTest` | Unitário (Mockito) | 9 |
-| `PagamentoServiceTest` | Unitário (Mockito) | 9 |
+| `PagamentoServiceTest` | Unitário (Mockito) | 10 |
 | `AulaServiceTest` | Unitário (Mockito) | 14 |
+| `AnamneseServiceTest` | Unitário (Mockito) | 17 |
+| `AvaliacaoFisioterapeuticaServiceTest` | Unitário (Mockito) | 8 |
 | `ProfissionalServiceTest` | Unitário (Mockito) | 15 |
 | `RelatorioPagamentoExporterServiceTest` | Unitário | 3 |
 | `RelatorioNfseServiceTest` | Unitário (Mockito) | 5 |
@@ -845,6 +927,7 @@ O projeto possui **210 testes** organizados em vinte e seis suítes:
 | `GlobalExceptionHandlerTest` | Unitário | 6 |
 | `PacienteServiceIntegrationTest` | JPA (`@DataJpaTest`) | 4 |
 | `ProfissionalServiceIntegrationTest` | JPA (`@DataJpaTest`) | 5 |
+| `PagamentoServiceAtomicidadeIntegrationTest` | Integração (`@SpringBootTest` + H2) | 1 |
 | `CobrancaSchedulerIntegrationTest` | JPA (`@DataJpaTest`) | 11 |
 | `AulaRepositoryTest` | JPA (`@DataJpaTest`) | 6 |
 | `PagamentoRepositoryTest` | JPA (`@DataJpaTest`) | 2 |
@@ -852,6 +935,8 @@ O projeto possui **210 testes** organizados em vinte e seis suítes:
 | `PlanoControllerTest` | Controller (`@WebMvcTest`) | 11 |
 | `PagamentoControllerTest` | Controller (`@WebMvcTest`) | 11 |
 | `AulaControllerTest` | Controller (`@WebMvcTest`) | 10 |
+| `AnamneseControllerTest` | Controller (`@WebMvcTest`) | 14 |
+| `AvaliacaoFisioterapeuticaControllerTest` | Controller (`@WebMvcTest`) | 10 |
 | `ProfissionalControllerTest` | Controller (`@WebMvcTest`) | 17 |
 | `RelatorioNfseControllerTest` | Controller (`@WebMvcTest`) | 6 |
 | `DashboardControllerTest` | Controller (`@WebMvcTest`) | 2 |

--- a/docs/context.md
+++ b/docs/context.md
@@ -50,6 +50,7 @@ com.carlesso.pilatesapi
 │   ├── PagamentoController.java      — endpoints REST de pagamentos
 │   ├── AulaController.java           — endpoints REST de aulas
 │   ├── AnamneseController.java       — endpoints REST de anamneses
+│   ├── AvaliacaoFisioterapeuticaController.java — endpoints REST de avaliações fisioterapêuticas
 │   ├── AuthController.java           — registro/login com JWT
 │   ├── UserController.java           — endpoint do usuário autenticado e CRUD administrativo
 │   ├── AdminController.java          — endpoints administrativos
@@ -59,6 +60,7 @@ com.carlesso.pilatesapi
 │   ├── PacienteService.java                    — lógica de negócio de pacientes
 │   ├── ProfissionalService.java                — lógica de negócio de profissionais
 │   ├── AnamneseService.java                    — lógica de negócio de anamneses
+│   ├── AvaliacaoFisioterapeuticaService.java   — lógica de negócio de avaliações fisioterapêuticas
 │   ├── PlanoService.java                       — regras de plano e frequência
 │   ├── PagamentoService.java                   — cobranças, confirmação, vencimentos
 │   ├── AulaService.java                        — geração e controle de aulas
@@ -78,6 +80,7 @@ com.carlesso.pilatesapi
 │   ├── PagamentoRepository.java
 │   ├── AulaRepository.java
 │   ├── AnamneseRepository.java
+│   ├── AvaliacaoFisioterapeuticaRepository.java
 │   └── UserRepository.java
 ├── entity
 │   ├── Paciente.java                 — entidade JPA, tabela `pacientes`
@@ -87,6 +90,7 @@ com.carlesso.pilatesapi
 │   ├── Pagamento.java                — entidade JPA, tabela `pagamentos`
 │   ├── Aula.java                     — entidade JPA, tabela `aulas`
 │   ├── Anamnese.java                 — entidade JPA, tabela `anamneses`
+│   ├── AvaliacaoFisioterapeutica.java — entidade JPA, tabela `avaliacoes_fisioterapeuticas`
 │   └── User.java                     — entidade JPA, tabela `users`
 ├── entity/enums
 │   ├── TipoPagamento.java            — MENSAL, TRIMESTRAL, ANUAL
@@ -121,6 +125,9 @@ com.carlesso.pilatesapi
 │   ├── AnamneseRequestDTO.java       — payload de criação de anamnese (record)
 │   ├── AnamneseUpdateDTO.java        — payload de atualização de anamnese (record)
 │   ├── AnamneseResponseDTO.java      — resposta da API de anamnese (record com factory method `from`)
+│   ├── AvaliacaoFisioterapeuticaRequestDTO.java — payload de criação de avaliação fisioterapêutica
+│   ├── AvaliacaoFisioterapeuticaUpdateDTO.java  — payload de atualização de avaliação fisioterapêutica
+│   ├── AvaliacaoFisioterapeuticaResponseDTO.java — resposta da API de avaliação fisioterapêutica
 │   ├── AuthRegisterRequestDTO.java
 │   ├── AuthLoginRequestDTO.java
 │   ├── AuthResponseDTO.java
@@ -233,6 +240,30 @@ Constraint: `UNIQUE (paciente_id, data)`
 
 Relacionamento `@OneToOne` com `Paciente`. Cada paciente possui no máximo uma anamnese principal (constraint `UNIQUE paciente_id`).
 
+### Tabela `avaliacoes_fisioterapeuticas`
+
+| Campo | Tipo | Restrição |
+|---|---|---|
+| `id` | BIGINT | PK, auto-increment |
+| `paciente_id` | BIGINT | NOT NULL, FK → pacientes |
+| `data_avaliacao` | DATE | NOT NULL |
+| `queixa_funcional` | TEXT | NOT NULL |
+| `avaliacao_postural` | TEXT | — |
+| `mobilidade_articular` | TEXT | — |
+| `forca_muscular` | TEXT | — |
+| `flexibilidade` | TEXT | — |
+| `equilibrio` | TEXT | — |
+| `coordenacao_motora` | TEXT | — |
+| `padrao_respiratorio` | TEXT | — |
+| `escala_dor` | INTEGER | NOT NULL, CHECK 0..10 |
+| `testes_funcionais_realizados` | TEXT | — |
+| `diagnostico_fisioterapeutico` | TEXT | NOT NULL |
+| `observacoes_gerais` | TEXT | — |
+| `data_criacao` | TIMESTAMP | NOT NULL |
+| `data_atualizacao` | TIMESTAMP | — |
+
+Relacionamento `@ManyToOne` com `Paciente`. Um paciente pode possuir múltiplas avaliações para manter histórico clínico.
+
 ### Índices
 
 | Índice | Tabela / Coluna | Motivação |
@@ -244,6 +275,7 @@ Relacionamento `@OneToOne` com `Paciente`. Cada paciente possui no máximo uma a
 | `idx_pagamentos_status` | `pagamentos(status)` | Scheduler diário e relatório NFSE filtram por `PENDENTE`/`VENCIDO`/`PAGO` |
 | `idx_pagamentos_data_vencimento` | `pagamentos(data_vencimento)` | Scheduler das 06:00 faz range scan diário nessa coluna |
 | `idx_aulas_realizada` | `aulas(realizada)` | Relatório de pagamento de profissional filtra `realizada = true` |
+| `idx_avaliacoes_fisioterapeuticas_paciente_id` | `avaliacoes_fisioterapeuticas(paciente_id)` | Listagem de avaliações por paciente |
 > **Nota:** colunas `plano_dias_semana(plano_id)`, `pagamentos(plano_id)`, `aulas(paciente_id)` e `anamneses(paciente_id)` **não** possuem índice dedicado porque já são o prefixo esquerdo de índices compostos existentes ou possuem índice automático de constraint `UNIQUE`, que o PostgreSQL pode usar para buscas na coluna isolada.
 
 ---
@@ -294,6 +326,10 @@ Relacionamento `@OneToOne` com `Paciente`. Cada paciente possui no máximo uma a
 | GET | `/anamneses/{id}` | Buscar anamnese por ID | 200 / 404 |
 | GET | `/anamneses/paciente/{pacienteId}` | Buscar anamnese por paciente | 200 / 404 |
 | PUT | `/anamneses/{id}` | Atualizar anamnese (atualização parcial) | 200 / 400 / 404 |
+| POST | `/avaliacoes-fisioterapeuticas` | Criar avaliação fisioterapêutica para um paciente | 201 / 400 / 404 |
+| GET | `/avaliacoes-fisioterapeuticas/{id}` | Buscar avaliação fisioterapêutica por ID | 200 / 404 |
+| GET | `/avaliacoes-fisioterapeuticas/paciente/{pacienteId}` | Listar avaliações fisioterapêuticas do paciente | 200 / 404 |
+| PUT | `/avaliacoes-fisioterapeuticas/{id}` | Atualizar avaliação fisioterapêutica (atualização parcial) | 200 / 400 / 404 |
 | GET | `/dashboard/resumo` | Resumo consolidado para o painel inicial (pacientes, profissionais, pagamentos, aulas) | 200 / 401 |
 
 Campos obrigatórios no cadastro de pacientes: `nome`, `email`, `cpf`.  
@@ -370,6 +406,15 @@ CPF não pode ser alterado após o cadastro.
 - Consultas e atualizações de anamnese filtram `paciente.ativo = true`
 - Atualização parcial: apenas campos não-nulos do DTO de update são aplicados; `queixaPrincipal` e `objetivos` não aceitam strings em branco quando enviados
 - `dataAtualizacao` é registrada automaticamente em cada atualização
+
+### Avaliação Fisioterapêutica
+- Um paciente pode possuir múltiplas avaliações fisioterapêuticas para manter histórico clínico
+- Criar avaliação para paciente inexistente ou inativo retorna `404`
+- Campos obrigatórios: `dataAvaliacao`, `queixaFuncional`, `escalaDor` e `diagnosticoFisioterapeutico`
+- `escalaDor` aceita apenas valores inteiros de 0 a 10
+- Consultas por ID e por paciente filtram `paciente.ativo = true`
+- Atualização parcial: apenas campos não-nulos do DTO de update são aplicados; campos textuais obrigatórios não aceitam strings em branco quando enviados
+- `dataCriacao` é registrada na criação e `dataAtualizacao` em cada atualização
 
 ### Scheduler (processos automáticos)
 | Cron (default) | Ação | Propriedade |
@@ -486,7 +531,7 @@ JAVA_HOME=~/jdk mvn spring-boot:run
 | `RelatorioNfseServiceTest` | Unitário (Mockito, sem Spring) | 5 |
 | `RelatorioNfseExporterServiceTest` | Unitário | 3 |
 | `PlanoServiceTest` | Unitário (Mockito, sem Spring) | 9 |
-| `PagamentoServiceTest` | Unitário (Mockito, sem Spring) | 9 |
+| `PagamentoServiceTest` | Unitário (Mockito, sem Spring) | 10 |
 | `AulaServiceTest` | Unitário (Mockito, sem Spring) | 14 |
 | `PacienteServiceIntegrationTest` | `@DataJpaTest` + H2 | 4 |
 | `ProfissionalServiceIntegrationTest` | `@DataJpaTest` + H2 | 5 |
@@ -499,8 +544,10 @@ JAVA_HOME=~/jdk mvn spring-boot:run
 | `PagamentoControllerTest` | `@WebMvcTest` + MockMvc | 11 |
 | `AulaControllerTest` | `@WebMvcTest` + MockMvc | 10 |
 | `RelatorioNfseControllerTest` | `@WebMvcTest` + MockMvc | 6 |
-| `AnamneseServiceTest` | Unitário (Mockito, sem Spring) | 9 |
-| `AnamneseControllerTest` | `@WebMvcTest` + MockMvc | 10 |
+| `AnamneseServiceTest` | Unitário (Mockito, sem Spring) | 17 |
+| `AnamneseControllerTest` | `@WebMvcTest` + MockMvc | 14 |
+| `AvaliacaoFisioterapeuticaServiceTest` | Unitário (Mockito, sem Spring) | 8 |
+| `AvaliacaoFisioterapeuticaControllerTest` | `@WebMvcTest` + MockMvc | 10 |
 | `DashboardControllerTest` | `@WebMvcTest` + MockMvc | 2 |
 | `DashboardServiceTest` | Unitário (Mockito, sem Spring) | 3 |
 | `AppPropertiesTest` | Unitário (ApplicationContextRunner) | 3 |

--- a/src/main/java/com/carlesso/pilatesapi/controller/AvaliacaoFisioterapeuticaController.java
+++ b/src/main/java/com/carlesso/pilatesapi/controller/AvaliacaoFisioterapeuticaController.java
@@ -1,0 +1,85 @@
+package com.carlesso.pilatesapi.controller;
+
+import com.carlesso.pilatesapi.dto.AvaliacaoFisioterapeuticaRequestDTO;
+import com.carlesso.pilatesapi.dto.AvaliacaoFisioterapeuticaResponseDTO;
+import com.carlesso.pilatesapi.dto.AvaliacaoFisioterapeuticaUpdateDTO;
+import com.carlesso.pilatesapi.service.AvaliacaoFisioterapeuticaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+
+@Tag(name = "Avaliações Fisioterapêuticas", description = "Gerenciamento de avaliações fisioterapêuticas de pacientes")
+@RestController
+@RequestMapping("/avaliacoes-fisioterapeuticas")
+public class AvaliacaoFisioterapeuticaController {
+
+    private final AvaliacaoFisioterapeuticaService service;
+
+    public AvaliacaoFisioterapeuticaController(AvaliacaoFisioterapeuticaService service) {
+        this.service = service;
+    }
+
+    @Operation(
+            summary = "Criar avaliação fisioterapêutica",
+            description = "Registra uma avaliação fisioterapêutica para um paciente. O paciente pode possuir múltiplas avaliações."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Avaliação criada com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Dados inválidos ou campos obrigatórios ausentes"),
+            @ApiResponse(responseCode = "404", description = "Paciente não encontrado")
+    })
+    @PostMapping
+    public ResponseEntity<AvaliacaoFisioterapeuticaResponseDTO> criar(
+            @RequestBody @Valid AvaliacaoFisioterapeuticaRequestDTO dto,
+            UriComponentsBuilder uriBuilder) {
+        AvaliacaoFisioterapeuticaResponseDTO response = service.criar(dto);
+        var uri = uriBuilder.path("/avaliacoes-fisioterapeuticas/{id}").buildAndExpand(response.id()).toUri();
+        return ResponseEntity.created(uri).body(response);
+    }
+
+    @Operation(summary = "Buscar avaliação fisioterapêutica por ID")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Avaliação encontrada"),
+            @ApiResponse(responseCode = "404", description = "Avaliação não encontrada")
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<AvaliacaoFisioterapeuticaResponseDTO> buscarPorId(
+            @Parameter(description = "ID da avaliação fisioterapêutica", required = true) @PathVariable Long id) {
+        return ResponseEntity.ok(service.buscarPorId(id));
+    }
+
+    @Operation(summary = "Listar avaliações fisioterapêuticas por paciente")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Avaliações encontradas"),
+            @ApiResponse(responseCode = "404", description = "Paciente não encontrado")
+    })
+    @GetMapping("/paciente/{pacienteId}")
+    public ResponseEntity<List<AvaliacaoFisioterapeuticaResponseDTO>> listarPorPaciente(
+            @Parameter(description = "ID do paciente", required = true) @PathVariable Long pacienteId) {
+        return ResponseEntity.ok(service.listarPorPaciente(pacienteId));
+    }
+
+    @Operation(
+            summary = "Atualizar avaliação fisioterapêutica",
+            description = "Atualiza uma avaliação fisioterapêutica. Apenas os campos enviados serão alterados."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Avaliação atualizada com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Dados inválidos"),
+            @ApiResponse(responseCode = "404", description = "Avaliação não encontrada")
+    })
+    @PutMapping("/{id}")
+    public ResponseEntity<AvaliacaoFisioterapeuticaResponseDTO> atualizar(
+            @Parameter(description = "ID da avaliação fisioterapêutica", required = true) @PathVariable Long id,
+            @RequestBody @Valid AvaliacaoFisioterapeuticaUpdateDTO dto) {
+        return ResponseEntity.ok(service.atualizar(id, dto));
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/dto/AvaliacaoFisioterapeuticaRequestDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/AvaliacaoFisioterapeuticaRequestDTO.java
@@ -1,0 +1,24 @@
+package com.carlesso.pilatesapi.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+public record AvaliacaoFisioterapeuticaRequestDTO(
+        @NotNull Long pacienteId,
+        @NotNull LocalDate dataAvaliacao,
+        @NotBlank String queixaFuncional,
+        String avaliacaoPostural,
+        String mobilidadeArticular,
+        String forcaMuscular,
+        String flexibilidade,
+        String equilibrio,
+        String coordenacaoMotora,
+        String padraoRespiratorio,
+        @NotNull @Min(0) @Max(10) Integer escalaDor,
+        String testesFuncionaisRealizados,
+        @NotBlank String diagnosticoFisioterapeutico,
+        String observacoesGerais
+) {}

--- a/src/main/java/com/carlesso/pilatesapi/dto/AvaliacaoFisioterapeuticaResponseDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/AvaliacaoFisioterapeuticaResponseDTO.java
@@ -1,0 +1,49 @@
+package com.carlesso.pilatesapi.dto;
+
+import com.carlesso.pilatesapi.entity.AvaliacaoFisioterapeutica;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record AvaliacaoFisioterapeuticaResponseDTO(
+        Long id,
+        Long pacienteId,
+        String nomePaciente,
+        LocalDate dataAvaliacao,
+        String queixaFuncional,
+        String avaliacaoPostural,
+        String mobilidadeArticular,
+        String forcaMuscular,
+        String flexibilidade,
+        String equilibrio,
+        String coordenacaoMotora,
+        String padraoRespiratorio,
+        Integer escalaDor,
+        String testesFuncionaisRealizados,
+        String diagnosticoFisioterapeutico,
+        String observacoesGerais,
+        LocalDateTime dataCriacao,
+        LocalDateTime dataAtualizacao
+) {
+    public static AvaliacaoFisioterapeuticaResponseDTO from(AvaliacaoFisioterapeutica a) {
+        return new AvaliacaoFisioterapeuticaResponseDTO(
+                a.getId(),
+                a.getPaciente().getId(),
+                a.getPaciente().getNome(),
+                a.getDataAvaliacao(),
+                a.getQueixaFuncional(),
+                a.getAvaliacaoPostural(),
+                a.getMobilidadeArticular(),
+                a.getForcaMuscular(),
+                a.getFlexibilidade(),
+                a.getEquilibrio(),
+                a.getCoordenacaoMotora(),
+                a.getPadraoRespiratorio(),
+                a.getEscalaDor(),
+                a.getTestesFuncionaisRealizados(),
+                a.getDiagnosticoFisioterapeutico(),
+                a.getObservacoesGerais(),
+                a.getDataCriacao(),
+                a.getDataAtualizacao()
+        );
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/dto/AvaliacaoFisioterapeuticaUpdateDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/AvaliacaoFisioterapeuticaUpdateDTO.java
@@ -1,0 +1,24 @@
+package com.carlesso.pilatesapi.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
+
+public record AvaliacaoFisioterapeuticaUpdateDTO(
+        LocalDate dataAvaliacao,
+        @Pattern(regexp = ".*\\S.*", message = "queixaFuncional não pode ser vazio")
+        String queixaFuncional,
+        String avaliacaoPostural,
+        String mobilidadeArticular,
+        String forcaMuscular,
+        String flexibilidade,
+        String equilibrio,
+        String coordenacaoMotora,
+        String padraoRespiratorio,
+        @Min(0) @Max(10) Integer escalaDor,
+        String testesFuncionaisRealizados,
+        @Pattern(regexp = ".*\\S.*", message = "diagnosticoFisioterapeutico não pode ser vazio")
+        String diagnosticoFisioterapeutico,
+        String observacoesGerais
+) {}

--- a/src/main/java/com/carlesso/pilatesapi/entity/AvaliacaoFisioterapeutica.java
+++ b/src/main/java/com/carlesso/pilatesapi/entity/AvaliacaoFisioterapeutica.java
@@ -1,0 +1,114 @@
+package com.carlesso.pilatesapi.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "avaliacoes_fisioterapeuticas")
+public class AvaliacaoFisioterapeutica {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "paciente_id", nullable = false)
+    private Paciente paciente;
+
+    @Column(nullable = false)
+    private LocalDate dataAvaliacao;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String queixaFuncional;
+
+    @Column(columnDefinition = "TEXT")
+    private String avaliacaoPostural;
+
+    @Column(columnDefinition = "TEXT")
+    private String mobilidadeArticular;
+
+    @Column(columnDefinition = "TEXT")
+    private String forcaMuscular;
+
+    @Column(columnDefinition = "TEXT")
+    private String flexibilidade;
+
+    @Column(columnDefinition = "TEXT")
+    private String equilibrio;
+
+    @Column(columnDefinition = "TEXT")
+    private String coordenacaoMotora;
+
+    @Column(columnDefinition = "TEXT")
+    private String padraoRespiratorio;
+
+    @Column(nullable = false)
+    private Integer escalaDor;
+
+    @Column(columnDefinition = "TEXT")
+    private String testesFuncionaisRealizados;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String diagnosticoFisioterapeutico;
+
+    @Column(columnDefinition = "TEXT")
+    private String observacoesGerais;
+
+    @Column(nullable = false)
+    private LocalDateTime dataCriacao;
+
+    private LocalDateTime dataAtualizacao;
+
+    public AvaliacaoFisioterapeutica() {}
+
+    public Long getId() { return id; }
+
+    public Paciente getPaciente() { return paciente; }
+    public void setPaciente(Paciente paciente) { this.paciente = paciente; }
+
+    public LocalDate getDataAvaliacao() { return dataAvaliacao; }
+    public void setDataAvaliacao(LocalDate dataAvaliacao) { this.dataAvaliacao = dataAvaliacao; }
+
+    public String getQueixaFuncional() { return queixaFuncional; }
+    public void setQueixaFuncional(String queixaFuncional) { this.queixaFuncional = queixaFuncional; }
+
+    public String getAvaliacaoPostural() { return avaliacaoPostural; }
+    public void setAvaliacaoPostural(String avaliacaoPostural) { this.avaliacaoPostural = avaliacaoPostural; }
+
+    public String getMobilidadeArticular() { return mobilidadeArticular; }
+    public void setMobilidadeArticular(String mobilidadeArticular) { this.mobilidadeArticular = mobilidadeArticular; }
+
+    public String getForcaMuscular() { return forcaMuscular; }
+    public void setForcaMuscular(String forcaMuscular) { this.forcaMuscular = forcaMuscular; }
+
+    public String getFlexibilidade() { return flexibilidade; }
+    public void setFlexibilidade(String flexibilidade) { this.flexibilidade = flexibilidade; }
+
+    public String getEquilibrio() { return equilibrio; }
+    public void setEquilibrio(String equilibrio) { this.equilibrio = equilibrio; }
+
+    public String getCoordenacaoMotora() { return coordenacaoMotora; }
+    public void setCoordenacaoMotora(String coordenacaoMotora) { this.coordenacaoMotora = coordenacaoMotora; }
+
+    public String getPadraoRespiratorio() { return padraoRespiratorio; }
+    public void setPadraoRespiratorio(String padraoRespiratorio) { this.padraoRespiratorio = padraoRespiratorio; }
+
+    public Integer getEscalaDor() { return escalaDor; }
+    public void setEscalaDor(Integer escalaDor) { this.escalaDor = escalaDor; }
+
+    public String getTestesFuncionaisRealizados() { return testesFuncionaisRealizados; }
+    public void setTestesFuncionaisRealizados(String testesFuncionaisRealizados) { this.testesFuncionaisRealizados = testesFuncionaisRealizados; }
+
+    public String getDiagnosticoFisioterapeutico() { return diagnosticoFisioterapeutico; }
+    public void setDiagnosticoFisioterapeutico(String diagnosticoFisioterapeutico) { this.diagnosticoFisioterapeutico = diagnosticoFisioterapeutico; }
+
+    public String getObservacoesGerais() { return observacoesGerais; }
+    public void setObservacoesGerais(String observacoesGerais) { this.observacoesGerais = observacoesGerais; }
+
+    public LocalDateTime getDataCriacao() { return dataCriacao; }
+    public void setDataCriacao(LocalDateTime dataCriacao) { this.dataCriacao = dataCriacao; }
+
+    public LocalDateTime getDataAtualizacao() { return dataAtualizacao; }
+    public void setDataAtualizacao(LocalDateTime dataAtualizacao) { this.dataAtualizacao = dataAtualizacao; }
+}

--- a/src/main/java/com/carlesso/pilatesapi/entity/AvaliacaoFisioterapeutica.java
+++ b/src/main/java/com/carlesso/pilatesapi/entity/AvaliacaoFisioterapeutica.java
@@ -62,6 +62,11 @@ public class AvaliacaoFisioterapeutica {
 
     public AvaliacaoFisioterapeutica() {}
 
+    @PrePersist
+    void prePersist() {
+        this.dataCriacao = LocalDateTime.now();
+    }
+
     public Long getId() { return id; }
 
     public Paciente getPaciente() { return paciente; }

--- a/src/main/java/com/carlesso/pilatesapi/repository/AvaliacaoFisioterapeuticaRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/AvaliacaoFisioterapeuticaRepository.java
@@ -2,13 +2,17 @@ package com.carlesso.pilatesapi.repository;
 
 import com.carlesso.pilatesapi.entity.AvaliacaoFisioterapeutica;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface AvaliacaoFisioterapeuticaRepository extends JpaRepository<AvaliacaoFisioterapeutica, Long> {
 
-    Optional<AvaliacaoFisioterapeutica> findByIdAndPacienteAtivoTrue(Long id);
+    @Query("SELECT a FROM AvaliacaoFisioterapeutica a JOIN FETCH a.paciente p WHERE a.id = :id AND p.ativo = true")
+    Optional<AvaliacaoFisioterapeutica> findAtivaById(@Param("id") Long id);
 
-    List<AvaliacaoFisioterapeutica> findByPacienteIdAndPacienteAtivoTrueOrderByDataAvaliacaoDescIdDesc(Long pacienteId);
+    @Query("SELECT a FROM AvaliacaoFisioterapeutica a JOIN FETCH a.paciente p WHERE p.id = :pacienteId AND p.ativo = true ORDER BY a.dataAvaliacao DESC, a.id DESC")
+    List<AvaliacaoFisioterapeutica> findAtivasByPacienteOrdenadas(@Param("pacienteId") Long pacienteId);
 }

--- a/src/main/java/com/carlesso/pilatesapi/repository/AvaliacaoFisioterapeuticaRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/AvaliacaoFisioterapeuticaRepository.java
@@ -1,0 +1,14 @@
+package com.carlesso.pilatesapi.repository;
+
+import com.carlesso.pilatesapi.entity.AvaliacaoFisioterapeutica;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AvaliacaoFisioterapeuticaRepository extends JpaRepository<AvaliacaoFisioterapeutica, Long> {
+
+    Optional<AvaliacaoFisioterapeutica> findByIdAndPacienteAtivoTrue(Long id);
+
+    List<AvaliacaoFisioterapeutica> findByPacienteIdAndPacienteAtivoTrueOrderByDataAvaliacaoDescIdDesc(Long pacienteId);
+}

--- a/src/main/java/com/carlesso/pilatesapi/service/AvaliacaoFisioterapeuticaService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/AvaliacaoFisioterapeuticaService.java
@@ -46,7 +46,7 @@ public class AvaliacaoFisioterapeuticaService {
         avaliacao.setTestesFuncionaisRealizados(dto.testesFuncionaisRealizados());
         avaliacao.setDiagnosticoFisioterapeutico(dto.diagnosticoFisioterapeutico());
         avaliacao.setObservacoesGerais(dto.observacoesGerais());
-        avaliacao.setDataCriacao(LocalDateTime.now());
+        // dataCriacao definida por @PrePersist na entidade
 
         return AvaliacaoFisioterapeuticaResponseDTO.from(avaliacaoRepository.save(avaliacao));
     }
@@ -61,7 +61,7 @@ public class AvaliacaoFisioterapeuticaService {
         if (!pacienteRepository.existsByIdAndAtivoTrue(pacienteId)) {
             throw new ResourceNotFoundException("Paciente não encontrado: " + pacienteId);
         }
-        return avaliacaoRepository.findByPacienteIdAndPacienteAtivoTrueOrderByDataAvaliacaoDescIdDesc(pacienteId)
+        return avaliacaoRepository.findAtivasByPacienteOrdenadas(pacienteId)
                 .stream()
                 .map(AvaliacaoFisioterapeuticaResponseDTO::from)
                 .toList();
@@ -70,9 +70,6 @@ public class AvaliacaoFisioterapeuticaService {
     @Transactional
     public AvaliacaoFisioterapeuticaResponseDTO atualizar(Long id, AvaliacaoFisioterapeuticaUpdateDTO dto) {
         AvaliacaoFisioterapeutica avaliacao = encontrar(id);
-
-        validarCampoObrigatorio("queixaFuncional", dto.queixaFuncional());
-        validarCampoObrigatorio("diagnosticoFisioterapeutico", dto.diagnosticoFisioterapeutico());
 
         if (dto.dataAvaliacao() != null) avaliacao.setDataAvaliacao(dto.dataAvaliacao());
         if (dto.queixaFuncional() != null) avaliacao.setQueixaFuncional(dto.queixaFuncional());
@@ -89,17 +86,11 @@ public class AvaliacaoFisioterapeuticaService {
         if (dto.observacoesGerais() != null) avaliacao.setObservacoesGerais(dto.observacoesGerais());
         avaliacao.setDataAtualizacao(LocalDateTime.now());
 
-        return AvaliacaoFisioterapeuticaResponseDTO.from(avaliacao);
+        return AvaliacaoFisioterapeuticaResponseDTO.from(avaliacaoRepository.save(avaliacao));
     }
 
     private AvaliacaoFisioterapeutica encontrar(Long id) {
-        return avaliacaoRepository.findByIdAndPacienteAtivoTrue(id)
+        return avaliacaoRepository.findAtivaById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Avaliação fisioterapêutica não encontrada: " + id));
-    }
-
-    private void validarCampoObrigatorio(String campo, String valor) {
-        if (valor != null && valor.isBlank()) {
-            throw new IllegalArgumentException(campo + " não pode ser vazio");
-        }
     }
 }

--- a/src/main/java/com/carlesso/pilatesapi/service/AvaliacaoFisioterapeuticaService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/AvaliacaoFisioterapeuticaService.java
@@ -1,0 +1,105 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.AvaliacaoFisioterapeuticaRequestDTO;
+import com.carlesso.pilatesapi.dto.AvaliacaoFisioterapeuticaResponseDTO;
+import com.carlesso.pilatesapi.dto.AvaliacaoFisioterapeuticaUpdateDTO;
+import com.carlesso.pilatesapi.entity.AvaliacaoFisioterapeutica;
+import com.carlesso.pilatesapi.entity.Paciente;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
+import com.carlesso.pilatesapi.repository.AvaliacaoFisioterapeuticaRepository;
+import com.carlesso.pilatesapi.repository.PacienteRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class AvaliacaoFisioterapeuticaService {
+
+    private final AvaliacaoFisioterapeuticaRepository avaliacaoRepository;
+    private final PacienteRepository pacienteRepository;
+
+    public AvaliacaoFisioterapeuticaService(AvaliacaoFisioterapeuticaRepository avaliacaoRepository,
+                                            PacienteRepository pacienteRepository) {
+        this.avaliacaoRepository = avaliacaoRepository;
+        this.pacienteRepository = pacienteRepository;
+    }
+
+    @Transactional
+    public AvaliacaoFisioterapeuticaResponseDTO criar(AvaliacaoFisioterapeuticaRequestDTO dto) {
+        Paciente paciente = pacienteRepository.findByIdAndAtivoTrue(dto.pacienteId())
+                .orElseThrow(() -> new ResourceNotFoundException("Paciente não encontrado: " + dto.pacienteId()));
+
+        AvaliacaoFisioterapeutica avaliacao = new AvaliacaoFisioterapeutica();
+        avaliacao.setPaciente(paciente);
+        avaliacao.setDataAvaliacao(dto.dataAvaliacao());
+        avaliacao.setQueixaFuncional(dto.queixaFuncional());
+        avaliacao.setAvaliacaoPostural(dto.avaliacaoPostural());
+        avaliacao.setMobilidadeArticular(dto.mobilidadeArticular());
+        avaliacao.setForcaMuscular(dto.forcaMuscular());
+        avaliacao.setFlexibilidade(dto.flexibilidade());
+        avaliacao.setEquilibrio(dto.equilibrio());
+        avaliacao.setCoordenacaoMotora(dto.coordenacaoMotora());
+        avaliacao.setPadraoRespiratorio(dto.padraoRespiratorio());
+        avaliacao.setEscalaDor(dto.escalaDor());
+        avaliacao.setTestesFuncionaisRealizados(dto.testesFuncionaisRealizados());
+        avaliacao.setDiagnosticoFisioterapeutico(dto.diagnosticoFisioterapeutico());
+        avaliacao.setObservacoesGerais(dto.observacoesGerais());
+        avaliacao.setDataCriacao(LocalDateTime.now());
+
+        return AvaliacaoFisioterapeuticaResponseDTO.from(avaliacaoRepository.save(avaliacao));
+    }
+
+    @Transactional(readOnly = true)
+    public AvaliacaoFisioterapeuticaResponseDTO buscarPorId(Long id) {
+        return AvaliacaoFisioterapeuticaResponseDTO.from(encontrar(id));
+    }
+
+    @Transactional(readOnly = true)
+    public List<AvaliacaoFisioterapeuticaResponseDTO> listarPorPaciente(Long pacienteId) {
+        if (!pacienteRepository.existsByIdAndAtivoTrue(pacienteId)) {
+            throw new ResourceNotFoundException("Paciente não encontrado: " + pacienteId);
+        }
+        return avaliacaoRepository.findByPacienteIdAndPacienteAtivoTrueOrderByDataAvaliacaoDescIdDesc(pacienteId)
+                .stream()
+                .map(AvaliacaoFisioterapeuticaResponseDTO::from)
+                .toList();
+    }
+
+    @Transactional
+    public AvaliacaoFisioterapeuticaResponseDTO atualizar(Long id, AvaliacaoFisioterapeuticaUpdateDTO dto) {
+        AvaliacaoFisioterapeutica avaliacao = encontrar(id);
+
+        validarCampoObrigatorio("queixaFuncional", dto.queixaFuncional());
+        validarCampoObrigatorio("diagnosticoFisioterapeutico", dto.diagnosticoFisioterapeutico());
+
+        if (dto.dataAvaliacao() != null) avaliacao.setDataAvaliacao(dto.dataAvaliacao());
+        if (dto.queixaFuncional() != null) avaliacao.setQueixaFuncional(dto.queixaFuncional());
+        if (dto.avaliacaoPostural() != null) avaliacao.setAvaliacaoPostural(dto.avaliacaoPostural());
+        if (dto.mobilidadeArticular() != null) avaliacao.setMobilidadeArticular(dto.mobilidadeArticular());
+        if (dto.forcaMuscular() != null) avaliacao.setForcaMuscular(dto.forcaMuscular());
+        if (dto.flexibilidade() != null) avaliacao.setFlexibilidade(dto.flexibilidade());
+        if (dto.equilibrio() != null) avaliacao.setEquilibrio(dto.equilibrio());
+        if (dto.coordenacaoMotora() != null) avaliacao.setCoordenacaoMotora(dto.coordenacaoMotora());
+        if (dto.padraoRespiratorio() != null) avaliacao.setPadraoRespiratorio(dto.padraoRespiratorio());
+        if (dto.escalaDor() != null) avaliacao.setEscalaDor(dto.escalaDor());
+        if (dto.testesFuncionaisRealizados() != null) avaliacao.setTestesFuncionaisRealizados(dto.testesFuncionaisRealizados());
+        if (dto.diagnosticoFisioterapeutico() != null) avaliacao.setDiagnosticoFisioterapeutico(dto.diagnosticoFisioterapeutico());
+        if (dto.observacoesGerais() != null) avaliacao.setObservacoesGerais(dto.observacoesGerais());
+        avaliacao.setDataAtualizacao(LocalDateTime.now());
+
+        return AvaliacaoFisioterapeuticaResponseDTO.from(avaliacao);
+    }
+
+    private AvaliacaoFisioterapeutica encontrar(Long id) {
+        return avaliacaoRepository.findByIdAndPacienteAtivoTrue(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Avaliação fisioterapêutica não encontrada: " + id));
+    }
+
+    private void validarCampoObrigatorio(String campo, String valor) {
+        if (valor != null && valor.isBlank()) {
+            throw new IllegalArgumentException(campo + " não pode ser vazio");
+        }
+    }
+}

--- a/src/main/resources/db/migration/V15__create_avaliacoes_fisioterapeuticas_table.sql
+++ b/src/main/resources/db/migration/V15__create_avaliacoes_fisioterapeuticas_table.sql
@@ -1,0 +1,22 @@
+CREATE TABLE avaliacoes_fisioterapeuticas (
+    id                               BIGSERIAL       PRIMARY KEY,
+    paciente_id                      BIGINT          NOT NULL REFERENCES pacientes(id),
+    data_avaliacao                   DATE            NOT NULL,
+    queixa_funcional                 TEXT            NOT NULL,
+    avaliacao_postural               TEXT,
+    mobilidade_articular             TEXT,
+    forca_muscular                   TEXT,
+    flexibilidade                    TEXT,
+    equilibrio                       TEXT,
+    coordenacao_motora               TEXT,
+    padrao_respiratorio              TEXT,
+    escala_dor                       INTEGER         NOT NULL CHECK (escala_dor BETWEEN 0 AND 10),
+    testes_funcionais_realizados     TEXT,
+    diagnostico_fisioterapeutico     TEXT            NOT NULL,
+    observacoes_gerais               TEXT,
+    data_criacao                     TIMESTAMP       NOT NULL,
+    data_atualizacao                 TIMESTAMP
+);
+
+CREATE INDEX idx_avaliacoes_fisioterapeuticas_paciente_id
+    ON avaliacoes_fisioterapeuticas(paciente_id);

--- a/src/test/java/com/carlesso/pilatesapi/controller/AvaliacaoFisioterapeuticaControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/AvaliacaoFisioterapeuticaControllerTest.java
@@ -1,0 +1,213 @@
+package com.carlesso.pilatesapi.controller;
+
+import com.carlesso.pilatesapi.dto.AvaliacaoFisioterapeuticaRequestDTO;
+import com.carlesso.pilatesapi.dto.AvaliacaoFisioterapeuticaResponseDTO;
+import com.carlesso.pilatesapi.dto.AvaliacaoFisioterapeuticaUpdateDTO;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
+import com.carlesso.pilatesapi.service.AvaliacaoFisioterapeuticaService;
+import com.carlesso.pilatesapi.service.CustomUserDetailsService;
+import com.carlesso.pilatesapi.service.JwtService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AvaliacaoFisioterapeuticaController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AvaliacaoFisioterapeuticaControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockitoBean
+    private AvaliacaoFisioterapeuticaService service;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    private AvaliacaoFisioterapeuticaResponseDTO responseDTO() {
+        return new AvaliacaoFisioterapeuticaResponseDTO(
+                1L, 1L, "Maria Souza",
+                LocalDate.of(2026, 4, 20),
+                "Dor ao agachar", "Anteriorização de cabeça", "Restrição em quadril direito",
+                "Glúteo médio grau 4", "Encurtamento de cadeia posterior", "Instável em apoio unipodal",
+                "Boa coordenação", "Respiração apical", 6,
+                "Agachamento, ponte, apoio unipodal", "Disfunção lombopélvica",
+                "Reavaliar em 30 dias", LocalDateTime.of(2026, 4, 20, 10, 0), null
+        );
+    }
+
+    private AvaliacaoFisioterapeuticaRequestDTO requestDTO() {
+        return new AvaliacaoFisioterapeuticaRequestDTO(
+                1L,
+                LocalDate.of(2026, 4, 20),
+                "Dor ao agachar",
+                "Anteriorização de cabeça",
+                "Restrição em quadril direito",
+                "Glúteo médio grau 4",
+                "Encurtamento de cadeia posterior",
+                "Instável em apoio unipodal",
+                "Boa coordenação",
+                "Respiração apical",
+                6,
+                "Agachamento, ponte, apoio unipodal",
+                "Disfunção lombopélvica",
+                "Reavaliar em 30 dias"
+        );
+    }
+
+    @Test
+    void criar_comDadosValidos_deveRetornar201ComHeaderLocation() throws Exception {
+        when(service.criar(any())).thenReturn(responseDTO());
+
+        mvc.perform(post("/avaliacoes-fisioterapeuticas")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(requestDTO())))
+                .andExpect(status().isCreated())
+                .andExpect(header().exists("Location"))
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.pacienteId").value(1))
+                .andExpect(jsonPath("$.nomePaciente").value("Maria Souza"))
+                .andExpect(jsonPath("$.escalaDor").value(6));
+    }
+
+    @Test
+    void criar_semPacienteId_deveRetornar400() throws Exception {
+        var dto = new AvaliacaoFisioterapeuticaRequestDTO(
+                null, LocalDate.of(2026, 4, 20), "Dor", null, null, null, null,
+                null, null, null, 5, null, "Diagnóstico", null
+        );
+
+        mvc.perform(post("/avaliacoes-fisioterapeuticas")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void criar_semDataAvaliacao_deveRetornar400() throws Exception {
+        var dto = new AvaliacaoFisioterapeuticaRequestDTO(
+                1L, null, "Dor", null, null, null, null,
+                null, null, null, 5, null, "Diagnóstico", null
+        );
+
+        mvc.perform(post("/avaliacoes-fisioterapeuticas")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void criar_comEscalaDorForaDoIntervalo_deveRetornar400() throws Exception {
+        var dto = new AvaliacaoFisioterapeuticaRequestDTO(
+                1L, LocalDate.of(2026, 4, 20), "Dor", null, null, null, null,
+                null, null, null, 11, null, "Diagnóstico", null
+        );
+
+        mvc.perform(post("/avaliacoes-fisioterapeuticas")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void criar_comPacienteInexistente_deveRetornar404() throws Exception {
+        when(service.criar(any())).thenThrow(new ResourceNotFoundException("Paciente não encontrado: 99"));
+
+        mvc.perform(post("/avaliacoes-fisioterapeuticas")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(requestDTO())))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.erro").value("Paciente não encontrado: 99"));
+    }
+
+    @Test
+    void buscarPorId_quandoExistente_deveRetornar200() throws Exception {
+        when(service.buscarPorId(1L)).thenReturn(responseDTO());
+
+        mvc.perform(get("/avaliacoes-fisioterapeuticas/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.queixaFuncional").value("Dor ao agachar"));
+    }
+
+    @Test
+    void buscarPorId_quandoNaoExistente_deveRetornar404() throws Exception {
+        when(service.buscarPorId(99L))
+                .thenThrow(new ResourceNotFoundException("Avaliação fisioterapêutica não encontrada: 99"));
+
+        mvc.perform(get("/avaliacoes-fisioterapeuticas/99"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.erro").value("Avaliação fisioterapêutica não encontrada: 99"));
+    }
+
+    @Test
+    void listarPorPaciente_deveRetornar200ComAvaliacoes() throws Exception {
+        when(service.listarPorPaciente(1L)).thenReturn(List.of(responseDTO()));
+
+        mvc.perform(get("/avaliacoes-fisioterapeuticas/paciente/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].pacienteId").value(1))
+                .andExpect(jsonPath("$[0].dataAvaliacao").value("2026-04-20"));
+    }
+
+    @Test
+    void atualizar_deveRetornar200ComDadosAtualizados() throws Exception {
+        var updated = new AvaliacaoFisioterapeuticaResponseDTO(
+                1L, 1L, "Maria Souza",
+                LocalDate.of(2026, 5, 5),
+                "Dor reduzida ao agachar", "Anteriorização de cabeça", "Restrição em quadril direito",
+                "Glúteo médio grau 4", "Encurtamento de cadeia posterior", "Instável em apoio unipodal",
+                "Boa coordenação", "Respiração apical", 3,
+                "Agachamento, ponte, apoio unipodal", "Disfunção lombopélvica",
+                "Evoluiu com exercícios", LocalDateTime.of(2026, 4, 20, 10, 0),
+                LocalDateTime.of(2026, 5, 5, 9, 0)
+        );
+        when(service.atualizar(eq(1L), any())).thenReturn(updated);
+
+        var dto = new AvaliacaoFisioterapeuticaUpdateDTO(
+                LocalDate.of(2026, 5, 5), "Dor reduzida ao agachar", null, null, null,
+                null, null, null, null, 3, null, null, "Evoluiu com exercícios"
+        );
+
+        mvc.perform(put("/avaliacoes-fisioterapeuticas/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.dataAvaliacao").value("2026-05-05"))
+                .andExpect(jsonPath("$.escalaDor").value(3))
+                .andExpect(jsonPath("$.dataAtualizacao").isNotEmpty());
+    }
+
+    @Test
+    void atualizar_comEscalaDorNegativa_deveRetornar400() throws Exception {
+        var dto = new AvaliacaoFisioterapeuticaUpdateDTO(
+                null, null, null, null, null, null, null, null, null, -1, null, null, null
+        );
+
+        mvc.perform(put("/avaliacoes-fisioterapeuticas/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/controller/AvaliacaoFisioterapeuticaControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/AvaliacaoFisioterapeuticaControllerTest.java
@@ -210,4 +210,32 @@ class AvaliacaoFisioterapeuticaControllerTest {
                         .content(mapper.writeValueAsString(dto)))
                 .andExpect(status().isBadRequest());
     }
+
+    @Test
+    void atualizar_comQueixaFuncionalEmBranco_deveRetornar400() throws Exception {
+        var dto = new AvaliacaoFisioterapeuticaUpdateDTO(
+                null, "   ", null, null, null, null, null, null, null, null, null, null, null
+        );
+
+        mvc.perform(put("/avaliacoes-fisioterapeuticas/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void atualizar_comAvaliacaoInexistente_deveRetornar404() throws Exception {
+        when(service.atualizar(eq(99L), any()))
+                .thenThrow(new ResourceNotFoundException("Avaliação fisioterapêutica não encontrada: 99"));
+
+        var dto = new AvaliacaoFisioterapeuticaUpdateDTO(
+                LocalDate.of(2026, 5, 5), null, null, null, null, null, null, null, null, null, null, null, null
+        );
+
+        mvc.perform(put("/avaliacoes-fisioterapeuticas/99")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.erro").value("Avaliação fisioterapêutica não encontrada: 99"));
+    }
 }

--- a/src/test/java/com/carlesso/pilatesapi/service/AvaliacaoFisioterapeuticaServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/AvaliacaoFisioterapeuticaServiceTest.java
@@ -138,7 +138,7 @@ class AvaliacaoFisioterapeuticaServiceTest {
 
     @Test
     void buscarPorId_quandoExistente_deveRetornarResponseDTO() {
-        when(avaliacaoRepository.findByIdAndPacienteAtivoTrue(1L)).thenReturn(Optional.of(avaliacao(paciente())));
+        when(avaliacaoRepository.findAtivaById(1L)).thenReturn(Optional.of(avaliacao(paciente())));
 
         AvaliacaoFisioterapeuticaResponseDTO response = service.buscarPorId(1L);
 
@@ -148,7 +148,7 @@ class AvaliacaoFisioterapeuticaServiceTest {
 
     @Test
     void buscarPorId_quandoNaoExistente_deveLancarResourceNotFoundException() {
-        when(avaliacaoRepository.findByIdAndPacienteAtivoTrue(99L)).thenReturn(Optional.empty());
+        when(avaliacaoRepository.findAtivaById(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.buscarPorId(99L))
                 .isInstanceOf(ResourceNotFoundException.class)
@@ -159,14 +159,23 @@ class AvaliacaoFisioterapeuticaServiceTest {
     void listarPorPaciente_deveRetornarAvaliacoesDoPaciente() {
         Paciente p = paciente();
         when(pacienteRepository.existsByIdAndAtivoTrue(1L)).thenReturn(true);
-        when(avaliacaoRepository.findByPacienteIdAndPacienteAtivoTrueOrderByDataAvaliacaoDescIdDesc(1L))
-                .thenReturn(List.of(avaliacao(p)));
+        when(avaliacaoRepository.findAtivasByPacienteOrdenadas(1L)).thenReturn(List.of(avaliacao(p)));
 
         List<AvaliacaoFisioterapeuticaResponseDTO> response = service.listarPorPaciente(1L);
 
         assertThat(response).hasSize(1);
         assertThat(response.getFirst().pacienteId()).isEqualTo(1L);
         assertThat(response.getFirst().dataAvaliacao()).isEqualTo(LocalDate.of(2026, 4, 20));
+    }
+
+    @Test
+    void listarPorPaciente_comPacienteAtivoSemAvaliacoes_deveRetornarListaVazia() {
+        when(pacienteRepository.existsByIdAndAtivoTrue(1L)).thenReturn(true);
+        when(avaliacaoRepository.findAtivasByPacienteOrdenadas(1L)).thenReturn(List.of());
+
+        List<AvaliacaoFisioterapeuticaResponseDTO> response = service.listarPorPaciente(1L);
+
+        assertThat(response).isEmpty();
     }
 
     @Test
@@ -181,7 +190,8 @@ class AvaliacaoFisioterapeuticaServiceTest {
     @Test
     void atualizar_deveAtualizarApenasOsCamposInformados() {
         AvaliacaoFisioterapeutica a = avaliacao(paciente());
-        when(avaliacaoRepository.findByIdAndPacienteAtivoTrue(1L)).thenReturn(Optional.of(a));
+        when(avaliacaoRepository.findAtivaById(1L)).thenReturn(Optional.of(a));
+        when(avaliacaoRepository.save(a)).thenReturn(a);
 
         var dto = new AvaliacaoFisioterapeuticaUpdateDTO(
                 LocalDate.of(2026, 5, 5),
@@ -203,15 +213,15 @@ class AvaliacaoFisioterapeuticaServiceTest {
     }
 
     @Test
-    void atualizar_comQueixaFuncionalEmBranco_deveLancarIllegalArgumentException() {
-        when(avaliacaoRepository.findByIdAndPacienteAtivoTrue(1L)).thenReturn(Optional.of(avaliacao(paciente())));
+    void atualizar_comAvaliacaoInexistente_deveLancarResourceNotFoundException() {
+        when(avaliacaoRepository.findAtivaById(99L)).thenReturn(Optional.empty());
 
         var dto = new AvaliacaoFisioterapeuticaUpdateDTO(
-                null, " ", null, null, null, null, null, null, null, null, null, null, null
+                null, null, null, null, null, null, null, null, null, null, null, null, null
         );
 
-        assertThatThrownBy(() -> service.atualizar(1L, dto))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("queixaFuncional");
+        assertThatThrownBy(() -> service.atualizar(99L, dto))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
     }
 }

--- a/src/test/java/com/carlesso/pilatesapi/service/AvaliacaoFisioterapeuticaServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/AvaliacaoFisioterapeuticaServiceTest.java
@@ -1,0 +1,217 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.AvaliacaoFisioterapeuticaRequestDTO;
+import com.carlesso.pilatesapi.dto.AvaliacaoFisioterapeuticaResponseDTO;
+import com.carlesso.pilatesapi.dto.AvaliacaoFisioterapeuticaUpdateDTO;
+import com.carlesso.pilatesapi.entity.AvaliacaoFisioterapeutica;
+import com.carlesso.pilatesapi.entity.Paciente;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
+import com.carlesso.pilatesapi.repository.AvaliacaoFisioterapeuticaRepository;
+import com.carlesso.pilatesapi.repository.PacienteRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AvaliacaoFisioterapeuticaServiceTest {
+
+    @Mock
+    private AvaliacaoFisioterapeuticaRepository avaliacaoRepository;
+
+    @Mock
+    private PacienteRepository pacienteRepository;
+
+    @InjectMocks
+    private AvaliacaoFisioterapeuticaService service;
+
+    private Paciente paciente() {
+        Paciente p = new Paciente();
+        p.setNome("Maria Souza");
+        p.setEmail("maria@email.com");
+        p.setCpf("12345678900");
+        setId(p, 1L);
+        return p;
+    }
+
+    private AvaliacaoFisioterapeutica avaliacao(Paciente paciente) {
+        AvaliacaoFisioterapeutica a = new AvaliacaoFisioterapeutica();
+        a.setPaciente(paciente);
+        a.setDataAvaliacao(LocalDate.of(2026, 4, 20));
+        a.setQueixaFuncional("Dor ao agachar");
+        a.setAvaliacaoPostural("Anteriorização de cabeça");
+        a.setMobilidadeArticular("Restrição em quadril direito");
+        a.setForcaMuscular("Glúteo médio grau 4");
+        a.setFlexibilidade("Encurtamento de cadeia posterior");
+        a.setEquilibrio("Instável em apoio unipodal");
+        a.setCoordenacaoMotora("Boa coordenação");
+        a.setPadraoRespiratorio("Respiração apical");
+        a.setEscalaDor(6);
+        a.setTestesFuncionaisRealizados("Agachamento, ponte, apoio unipodal");
+        a.setDiagnosticoFisioterapeutico("Disfunção lombopélvica");
+        a.setObservacoesGerais("Reavaliar em 30 dias");
+        a.setDataCriacao(LocalDateTime.of(2026, 4, 20, 10, 0));
+        setAvaliacaoId(a, 1L);
+        return a;
+    }
+
+    private AvaliacaoFisioterapeuticaRequestDTO requestDTO() {
+        return new AvaliacaoFisioterapeuticaRequestDTO(
+                1L,
+                LocalDate.of(2026, 4, 20),
+                "Dor ao agachar",
+                "Anteriorização de cabeça",
+                "Restrição em quadril direito",
+                "Glúteo médio grau 4",
+                "Encurtamento de cadeia posterior",
+                "Instável em apoio unipodal",
+                "Boa coordenação",
+                "Respiração apical",
+                6,
+                "Agachamento, ponte, apoio unipodal",
+                "Disfunção lombopélvica",
+                "Reavaliar em 30 dias"
+        );
+    }
+
+    private void setId(Paciente p, Long id) {
+        try {
+            var field = Paciente.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(p, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void setAvaliacaoId(AvaliacaoFisioterapeutica a, Long id) {
+        try {
+            var field = AvaliacaoFisioterapeutica.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(a, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void criar_comPacienteValido_deveRetornarResponseDTO() {
+        Paciente p = paciente();
+        when(pacienteRepository.findByIdAndAtivoTrue(1L)).thenReturn(Optional.of(p));
+        when(avaliacaoRepository.save(any(AvaliacaoFisioterapeutica.class))).thenReturn(avaliacao(p));
+
+        AvaliacaoFisioterapeuticaResponseDTO response = service.criar(requestDTO());
+
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.pacienteId()).isEqualTo(1L);
+        assertThat(response.nomePaciente()).isEqualTo("Maria Souza");
+        assertThat(response.queixaFuncional()).isEqualTo("Dor ao agachar");
+        assertThat(response.escalaDor()).isEqualTo(6);
+        verify(avaliacaoRepository).save(any(AvaliacaoFisioterapeutica.class));
+    }
+
+    @Test
+    void criar_comPacienteInexistente_deveLancarResourceNotFoundException() {
+        when(pacienteRepository.findByIdAndAtivoTrue(99L)).thenReturn(Optional.empty());
+
+        var dto = new AvaliacaoFisioterapeuticaRequestDTO(
+                99L, LocalDate.of(2026, 4, 20), "Dor", null, null, null, null,
+                null, null, null, 5, null, "Diagnóstico", null
+        );
+
+        assertThatThrownBy(() -> service.criar(dto))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    void buscarPorId_quandoExistente_deveRetornarResponseDTO() {
+        when(avaliacaoRepository.findByIdAndPacienteAtivoTrue(1L)).thenReturn(Optional.of(avaliacao(paciente())));
+
+        AvaliacaoFisioterapeuticaResponseDTO response = service.buscarPorId(1L);
+
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.diagnosticoFisioterapeutico()).isEqualTo("Disfunção lombopélvica");
+    }
+
+    @Test
+    void buscarPorId_quandoNaoExistente_deveLancarResourceNotFoundException() {
+        when(avaliacaoRepository.findByIdAndPacienteAtivoTrue(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.buscarPorId(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    void listarPorPaciente_deveRetornarAvaliacoesDoPaciente() {
+        Paciente p = paciente();
+        when(pacienteRepository.existsByIdAndAtivoTrue(1L)).thenReturn(true);
+        when(avaliacaoRepository.findByPacienteIdAndPacienteAtivoTrueOrderByDataAvaliacaoDescIdDesc(1L))
+                .thenReturn(List.of(avaliacao(p)));
+
+        List<AvaliacaoFisioterapeuticaResponseDTO> response = service.listarPorPaciente(1L);
+
+        assertThat(response).hasSize(1);
+        assertThat(response.getFirst().pacienteId()).isEqualTo(1L);
+        assertThat(response.getFirst().dataAvaliacao()).isEqualTo(LocalDate.of(2026, 4, 20));
+    }
+
+    @Test
+    void listarPorPaciente_comPacienteInexistente_deveLancarResourceNotFoundException() {
+        when(pacienteRepository.existsByIdAndAtivoTrue(99L)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.listarPorPaciente(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    void atualizar_deveAtualizarApenasOsCamposInformados() {
+        AvaliacaoFisioterapeutica a = avaliacao(paciente());
+        when(avaliacaoRepository.findByIdAndPacienteAtivoTrue(1L)).thenReturn(Optional.of(a));
+
+        var dto = new AvaliacaoFisioterapeuticaUpdateDTO(
+                LocalDate.of(2026, 5, 5),
+                "Dor reduzida ao agachar",
+                null, null, null, null, null, null, null,
+                3,
+                null,
+                null,
+                "Evoluiu com exercícios"
+        );
+
+        AvaliacaoFisioterapeuticaResponseDTO response = service.atualizar(1L, dto);
+
+        assertThat(response.dataAvaliacao()).isEqualTo(LocalDate.of(2026, 5, 5));
+        assertThat(response.queixaFuncional()).isEqualTo("Dor reduzida ao agachar");
+        assertThat(response.escalaDor()).isEqualTo(3);
+        assertThat(response.diagnosticoFisioterapeutico()).isEqualTo("Disfunção lombopélvica");
+        assertThat(response.dataAtualizacao()).isNotNull();
+    }
+
+    @Test
+    void atualizar_comQueixaFuncionalEmBranco_deveLancarIllegalArgumentException() {
+        when(avaliacaoRepository.findByIdAndPacienteAtivoTrue(1L)).thenReturn(Optional.of(avaliacao(paciente())));
+
+        var dto = new AvaliacaoFisioterapeuticaUpdateDTO(
+                null, " ", null, null, null, null, null, null, null, null, null, null, null
+        );
+
+        assertThatThrownBy(() -> service.atualizar(1L, dto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("queixaFuncional");
+    }
+}


### PR DESCRIPTION
## Resumo da alteração

- Adiciona o módulo de Avaliação Fisioterapêutica com entidade JPA, DTOs, repository, service e controller REST.
- Cria endpoints para cadastrar, buscar por ID, listar por paciente e atualizar avaliações.
- Adiciona migration Flyway para a tabela `avaliacoes_fisioterapeuticas`, incluindo índice por `paciente_id` e validação de `escala_dor` entre 0 e 10.
- Atualiza README e `docs/context.md` com endpoints, modelo de dados, regras e testes.

## Motivo da mudança

Permitir registrar avaliações fisioterapêuticas técnicas vinculadas ao paciente, mantendo histórico clínico com múltiplas avaliações por paciente, conforme solicitado na issue #50.

## Testes executados

- `JAVA_HOME=~/jdk mvn -Dtest=AvaliacaoFisioterapeuticaServiceTest,AvaliacaoFisioterapeuticaControllerTest test`
- `JAVA_HOME=~/jdk mvn test` (261 testes, 0 falhas)
- `JAVA_HOME=~/jdk mvn -DskipTests package`

## Arquivos principais alterados

- `src/main/java/com/carlesso/pilatesapi/entity/AvaliacaoFisioterapeutica.java`
- `src/main/java/com/carlesso/pilatesapi/controller/AvaliacaoFisioterapeuticaController.java`
- `src/main/java/com/carlesso/pilatesapi/service/AvaliacaoFisioterapeuticaService.java`
- `src/main/java/com/carlesso/pilatesapi/dto/AvaliacaoFisioterapeutica*.java`
- `src/main/java/com/carlesso/pilatesapi/repository/AvaliacaoFisioterapeuticaRepository.java`
- `src/main/resources/db/migration/V15__create_avaliacoes_fisioterapeuticas_table.sql`
- `src/test/java/com/carlesso/pilatesapi/service/AvaliacaoFisioterapeuticaServiceTest.java`
- `src/test/java/com/carlesso/pilatesapi/controller/AvaliacaoFisioterapeuticaControllerTest.java`
- `README.md`
- `docs/context.md`

## Referência

Closes #50