### PR TITLE
feat: implementar plano de tratamento do paciente

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ src/
 │   │   │   ├── AulaController.java          # /aulas
 │   │   │   ├── AnamneseController.java      # /anamneses
 │   │   │   ├── AvaliacaoFisioterapeuticaController.java # /avaliacoes-fisioterapeuticas
+│   │   │   ├── PlanoTratamentoController.java          # /planos-tratamento
 │   │   │   ├── AuthController.java          # /auth/register e /auth/login
 │   │   │   ├── UserController.java          # /users/me e CRUD administrativo de usuários
 │   │   │   ├── AdminController.java         # /admin/health
@@ -62,6 +63,7 @@ src/
 │   │   │   ├── AulaService.java                        # Geração e controle de aulas
 │   │   │   ├── AnamneseService.java                    # Anamnese clínica do paciente
 │   │   │   ├── AvaliacaoFisioterapeuticaService.java   # Avaliação fisioterapêutica do paciente
+│   │   │   ├── PlanoTratamentoService.java             # Plano de tratamento do paciente
 │   │   │   ├── DashboardService.java                   # Contadores e totais para o painel inicial
 │   │   │   ├── RelatorioPagamentoExporterService.java  # Exportação do relatório em PDF e XLSX
 │   │   │   ├── RelatorioNfseService.java               # Relatório de emissão de NFSEs por competência
@@ -79,6 +81,7 @@ src/
 │   │   │   ├── AulaRepository.java
 │   │   │   ├── AnamneseRepository.java
 │   │   │   ├── AvaliacaoFisioterapeuticaRepository.java
+│   │   │   ├── PlanoTratamentoRepository.java
 │   │   │   └── UserRepository.java
 │   │   ├── entity/
 │   │   │   ├── Paciente.java                # Entidade JPA
@@ -89,6 +92,7 @@ src/
 │   │   │   ├── Aula.java                    # Aula agendada (com presença)
 │   │   │   ├── Anamnese.java                # Anamnese clínica do paciente
 │   │   │   ├── AvaliacaoFisioterapeutica.java # Avaliação técnica do paciente
+│   │   │   ├── PlanoTratamento.java           # Plano de tratamento clínico do paciente
 │   │   │   └── User.java                    # Usuário autenticável da API
 │   │   ├── security/
 │   │   │   └── JwtAuthenticationFilter.java # Validação do Bearer token por requisição
@@ -150,7 +154,8 @@ src/
 │           ├── V12__insert_users_perfis_acesso.sql
 │           ├── V13__add_indexes_on_foreign_keys.sql
 │           ├── V14__create_anamneses_table.sql
-│           └── V15__create_avaliacoes_fisioterapeuticas_table.sql
+│           ├── V15__create_avaliacoes_fisioterapeuticas_table.sql
+│           └── V16__create_planos_tratamento_table.sql
 └── test/java/com/carlesso/pilatesapi/
     ├── PilatesApiApplicationTests.java
     ├── actuator/
@@ -270,6 +275,15 @@ As demais rotas de negócio exigem `Authorization: Bearer <accessToken>`. Tokens
 | `GET` | `/avaliacoes-fisioterapeuticas/{id}` | Buscar avaliação fisioterapêutica por ID |
 | `GET` | `/avaliacoes-fisioterapeuticas/paciente/{pacienteId}` | Listar avaliações fisioterapêuticas do paciente |
 | `PUT` | `/avaliacoes-fisioterapeuticas/{id}` | Atualizar dados da avaliação fisioterapêutica |
+
+### Planos de Tratamento
+
+| Método | Endpoint | Descrição |
+|---|---|---|
+| `POST` | `/planos-tratamento` | Criar plano de tratamento para um paciente |
+| `GET` | `/planos-tratamento/{id}` | Buscar plano de tratamento por ID |
+| `GET` | `/planos-tratamento/paciente/{pacienteId}` | Listar planos de tratamento do paciente |
+| `PUT` | `/planos-tratamento/{id}` | Atualizar dados do plano de tratamento |
 
 ### Relatórios
 
@@ -645,6 +659,7 @@ O projeto utiliza **Flyway** para versionamento e execução automática das mig
 | `V13__add_indexes_on_foreign_keys.sql` | Adiciona índices para FKs e filtros recorrentes |
 | `V14__create_anamneses_table.sql` | Cria tabela `anamneses` vinculada a pacientes |
 | `V15__create_avaliacoes_fisioterapeuticas_table.sql` | Cria histórico de avaliações fisioterapêuticas do paciente |
+| `V16__create_planos_tratamento_table.sql` | Cria tabela de planos de tratamento do paciente |
 
 > Nos testes automatizados o Flyway fica desabilitado (`spring.flyway.enabled=false`), pois o banco H2 é gerenciado pelo Hibernate com `ddl-auto=create-drop`.
 
@@ -876,6 +891,14 @@ curl -s -OJ "http://localhost:8080/api/relatorios/nfse?competencia=04/2026&forma
 - Consultas e atualizações filtram avaliações vinculadas a pacientes ativos
 - Atualização parcial: apenas campos não-nulos do DTO de update são aplicados
 
+### Planos de Tratamento
+- Um paciente pode ter múltiplos planos de tratamento para manter histórico clínico
+- Criar plano para paciente inexistente ou inativo retorna `404`
+- Campos obrigatórios: `pacienteId`, `dataInicio` e `objetivosTratamento`
+- `numeroSessoesPrevistas` aceita apenas valores positivos quando informado
+- Consultas e atualizações filtram planos vinculados a pacientes ativos
+- Atualização parcial: apenas campos não-nulos do DTO de update são aplicados; `objetivosTratamento` não aceita strings em branco quando enviado
+
 ### Scheduler (processos automáticos)
 | Horário | Ação | Configuração |
 |---|---|---|
@@ -919,6 +942,7 @@ O projeto possui testes unitários, de controller e de integração organizados 
 | `AulaServiceTest` | Unitário (Mockito) | 14 |
 | `AnamneseServiceTest` | Unitário (Mockito) | 17 |
 | `AvaliacaoFisioterapeuticaServiceTest` | Unitário (Mockito) | 8 |
+| `PlanoTratamentoServiceTest` | Unitário (Mockito) | 8 |
 | `ProfissionalServiceTest` | Unitário (Mockito) | 15 |
 | `RelatorioPagamentoExporterServiceTest` | Unitário | 3 |
 | `RelatorioNfseServiceTest` | Unitário (Mockito) | 5 |
@@ -937,6 +961,7 @@ O projeto possui testes unitários, de controller e de integração organizados 
 | `AulaControllerTest` | Controller (`@WebMvcTest`) | 10 |
 | `AnamneseControllerTest` | Controller (`@WebMvcTest`) | 14 |
 | `AvaliacaoFisioterapeuticaControllerTest` | Controller (`@WebMvcTest`) | 10 |
+| `PlanoTratamentoControllerTest` | Controller (`@WebMvcTest`) | 11 |
 | `ProfissionalControllerTest` | Controller (`@WebMvcTest`) | 17 |
 | `RelatorioNfseControllerTest` | Controller (`@WebMvcTest`) | 6 |
 | `DashboardControllerTest` | Controller (`@WebMvcTest`) | 2 |

--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ As demais rotas de negócio exigem `Authorization: Bearer <accessToken>`. Tokens
 | `GET` | `/planos-tratamento/{id}` | Buscar plano de tratamento por ID |
 | `GET` | `/planos-tratamento/paciente/{pacienteId}` | Listar planos de tratamento do paciente |
 | `PUT` | `/planos-tratamento/{id}` | Atualizar dados do plano de tratamento |
+| `DELETE` | `/planos-tratamento/{id}` | Inativar plano de tratamento |
 
 ### Relatórios
 
@@ -895,9 +896,11 @@ curl -s -OJ "http://localhost:8080/api/relatorios/nfse?competencia=04/2026&forma
 - Um paciente pode ter múltiplos planos de tratamento para manter histórico clínico
 - Criar plano para paciente inexistente ou inativo retorna `404`
 - Campos obrigatórios: `pacienteId`, `dataInicio` e `objetivosTratamento`
+- `dataFimPrevista`, quando informada, não pode ser anterior a `dataInicio`
 - `numeroSessoesPrevistas` aceita apenas valores positivos quando informado
-- Consultas e atualizações filtram planos vinculados a pacientes ativos
+- Consultas e atualizações filtram planos ativos vinculados a pacientes ativos
 - Atualização parcial: apenas campos não-nulos do DTO de update são aplicados; `objetivosTratamento` não aceita strings em branco quando enviado
+- Exclusão é lógica: `DELETE /planos-tratamento/{id}` marca o plano como inativo e preserva o histórico no banco
 
 ### Scheduler (processos automáticos)
 | Horário | Ação | Configuração |
@@ -942,7 +945,7 @@ O projeto possui testes unitários, de controller e de integração organizados 
 | `AulaServiceTest` | Unitário (Mockito) | 14 |
 | `AnamneseServiceTest` | Unitário (Mockito) | 17 |
 | `AvaliacaoFisioterapeuticaServiceTest` | Unitário (Mockito) | 8 |
-| `PlanoTratamentoServiceTest` | Unitário (Mockito) | 8 |
+| `PlanoTratamentoServiceTest` | Unitário (Mockito) | 13 |
 | `ProfissionalServiceTest` | Unitário (Mockito) | 15 |
 | `RelatorioPagamentoExporterServiceTest` | Unitário | 3 |
 | `RelatorioNfseServiceTest` | Unitário (Mockito) | 5 |
@@ -960,8 +963,8 @@ O projeto possui testes unitários, de controller e de integração organizados 
 | `PagamentoControllerTest` | Controller (`@WebMvcTest`) | 11 |
 | `AulaControllerTest` | Controller (`@WebMvcTest`) | 10 |
 | `AnamneseControllerTest` | Controller (`@WebMvcTest`) | 14 |
-| `AvaliacaoFisioterapeuticaControllerTest` | Controller (`@WebMvcTest`) | 10 |
-| `PlanoTratamentoControllerTest` | Controller (`@WebMvcTest`) | 11 |
+| `AvaliacaoFisioterapeuticaControllerTest` | Controller (`@WebMvcTest`) | 12 |
+| `PlanoTratamentoControllerTest` | Controller (`@WebMvcTest`) | 18 |
 | `ProfissionalControllerTest` | Controller (`@WebMvcTest`) | 17 |
 | `RelatorioNfseControllerTest` | Controller (`@WebMvcTest`) | 6 |
 | `DashboardControllerTest` | Controller (`@WebMvcTest`) | 2 |

--- a/docs/context.md
+++ b/docs/context.md
@@ -51,6 +51,7 @@ com.carlesso.pilatesapi
 │   ├── AulaController.java           — endpoints REST de aulas
 │   ├── AnamneseController.java       — endpoints REST de anamneses
 │   ├── AvaliacaoFisioterapeuticaController.java — endpoints REST de avaliações fisioterapêuticas
+│   ├── PlanoTratamentoController.java — endpoints REST de planos de tratamento
 │   ├── AuthController.java           — registro/login com JWT
 │   ├── UserController.java           — endpoint do usuário autenticado e CRUD administrativo
 │   ├── AdminController.java          — endpoints administrativos
@@ -61,6 +62,7 @@ com.carlesso.pilatesapi
 │   ├── ProfissionalService.java                — lógica de negócio de profissionais
 │   ├── AnamneseService.java                    — lógica de negócio de anamneses
 │   ├── AvaliacaoFisioterapeuticaService.java   — lógica de negócio de avaliações fisioterapêuticas
+│   ├── PlanoTratamentoService.java             — lógica de negócio de planos de tratamento
 │   ├── PlanoService.java                       — regras de plano e frequência
 │   ├── PagamentoService.java                   — cobranças, confirmação, vencimentos
 │   ├── AulaService.java                        — geração e controle de aulas
@@ -81,6 +83,7 @@ com.carlesso.pilatesapi
 │   ├── AulaRepository.java
 │   ├── AnamneseRepository.java
 │   ├── AvaliacaoFisioterapeuticaRepository.java
+│   ├── PlanoTratamentoRepository.java
 │   └── UserRepository.java
 ├── entity
 │   ├── Paciente.java                 — entidade JPA, tabela `pacientes`
@@ -91,6 +94,7 @@ com.carlesso.pilatesapi
 │   ├── Aula.java                     — entidade JPA, tabela `aulas`
 │   ├── Anamnese.java                 — entidade JPA, tabela `anamneses`
 │   ├── AvaliacaoFisioterapeutica.java — entidade JPA, tabela `avaliacoes_fisioterapeuticas`
+│   ├── PlanoTratamento.java          — entidade JPA, tabela `planos_tratamento`
 │   └── User.java                     — entidade JPA, tabela `users`
 ├── entity/enums
 │   ├── TipoPagamento.java            — MENSAL, TRIMESTRAL, ANUAL
@@ -128,6 +132,9 @@ com.carlesso.pilatesapi
 │   ├── AvaliacaoFisioterapeuticaRequestDTO.java — payload de criação de avaliação fisioterapêutica
 │   ├── AvaliacaoFisioterapeuticaUpdateDTO.java  — payload de atualização de avaliação fisioterapêutica
 │   ├── AvaliacaoFisioterapeuticaResponseDTO.java — resposta da API de avaliação fisioterapêutica
+│   ├── PlanoTratamentoRequestDTO.java — payload de criação de plano de tratamento (record)
+│   ├── PlanoTratamentoUpdateDTO.java  — payload de atualização de plano de tratamento (record)
+│   ├── PlanoTratamentoResponseDTO.java — resposta da API de plano de tratamento (record com factory method `from`)
 │   ├── AuthRegisterRequestDTO.java
 │   ├── AuthLoginRequestDTO.java
 │   ├── AuthResponseDTO.java
@@ -264,6 +271,25 @@ Relacionamento `@OneToOne` com `Paciente`. Cada paciente possui no máximo uma a
 
 Relacionamento `@ManyToOne` com `Paciente`. Um paciente pode possuir múltiplas avaliações para manter histórico clínico.
 
+### Tabela `planos_tratamento`
+
+| Campo | Tipo | Restrição |
+|---|---|---|
+| `id` | BIGINT | PK, auto-increment |
+| `paciente_id` | BIGINT | NOT NULL, FK → pacientes |
+| `data_inicio` | DATE | NOT NULL |
+| `data_fim_prevista` | DATE | — |
+| `objetivos_tratamento` | TEXT | NOT NULL |
+| `intervencoes_planejadas` | TEXT | — |
+| `numero_sessoes_previstas` | INTEGER | — |
+| `frequencia_sessoes` | VARCHAR(100) | — |
+| `responsavel_tratamento` | VARCHAR(255) | — |
+| `observacoes` | TEXT | — |
+| `data_criacao` | TIMESTAMP | NOT NULL |
+| `data_atualizacao` | TIMESTAMP | — |
+
+Relacionamento `@ManyToOne` com `Paciente`. Um paciente pode possuir múltiplos planos de tratamento para manter histórico clínico.
+
 ### Índices
 
 | Índice | Tabela / Coluna | Motivação |
@@ -276,6 +302,7 @@ Relacionamento `@ManyToOne` com `Paciente`. Um paciente pode possuir múltiplas 
 | `idx_pagamentos_data_vencimento` | `pagamentos(data_vencimento)` | Scheduler das 06:00 faz range scan diário nessa coluna |
 | `idx_aulas_realizada` | `aulas(realizada)` | Relatório de pagamento de profissional filtra `realizada = true` |
 | `idx_avaliacoes_fisioterapeuticas_paciente_id` | `avaliacoes_fisioterapeuticas(paciente_id)` | Listagem de avaliações por paciente |
+| `idx_planos_tratamento_paciente_id` | `planos_tratamento(paciente_id)` | Listagem de planos de tratamento por paciente |
 > **Nota:** colunas `plano_dias_semana(plano_id)`, `pagamentos(plano_id)`, `aulas(paciente_id)` e `anamneses(paciente_id)` **não** possuem índice dedicado porque já são o prefixo esquerdo de índices compostos existentes ou possuem índice automático de constraint `UNIQUE`, que o PostgreSQL pode usar para buscas na coluna isolada.
 
 ---
@@ -330,6 +357,10 @@ Relacionamento `@ManyToOne` com `Paciente`. Um paciente pode possuir múltiplas 
 | GET | `/avaliacoes-fisioterapeuticas/{id}` | Buscar avaliação fisioterapêutica por ID | 200 / 404 |
 | GET | `/avaliacoes-fisioterapeuticas/paciente/{pacienteId}` | Listar avaliações fisioterapêuticas do paciente | 200 / 404 |
 | PUT | `/avaliacoes-fisioterapeuticas/{id}` | Atualizar avaliação fisioterapêutica (atualização parcial) | 200 / 400 / 404 |
+| POST | `/planos-tratamento` | Criar plano de tratamento para um paciente | 201 / 400 / 404 |
+| GET | `/planos-tratamento/{id}` | Buscar plano de tratamento por ID | 200 / 404 |
+| GET | `/planos-tratamento/paciente/{pacienteId}` | Listar planos de tratamento do paciente | 200 / 404 |
+| PUT | `/planos-tratamento/{id}` | Atualizar plano de tratamento (atualização parcial) | 200 / 400 / 404 |
 | GET | `/dashboard/resumo` | Resumo consolidado para o painel inicial (pacientes, profissionais, pagamentos, aulas) | 200 / 401 |
 
 Campos obrigatórios no cadastro de pacientes: `nome`, `email`, `cpf`.  
@@ -414,6 +445,15 @@ CPF não pode ser alterado após o cadastro.
 - `escalaDor` aceita apenas valores inteiros de 0 a 10
 - Consultas por ID e por paciente filtram `paciente.ativo = true`
 - Atualização parcial: apenas campos não-nulos do DTO de update são aplicados; campos textuais obrigatórios não aceitam strings em branco quando enviados
+- `dataCriacao` é registrada na criação e `dataAtualizacao` em cada atualização
+
+### Plano de Tratamento
+- Um paciente pode possuir múltiplos planos de tratamento para manter histórico clínico
+- Criar plano de tratamento para paciente inexistente ou inativo retorna `404`
+- Campos obrigatórios: `pacienteId`, `dataInicio` e `objetivosTratamento`
+- `numeroSessoesPrevistas` aceita apenas valores positivos quando informado
+- Consultas por ID e por paciente filtram `paciente.ativo = true`
+- Atualização parcial: apenas campos não-nulos do DTO de update são aplicados; `objetivosTratamento` não aceita strings em branco quando enviado
 - `dataCriacao` é registrada na criação e `dataAtualizacao` em cada atualização
 
 ### Scheduler (processos automáticos)

--- a/docs/context.md
+++ b/docs/context.md
@@ -244,6 +244,7 @@ Constraint: `UNIQUE (paciente_id, data)`
 | `observacoes` | TEXT | — |
 | `data_criacao` | TIMESTAMP | NOT NULL |
 | `data_atualizacao` | TIMESTAMP | — |
+| `ativo` | BOOLEAN | NOT NULL, default `true` |
 
 Relacionamento `@OneToOne` com `Paciente`. Cada paciente possui no máximo uma anamnese principal (constraint `UNIQUE paciente_id`).
 
@@ -361,6 +362,7 @@ Relacionamento `@ManyToOne` com `Paciente`. Um paciente pode possuir múltiplos 
 | GET | `/planos-tratamento/{id}` | Buscar plano de tratamento por ID | 200 / 404 |
 | GET | `/planos-tratamento/paciente/{pacienteId}` | Listar planos de tratamento do paciente | 200 / 404 |
 | PUT | `/planos-tratamento/{id}` | Atualizar plano de tratamento (atualização parcial) | 200 / 400 / 404 |
+| DELETE | `/planos-tratamento/{id}` | Inativar plano de tratamento | 204 / 404 |
 | GET | `/dashboard/resumo` | Resumo consolidado para o painel inicial (pacientes, profissionais, pagamentos, aulas) | 200 / 401 |
 
 Campos obrigatórios no cadastro de pacientes: `nome`, `email`, `cpf`.  
@@ -451,9 +453,11 @@ CPF não pode ser alterado após o cadastro.
 - Um paciente pode possuir múltiplos planos de tratamento para manter histórico clínico
 - Criar plano de tratamento para paciente inexistente ou inativo retorna `404`
 - Campos obrigatórios: `pacienteId`, `dataInicio` e `objetivosTratamento`
+- `dataFimPrevista`, quando informada, não pode ser anterior a `dataInicio`
 - `numeroSessoesPrevistas` aceita apenas valores positivos quando informado
-- Consultas por ID e por paciente filtram `paciente.ativo = true`
+- Consultas por ID e por paciente filtram `plano.ativo = true` e `paciente.ativo = true`
 - Atualização parcial: apenas campos não-nulos do DTO de update são aplicados; `objetivosTratamento` não aceita strings em branco quando enviado
+- Exclusão é lógica: `DELETE /planos-tratamento/{id}` marca `ativo = false` e preserva o histórico clínico
 - `dataCriacao` é registrada na criação e `dataAtualizacao` em cada atualização
 
 ### Scheduler (processos automáticos)
@@ -587,7 +591,9 @@ JAVA_HOME=~/jdk mvn spring-boot:run
 | `AnamneseServiceTest` | Unitário (Mockito, sem Spring) | 17 |
 | `AnamneseControllerTest` | `@WebMvcTest` + MockMvc | 14 |
 | `AvaliacaoFisioterapeuticaServiceTest` | Unitário (Mockito, sem Spring) | 8 |
-| `AvaliacaoFisioterapeuticaControllerTest` | `@WebMvcTest` + MockMvc | 10 |
+| `AvaliacaoFisioterapeuticaControllerTest` | `@WebMvcTest` + MockMvc | 12 |
+| `PlanoTratamentoServiceTest` | Unitário (Mockito, sem Spring) | 13 |
+| `PlanoTratamentoControllerTest` | `@WebMvcTest` + MockMvc | 18 |
 | `DashboardControllerTest` | `@WebMvcTest` + MockMvc | 2 |
 | `DashboardServiceTest` | Unitário (Mockito, sem Spring) | 3 |
 | `AppPropertiesTest` | Unitário (ApplicationContextRunner) | 3 |

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -74,6 +74,9 @@ src/
 │   │   │   ├── PlanoController.java         # /planos
 │   │   │   ├── PagamentoController.java     # /pagamentos
 │   │   │   ├── AulaController.java          # /aulas
+│   │   │   ├── AnamneseController.java      # /anamneses
+│   │   │   ├── AvaliacaoFisioterapeuticaController.java # /avaliacoes-fisioterapeuticas
+│   │   │   ├── PlanoTratamentoController.java # /planos-tratamento
 │   │   │   ├── AuthController.java          # /auth/register e /auth/login
 │   │   │   ├── UserController.java          # /users/me e CRUD administrativo
 │   │   │   ├── AdminController.java         # /admin/health
@@ -85,6 +88,9 @@ src/
 │   │   │   ├── PlanoService.java                       # Regras de plano e frequência
 │   │   │   ├── PagamentoService.java                   # Cobranças, confirmação, vencimentos
 │   │   │   ├── AulaService.java                        # Geração e controle de aulas
+│   │   │   ├── AnamneseService.java                    # Anamnese clínica do paciente
+│   │   │   ├── AvaliacaoFisioterapeuticaService.java   # Avaliação fisioterapêutica do paciente
+│   │   │   ├── PlanoTratamentoService.java             # Plano de tratamento clínico do paciente
 │   │   │   ├── DashboardService.java                   # Contadores e totais para o painel inicial
 │   │   │   ├── RelatorioPagamentoExporterService.java  # Exportação do relatório em PDF e XLSX
 │   │   │   ├── RelatorioNfseService.java               # Relatório de emissão de NFSEs por competência
@@ -99,6 +105,9 @@ src/
 │   │   │   ├── PlanoRepository.java
 │   │   │   ├── PagamentoRepository.java
 │   │   │   ├── AulaRepository.java
+│   │   │   ├── AnamneseRepository.java
+│   │   │   ├── AvaliacaoFisioterapeuticaRepository.java
+│   │   │   ├── PlanoTratamentoRepository.java
 │   │   │   └── UserRepository.java
 │   │   ├── entity/
 │   │   │   ├── Paciente.java                # Entidade JPA
@@ -107,6 +116,9 @@ src/
 │   │   │   ├── Plano.java
 │   │   │   ├── Pagamento.java
 │   │   │   ├── Aula.java
+│   │   │   ├── Anamnese.java
+│   │   │   ├── AvaliacaoFisioterapeutica.java
+│   │   │   ├── PlanoTratamento.java
 │   │   │   └── User.java
 │   │   ├── entity/enums/
 │   │   │   ├── TipoPagamento.java           # MENSAL, TRIMESTRAL, ANUAL
@@ -137,6 +149,15 @@ src/
 │   │   │   ├── PagamentoPagarRequestDTO.java
 │   │   │   ├── PagamentoResponseDTO.java
 │   │   │   ├── AulaResponseDTO.java
+│   │   │   ├── AnamneseRequestDTO.java
+│   │   │   ├── AnamneseUpdateDTO.java
+│   │   │   ├── AnamneseResponseDTO.java
+│   │   │   ├── AvaliacaoFisioterapeuticaRequestDTO.java
+│   │   │   ├── AvaliacaoFisioterapeuticaUpdateDTO.java
+│   │   │   ├── AvaliacaoFisioterapeuticaResponseDTO.java
+│   │   │   ├── PlanoTratamentoRequestDTO.java
+│   │   │   ├── PlanoTratamentoUpdateDTO.java
+│   │   │   ├── PlanoTratamentoResponseDTO.java
 │   │   │   ├── AuthRegisterRequestDTO.java
 │   │   │   ├── AuthLoginRequestDTO.java
 │   │   │   ├── AuthResponseDTO.java
@@ -159,7 +180,11 @@ src/
 │           ├── V9__alter_profissionais_percentual_precision.sql
 │           ├── V10__add_profissional_to_aulas.sql
 │           ├── V11__create_users_table.sql
-│           └── V12__insert_users_perfis_acesso.sql
+│           ├── V12__insert_users_perfis_acesso.sql
+│           ├── V13__add_indexes_on_foreign_keys.sql
+│           ├── V14__create_anamneses_table.sql
+│           ├── V15__create_avaliacoes_fisioterapeuticas_table.sql
+│           └── V16__create_planos_tratamento_table.sql
 └── test/java/com/carlesso/pilatesapi/
     ├── PilatesApiApplicationTests.java
     ├── actuator/
@@ -167,15 +192,18 @@ src/
     ├── config/
     │   └── GlobalExceptionHandlerTest.java      # 6 casos
     ├── security/
-    │   └── SecurityIntegrationTest.java         # 21 casos
+    │   └── SecurityIntegrationTest.java         # 23 casos
     ├── service/
     │   ├── PacienteServiceTest.java                   # 12 casos
     │   ├── PacienteServiceIntegrationTest.java        # 4 casos
     │   ├── ProfissionalServiceIntegrationTest.java    # 5 casos
     │   ├── ProfissionalServiceTest.java               # 15 casos
     │   ├── PlanoServiceTest.java                      # 9 casos
-    │   ├── PagamentoServiceTest.java                  # 8 casos
+    │   ├── PagamentoServiceTest.java                  # 10 casos
     │   ├── AulaServiceTest.java                       # 14 casos
+    │   ├── AnamneseServiceTest.java                   # 17 casos
+    │   ├── AvaliacaoFisioterapeuticaServiceTest.java  # 8 casos
+    │   ├── PlanoTratamentoServiceTest.java            # 13 casos
     │   └── RelatorioPagamentoExporterServiceTest.java # 3 casos
     ├── repository/
     │   └── AulaRepositoryTest.java              # 6 casos
@@ -184,7 +212,10 @@ src/
         ├── ProfissionalControllerTest.java      # 17 casos
         ├── PlanoControllerTest.java             # 11 casos
         ├── PagamentoControllerTest.java         # 11 casos
-        └── AulaControllerTest.java              # 10 casos
+        ├── AulaControllerTest.java              # 10 casos
+        ├── AnamneseControllerTest.java          # 14 casos
+        ├── AvaliacaoFisioterapeuticaControllerTest.java # 12 casos
+        └── PlanoTratamentoControllerTest.java   # 18 casos
 ```
 
 ---
@@ -254,7 +285,18 @@ src/
 - Consultas por ID, paciente, pagamento e relatório filtram `paciente.ativo = true`
 - Métodos de leitura nos services usam `@Transactional(readOnly = true)` para reduzir flush desnecessário e permitir otimizações de conexão.
 
-### 4.7 Relatório de emissão de NFSEs
+### 4.7 Plano de Tratamento
+
+- Um paciente pode possuir múltiplos planos de tratamento para preservar histórico clínico
+- Criar plano para paciente inexistente ou inativo retorna `404`
+- Campos obrigatórios: `pacienteId`, `dataInicio` e `objetivosTratamento`
+- `dataFimPrevista`, quando informada, não pode ser anterior a `dataInicio`
+- `numeroSessoesPrevistas` aceita apenas valores positivos quando informado
+- Consultas por ID e por paciente filtram `planos_tratamento.ativo = true` e `paciente.ativo = true`
+- Atualização parcial: apenas campos não-nulos do DTO de update são aplicados; `objetivosTratamento` não aceita strings em branco quando enviado
+- Exclusão é lógica: `DELETE /planos-tratamento/{id}` marca `ativo = false` e preserva o histórico no banco
+
+### 4.8 Relatório de emissão de NFSEs
 
 - O relatório considera apenas pagamentos `PAGO` com `dataPagamento` dentro da competência informada e pacientes ativos
 - `competencia` é obrigatória no formato `MM/AAAA`; mês deve estar entre `01` e `12`
@@ -265,7 +307,7 @@ src/
 - `formato` aceita `JSON`, `CSV` e `XLSX`; CSV e XLSX retornam anexo com nome `relatorio-nfse-{MM-AAAA}.{ext}`
 - Registros sem nome do paciente, CPF/CNPJ, valor positivo ou data de pagamento retornam `422 Unprocessable Entity`
 
-### 4.8 Dashboard — Resumo do Painel Inicial
+### 4.9 Dashboard — Resumo do Painel Inicial
 
 O endpoint `GET /dashboard/resumo` agrega contadores e totais do banco em um único objeto para consumo direto pelo painel inicial do frontend:
 
@@ -277,7 +319,7 @@ O endpoint `GET /dashboard/resumo` agrega contadores e totais do banco em um ún
 
 Exige `Authorization: Bearer <token>`.
 
-### 4.9 Processos Automáticos (Scheduler)
+### 4.10 Processos Automáticos (Scheduler)
 
 | Cron (default) | Ação | Propriedade |
 |---|---|---|
@@ -390,6 +432,30 @@ Tabela: `aulas`
 | `realizada` | `BOOLEAN` | NOT NULL, default `false` | Presença confirmada |
 
 Constraint: `UNIQUE (paciente_id, data)`
+
+---
+
+### Entidade: PlanoTratamento
+
+Tabela: `planos_tratamento`
+
+| Campo | Tipo | Restrições | Descrição |
+|---|---|---|---|
+| `id` | `BIGINT` | PK, auto-increment | Identificador único |
+| `paciente_id` | `BIGINT` | NOT NULL, FK | Paciente vinculado |
+| `data_inicio` | `DATE` | NOT NULL | Data de início do tratamento |
+| `data_fim_prevista` | `DATE` | — | Data prevista de encerramento |
+| `objetivos_tratamento` | `TEXT` | NOT NULL | Objetivos terapêuticos |
+| `intervencoes_planejadas` | `TEXT` | — | Intervenções planejadas |
+| `numero_sessoes_previstas` | `INTEGER` | — | Quantidade prevista de sessões |
+| `frequencia_sessoes` | `VARCHAR(100)` | — | Frequência planejada |
+| `responsavel_tratamento` | `VARCHAR(255)` | — | Profissional responsável |
+| `observacoes` | `TEXT` | — | Observações clínicas |
+| `data_criacao` | `TIMESTAMP` | NOT NULL | Registro de criação |
+| `data_atualizacao` | `TIMESTAMP` | — | Última atualização |
+| `ativo` | `BOOLEAN` | NOT NULL, default `true` | Controle de exclusão lógica |
+
+Índice: `idx_planos_tratamento_paciente_id` para listagem por paciente.
 
 ---
 
@@ -701,7 +767,19 @@ GET /profissionais/{id}/relatorio-pagamento/xlsx?inicio=2025-02-01&fim=2025-02-2
 | `GET` | `/aulas/pagamento/{id}` | Listar aulas de um pagamento |
 | `PATCH` | `/aulas/{id}/realizar` | Marcar aula como realizada; aceita `profissionalId` opcional |
 
-### 6.4 Relatórios fiscais
+### 6.4 Planos de Tratamento
+
+| Método | Rota | Descrição |
+|---|---|---|
+| `POST` | `/planos-tratamento` | Criar plano de tratamento para paciente |
+| `GET` | `/planos-tratamento/{id}` | Buscar plano de tratamento por ID |
+| `GET` | `/planos-tratamento/paciente/{pacienteId}` | Listar planos ativos do paciente |
+| `PUT` | `/planos-tratamento/{id}` | Atualizar parcialmente um plano de tratamento |
+| `DELETE` | `/planos-tratamento/{id}` | Inativar plano de tratamento |
+
+Todas as rotas exigem `Authorization: Bearer <accessToken>`.
+
+### 6.5 Relatórios fiscais
 
 #### Relatório de emissão de NFSEs
 
@@ -833,6 +911,10 @@ O **Flyway** executa automaticamente os scripts SQL ao iniciar a aplicação, se
 | V10 | `V10__add_profissional_to_aulas.sql` | Vincula profissional às aulas realizadas |
 | V11 | `V11__create_users_table.sql` | Cria a tabela `users` para autenticação e autorização |
 | V12 | `V12__insert_users_perfis_acesso.sql` | Insere 5 usuários iniciais com perfis `ADMIN` e `USER` |
+| V13 | `V13__add_indexes_on_foreign_keys.sql` | Adiciona índices para chaves estrangeiras e filtros recorrentes |
+| V14 | `V14__create_anamneses_table.sql` | Cria tabela `anamneses` vinculada a pacientes |
+| V15 | `V15__create_avaliacoes_fisioterapeuticas_table.sql` | Cria tabela de avaliações fisioterapêuticas do paciente |
+| V16 | `V16__create_planos_tratamento_table.sql` | Cria tabela de planos de tratamento do paciente |
 
 Os usuários iniciais da migração `V12` usam a senha `senha1234`; `admin@carlessopilates.com` e `operacional@carlessopilates.com` têm perfil `ADMIN`.
 
@@ -1002,26 +1084,41 @@ O serviço `app` aguarda o `db` estar saudável (healthcheck via `pg_isready`) a
 
 ### Visão geral
 
-A suíte de testes possui **172 casos** distribuídos em dezoito classes:
+A suíte de testes possui **295 casos** distribuídos nas classes abaixo:
 
 | Classe | Tipo | Casos |
 |---|---|---|
 | `PacienteServiceTest` | Unitário (Mockito) | 12 |
 | `ProfissionalServiceTest` | Unitário (Mockito) | 15 |
 | `PlanoServiceTest` | Unitário (Mockito) | 9 |
-| `PagamentoServiceTest` | Unitário (Mockito) | 8 |
+| `PagamentoServiceTest` | Unitário (Mockito) | 10 |
 | `AulaServiceTest` | Unitário (Mockito) | 14 |
+| `AnamneseServiceTest` | Unitário (Mockito) | 17 |
+| `AvaliacaoFisioterapeuticaServiceTest` | Unitário (Mockito) | 8 |
+| `PlanoTratamentoServiceTest` | Unitário (Mockito) | 13 |
 | `RelatorioPagamentoExporterServiceTest` | Unitário | 3 |
+| `RelatorioNfseServiceTest` | Unitário (Mockito) | 5 |
+| `RelatorioNfseExporterServiceTest` | Unitário | 3 |
+| `DashboardServiceTest` | Unitário (Mockito) | 3 |
+| `AppPropertiesTest` | Unitário (ApplicationContextRunner) | 3 |
 | `PacienteServiceIntegrationTest` | JPA (`@DataJpaTest`) | 4 |
 | `ProfissionalServiceIntegrationTest` | JPA (`@DataJpaTest`) | 5 |
+| `PagamentoServiceAtomicidadeIntegrationTest` | Integração (`@SpringBootTest` + H2) | 1 |
+| `CobrancaSchedulerIntegrationTest` | JPA (`@DataJpaTest`) | 11 |
 | `AulaRepositoryTest` | JPA (`@DataJpaTest`) | 6 |
+| `PagamentoRepositoryTest` | JPA (`@DataJpaTest`) | 2 |
 | `PacienteControllerTest` | Controller (`@WebMvcTest`) | 16 |
 | `ProfissionalControllerTest` | Controller (`@WebMvcTest`) | 17 |
 | `PlanoControllerTest` | Controller (`@WebMvcTest`) | 11 |
 | `PagamentoControllerTest` | Controller (`@WebMvcTest`) | 11 |
 | `AulaControllerTest` | Controller (`@WebMvcTest`) | 10 |
+| `AnamneseControllerTest` | Controller (`@WebMvcTest`) | 14 |
+| `AvaliacaoFisioterapeuticaControllerTest` | Controller (`@WebMvcTest`) | 12 |
+| `PlanoTratamentoControllerTest` | Controller (`@WebMvcTest`) | 18 |
+| `RelatorioNfseControllerTest` | Controller (`@WebMvcTest`) | 6 |
+| `DashboardControllerTest` | Controller (`@WebMvcTest`) | 2 |
 | `GlobalExceptionHandlerTest` | Unitário | 6 |
-| `SecurityIntegrationTest` | Integração (`@SpringBootTest` + MockMvc + H2) | 21 |
+| `SecurityIntegrationTest` | Integração (`@SpringBootTest` + MockMvc + H2) | 23 |
 | `ActuatorTest` | Integração (`@SpringBootTest`) | 3 |
 | `PilatesApiApplicationTests` | Integração (`@SpringBootTest` + H2) | 1 |
 

--- a/src/main/java/com/carlesso/pilatesapi/controller/PlanoTratamentoController.java
+++ b/src/main/java/com/carlesso/pilatesapi/controller/PlanoTratamentoController.java
@@ -82,4 +82,19 @@ public class PlanoTratamentoController {
             @RequestBody @Valid PlanoTratamentoUpdateDTO dto) {
         return ResponseEntity.ok(service.atualizar(id, dto));
     }
+
+    @Operation(
+            summary = "Inativar plano de tratamento",
+            description = "Inativa um plano de tratamento sem remover o histórico clínico do banco."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "Plano de tratamento inativado com sucesso"),
+            @ApiResponse(responseCode = "404", description = "Plano de tratamento não encontrado")
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> inativar(
+            @Parameter(description = "ID do plano de tratamento", required = true) @PathVariable Long id) {
+        service.inativar(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/carlesso/pilatesapi/controller/PlanoTratamentoController.java
+++ b/src/main/java/com/carlesso/pilatesapi/controller/PlanoTratamentoController.java
@@ -1,0 +1,85 @@
+package com.carlesso.pilatesapi.controller;
+
+import com.carlesso.pilatesapi.dto.PlanoTratamentoRequestDTO;
+import com.carlesso.pilatesapi.dto.PlanoTratamentoResponseDTO;
+import com.carlesso.pilatesapi.dto.PlanoTratamentoUpdateDTO;
+import com.carlesso.pilatesapi.service.PlanoTratamentoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+
+@Tag(name = "Planos de Tratamento", description = "Gerenciamento de planos de tratamento de pacientes")
+@RestController
+@RequestMapping("/planos-tratamento")
+public class PlanoTratamentoController {
+
+    private final PlanoTratamentoService service;
+
+    public PlanoTratamentoController(PlanoTratamentoService service) {
+        this.service = service;
+    }
+
+    @Operation(
+            summary = "Criar plano de tratamento",
+            description = "Registra um plano de tratamento para um paciente. O paciente pode possuir múltiplos planos ao longo do tempo."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Plano de tratamento criado com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Dados inválidos ou campos obrigatórios ausentes"),
+            @ApiResponse(responseCode = "404", description = "Paciente não encontrado")
+    })
+    @PostMapping
+    public ResponseEntity<PlanoTratamentoResponseDTO> criar(
+            @RequestBody @Valid PlanoTratamentoRequestDTO dto,
+            UriComponentsBuilder uriBuilder) {
+        PlanoTratamentoResponseDTO response = service.criar(dto);
+        var uri = uriBuilder.path("/planos-tratamento/{id}").buildAndExpand(response.id()).toUri();
+        return ResponseEntity.created(uri).body(response);
+    }
+
+    @Operation(summary = "Buscar plano de tratamento por ID")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Plano de tratamento encontrado"),
+            @ApiResponse(responseCode = "404", description = "Plano de tratamento não encontrado")
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<PlanoTratamentoResponseDTO> buscarPorId(
+            @Parameter(description = "ID do plano de tratamento", required = true) @PathVariable Long id) {
+        return ResponseEntity.ok(service.buscarPorId(id));
+    }
+
+    @Operation(summary = "Listar planos de tratamento por paciente")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Planos de tratamento encontrados"),
+            @ApiResponse(responseCode = "404", description = "Paciente não encontrado")
+    })
+    @GetMapping("/paciente/{pacienteId}")
+    public ResponseEntity<List<PlanoTratamentoResponseDTO>> listarPorPaciente(
+            @Parameter(description = "ID do paciente", required = true) @PathVariable Long pacienteId) {
+        return ResponseEntity.ok(service.listarPorPaciente(pacienteId));
+    }
+
+    @Operation(
+            summary = "Atualizar plano de tratamento",
+            description = "Atualiza um plano de tratamento. Apenas os campos enviados serão alterados."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Plano de tratamento atualizado com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Dados inválidos"),
+            @ApiResponse(responseCode = "404", description = "Plano de tratamento não encontrado")
+    })
+    @PutMapping("/{id}")
+    public ResponseEntity<PlanoTratamentoResponseDTO> atualizar(
+            @Parameter(description = "ID do plano de tratamento", required = true) @PathVariable Long id,
+            @RequestBody @Valid PlanoTratamentoUpdateDTO dto) {
+        return ResponseEntity.ok(service.atualizar(id, dto));
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/dto/PlanoTratamentoRequestDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/PlanoTratamentoRequestDTO.java
@@ -1,0 +1,18 @@
+package com.carlesso.pilatesapi.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.time.LocalDate;
+
+public record PlanoTratamentoRequestDTO(
+        @NotNull Long pacienteId,
+        @NotNull LocalDate dataInicio,
+        LocalDate dataFimPrevista,
+        @NotBlank String objetivosTratamento,
+        String intervencoesPlanejadas,
+        @Positive Integer numeroSessoesPrevistas,
+        String frequenciaSessoes,
+        String responsavelTratamento,
+        String observacoes
+) {}

--- a/src/main/java/com/carlesso/pilatesapi/dto/PlanoTratamentoResponseDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/PlanoTratamentoResponseDTO.java
@@ -1,0 +1,39 @@
+package com.carlesso.pilatesapi.dto;
+
+import com.carlesso.pilatesapi.entity.PlanoTratamento;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record PlanoTratamentoResponseDTO(
+        Long id,
+        Long pacienteId,
+        String nomePaciente,
+        LocalDate dataInicio,
+        LocalDate dataFimPrevista,
+        String objetivosTratamento,
+        String intervencoesPlanejadas,
+        Integer numeroSessoesPrevistas,
+        String frequenciaSessoes,
+        String responsavelTratamento,
+        String observacoes,
+        LocalDateTime dataCriacao,
+        LocalDateTime dataAtualizacao
+) {
+    public static PlanoTratamentoResponseDTO from(PlanoTratamento p) {
+        return new PlanoTratamentoResponseDTO(
+                p.getId(),
+                p.getPaciente().getId(),
+                p.getPaciente().getNome(),
+                p.getDataInicio(),
+                p.getDataFimPrevista(),
+                p.getObjetivosTratamento(),
+                p.getIntervencoesPlanejadas(),
+                p.getNumeroSessoesPrevistas(),
+                p.getFrequenciaSessoes(),
+                p.getResponsavelTratamento(),
+                p.getObservacoes(),
+                p.getDataCriacao(),
+                p.getDataAtualizacao()
+        );
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/dto/PlanoTratamentoUpdateDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/PlanoTratamentoUpdateDTO.java
@@ -1,0 +1,17 @@
+package com.carlesso.pilatesapi.dto;
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import java.time.LocalDate;
+
+public record PlanoTratamentoUpdateDTO(
+        LocalDate dataInicio,
+        LocalDate dataFimPrevista,
+        @Pattern(regexp = ".*\\S.*", message = "objetivosTratamento não pode ser vazio")
+        String objetivosTratamento,
+        String intervencoesPlanejadas,
+        @Positive Integer numeroSessoesPrevistas,
+        String frequenciaSessoes,
+        String responsavelTratamento,
+        String observacoes
+) {}

--- a/src/main/java/com/carlesso/pilatesapi/entity/PlanoTratamento.java
+++ b/src/main/java/com/carlesso/pilatesapi/entity/PlanoTratamento.java
@@ -1,0 +1,87 @@
+package com.carlesso.pilatesapi.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "planos_tratamento")
+public class PlanoTratamento {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "paciente_id", nullable = false)
+    private Paciente paciente;
+
+    @Column(nullable = false)
+    private LocalDate dataInicio;
+
+    private LocalDate dataFimPrevista;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String objetivosTratamento;
+
+    @Column(columnDefinition = "TEXT")
+    private String intervencoesPlanejadas;
+
+    private Integer numeroSessoesPrevistas;
+
+    @Column(length = 100)
+    private String frequenciaSessoes;
+
+    @Column(length = 255)
+    private String responsavelTratamento;
+
+    @Column(columnDefinition = "TEXT")
+    private String observacoes;
+
+    @Column(nullable = false)
+    private LocalDateTime dataCriacao;
+
+    private LocalDateTime dataAtualizacao;
+
+    public PlanoTratamento() {}
+
+    @PrePersist
+    void prePersist() {
+        this.dataCriacao = LocalDateTime.now();
+    }
+
+    public Long getId() { return id; }
+
+    public Paciente getPaciente() { return paciente; }
+    public void setPaciente(Paciente paciente) { this.paciente = paciente; }
+
+    public LocalDate getDataInicio() { return dataInicio; }
+    public void setDataInicio(LocalDate dataInicio) { this.dataInicio = dataInicio; }
+
+    public LocalDate getDataFimPrevista() { return dataFimPrevista; }
+    public void setDataFimPrevista(LocalDate dataFimPrevista) { this.dataFimPrevista = dataFimPrevista; }
+
+    public String getObjetivosTratamento() { return objetivosTratamento; }
+    public void setObjetivosTratamento(String objetivosTratamento) { this.objetivosTratamento = objetivosTratamento; }
+
+    public String getIntervencoesPlanejadas() { return intervencoesPlanejadas; }
+    public void setIntervencoesPlanejadas(String intervencoesPlanejadas) { this.intervencoesPlanejadas = intervencoesPlanejadas; }
+
+    public Integer getNumeroSessoesPrevistas() { return numeroSessoesPrevistas; }
+    public void setNumeroSessoesPrevistas(Integer numeroSessoesPrevistas) { this.numeroSessoesPrevistas = numeroSessoesPrevistas; }
+
+    public String getFrequenciaSessoes() { return frequenciaSessoes; }
+    public void setFrequenciaSessoes(String frequenciaSessoes) { this.frequenciaSessoes = frequenciaSessoes; }
+
+    public String getResponsavelTratamento() { return responsavelTratamento; }
+    public void setResponsavelTratamento(String responsavelTratamento) { this.responsavelTratamento = responsavelTratamento; }
+
+    public String getObservacoes() { return observacoes; }
+    public void setObservacoes(String observacoes) { this.observacoes = observacoes; }
+
+    public LocalDateTime getDataCriacao() { return dataCriacao; }
+    public void setDataCriacao(LocalDateTime dataCriacao) { this.dataCriacao = dataCriacao; }
+
+    public LocalDateTime getDataAtualizacao() { return dataAtualizacao; }
+    public void setDataAtualizacao(LocalDateTime dataAtualizacao) { this.dataAtualizacao = dataAtualizacao; }
+}

--- a/src/main/java/com/carlesso/pilatesapi/entity/PlanoTratamento.java
+++ b/src/main/java/com/carlesso/pilatesapi/entity/PlanoTratamento.java
@@ -43,6 +43,9 @@ public class PlanoTratamento {
 
     private LocalDateTime dataAtualizacao;
 
+    @Column(nullable = false)
+    private boolean ativo = true;
+
     public PlanoTratamento() {}
 
     @PrePersist
@@ -84,4 +87,7 @@ public class PlanoTratamento {
 
     public LocalDateTime getDataAtualizacao() { return dataAtualizacao; }
     public void setDataAtualizacao(LocalDateTime dataAtualizacao) { this.dataAtualizacao = dataAtualizacao; }
+
+    public boolean isAtivo() { return ativo; }
+    public void setAtivo(boolean ativo) { this.ativo = ativo; }
 }

--- a/src/main/java/com/carlesso/pilatesapi/repository/PlanoTratamentoRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/PlanoTratamentoRepository.java
@@ -10,9 +10,9 @@ import java.util.Optional;
 
 public interface PlanoTratamentoRepository extends JpaRepository<PlanoTratamento, Long> {
 
-    @Query("SELECT p FROM PlanoTratamento p JOIN FETCH p.paciente pac WHERE p.id = :id AND pac.ativo = true")
+    @Query("SELECT p FROM PlanoTratamento p JOIN FETCH p.paciente pac WHERE p.id = :id AND p.ativo = true AND pac.ativo = true")
     Optional<PlanoTratamento> findAtivoById(@Param("id") Long id);
 
-    @Query("SELECT p FROM PlanoTratamento p JOIN FETCH p.paciente pac WHERE pac.id = :pacienteId AND pac.ativo = true ORDER BY p.dataInicio DESC, p.id DESC")
+    @Query("SELECT p FROM PlanoTratamento p JOIN FETCH p.paciente pac WHERE pac.id = :pacienteId AND p.ativo = true AND pac.ativo = true ORDER BY p.dataInicio DESC, p.id DESC")
     List<PlanoTratamento> findAtivosByPacienteOrdenados(@Param("pacienteId") Long pacienteId);
 }

--- a/src/main/java/com/carlesso/pilatesapi/repository/PlanoTratamentoRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/PlanoTratamentoRepository.java
@@ -1,0 +1,18 @@
+package com.carlesso.pilatesapi.repository;
+
+import com.carlesso.pilatesapi.entity.PlanoTratamento;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PlanoTratamentoRepository extends JpaRepository<PlanoTratamento, Long> {
+
+    @Query("SELECT p FROM PlanoTratamento p JOIN FETCH p.paciente pac WHERE p.id = :id AND pac.ativo = true")
+    Optional<PlanoTratamento> findAtivoById(@Param("id") Long id);
+
+    @Query("SELECT p FROM PlanoTratamento p JOIN FETCH p.paciente pac WHERE pac.id = :pacienteId AND pac.ativo = true ORDER BY p.dataInicio DESC, p.id DESC")
+    List<PlanoTratamento> findAtivosByPacienteOrdenados(@Param("pacienteId") Long pacienteId);
+}

--- a/src/main/java/com/carlesso/pilatesapi/service/PlanoTratamentoService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/PlanoTratamentoService.java
@@ -11,6 +11,7 @@ import com.carlesso.pilatesapi.repository.PacienteRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -28,6 +29,8 @@ public class PlanoTratamentoService {
 
     @Transactional
     public PlanoTratamentoResponseDTO criar(PlanoTratamentoRequestDTO dto) {
+        validarPeriodo(dto.dataInicio(), dto.dataFimPrevista());
+
         Paciente paciente = pacienteRepository.findByIdAndAtivoTrue(dto.pacienteId())
                 .orElseThrow(() -> new ResourceNotFoundException("Paciente não encontrado: " + dto.pacienteId()));
 
@@ -64,6 +67,9 @@ public class PlanoTratamentoService {
     @Transactional
     public PlanoTratamentoResponseDTO atualizar(Long id, PlanoTratamentoUpdateDTO dto) {
         PlanoTratamento plano = encontrar(id);
+        var dataInicio = dto.dataInicio() != null ? dto.dataInicio() : plano.getDataInicio();
+        var dataFimPrevista = dto.dataFimPrevista() != null ? dto.dataFimPrevista() : plano.getDataFimPrevista();
+        validarPeriodo(dataInicio, dataFimPrevista);
 
         if (dto.dataInicio() != null) plano.setDataInicio(dto.dataInicio());
         if (dto.dataFimPrevista() != null) plano.setDataFimPrevista(dto.dataFimPrevista());
@@ -78,8 +84,21 @@ public class PlanoTratamentoService {
         return PlanoTratamentoResponseDTO.from(planoTratamentoRepository.save(plano));
     }
 
+    @Transactional
+    public void inativar(Long id) {
+        PlanoTratamento plano = encontrar(id);
+        plano.setAtivo(false);
+        plano.setDataAtualizacao(LocalDateTime.now());
+    }
+
     private PlanoTratamento encontrar(Long id) {
         return planoTratamentoRepository.findAtivoById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Plano de tratamento não encontrado: " + id));
+    }
+
+    private void validarPeriodo(LocalDate dataInicio, LocalDate dataFimPrevista) {
+        if (dataInicio != null && dataFimPrevista != null && dataFimPrevista.isBefore(dataInicio)) {
+            throw new IllegalArgumentException("dataFimPrevista não pode ser anterior a dataInicio");
+        }
     }
 }

--- a/src/main/java/com/carlesso/pilatesapi/service/PlanoTratamentoService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/PlanoTratamentoService.java
@@ -1,0 +1,85 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.PlanoTratamentoRequestDTO;
+import com.carlesso.pilatesapi.dto.PlanoTratamentoResponseDTO;
+import com.carlesso.pilatesapi.dto.PlanoTratamentoUpdateDTO;
+import com.carlesso.pilatesapi.entity.PlanoTratamento;
+import com.carlesso.pilatesapi.entity.Paciente;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
+import com.carlesso.pilatesapi.repository.PlanoTratamentoRepository;
+import com.carlesso.pilatesapi.repository.PacienteRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class PlanoTratamentoService {
+
+    private final PlanoTratamentoRepository planoTratamentoRepository;
+    private final PacienteRepository pacienteRepository;
+
+    public PlanoTratamentoService(PlanoTratamentoRepository planoTratamentoRepository,
+                                   PacienteRepository pacienteRepository) {
+        this.planoTratamentoRepository = planoTratamentoRepository;
+        this.pacienteRepository = pacienteRepository;
+    }
+
+    @Transactional
+    public PlanoTratamentoResponseDTO criar(PlanoTratamentoRequestDTO dto) {
+        Paciente paciente = pacienteRepository.findByIdAndAtivoTrue(dto.pacienteId())
+                .orElseThrow(() -> new ResourceNotFoundException("Paciente não encontrado: " + dto.pacienteId()));
+
+        PlanoTratamento plano = new PlanoTratamento();
+        plano.setPaciente(paciente);
+        plano.setDataInicio(dto.dataInicio());
+        plano.setDataFimPrevista(dto.dataFimPrevista());
+        plano.setObjetivosTratamento(dto.objetivosTratamento());
+        plano.setIntervencoesPlanejadas(dto.intervencoesPlanejadas());
+        plano.setNumeroSessoesPrevistas(dto.numeroSessoesPrevistas());
+        plano.setFrequenciaSessoes(dto.frequenciaSessoes());
+        plano.setResponsavelTratamento(dto.responsavelTratamento());
+        plano.setObservacoes(dto.observacoes());
+
+        return PlanoTratamentoResponseDTO.from(planoTratamentoRepository.save(plano));
+    }
+
+    @Transactional(readOnly = true)
+    public PlanoTratamentoResponseDTO buscarPorId(Long id) {
+        return PlanoTratamentoResponseDTO.from(encontrar(id));
+    }
+
+    @Transactional(readOnly = true)
+    public List<PlanoTratamentoResponseDTO> listarPorPaciente(Long pacienteId) {
+        if (!pacienteRepository.existsByIdAndAtivoTrue(pacienteId)) {
+            throw new ResourceNotFoundException("Paciente não encontrado: " + pacienteId);
+        }
+        return planoTratamentoRepository.findAtivosByPacienteOrdenados(pacienteId)
+                .stream()
+                .map(PlanoTratamentoResponseDTO::from)
+                .toList();
+    }
+
+    @Transactional
+    public PlanoTratamentoResponseDTO atualizar(Long id, PlanoTratamentoUpdateDTO dto) {
+        PlanoTratamento plano = encontrar(id);
+
+        if (dto.dataInicio() != null) plano.setDataInicio(dto.dataInicio());
+        if (dto.dataFimPrevista() != null) plano.setDataFimPrevista(dto.dataFimPrevista());
+        if (dto.objetivosTratamento() != null) plano.setObjetivosTratamento(dto.objetivosTratamento());
+        if (dto.intervencoesPlanejadas() != null) plano.setIntervencoesPlanejadas(dto.intervencoesPlanejadas());
+        if (dto.numeroSessoesPrevistas() != null) plano.setNumeroSessoesPrevistas(dto.numeroSessoesPrevistas());
+        if (dto.frequenciaSessoes() != null) plano.setFrequenciaSessoes(dto.frequenciaSessoes());
+        if (dto.responsavelTratamento() != null) plano.setResponsavelTratamento(dto.responsavelTratamento());
+        if (dto.observacoes() != null) plano.setObservacoes(dto.observacoes());
+        plano.setDataAtualizacao(LocalDateTime.now());
+
+        return PlanoTratamentoResponseDTO.from(planoTratamentoRepository.save(plano));
+    }
+
+    private PlanoTratamento encontrar(Long id) {
+        return planoTratamentoRepository.findAtivoById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Plano de tratamento não encontrado: " + id));
+    }
+}

--- a/src/main/resources/db/migration/V16__create_planos_tratamento_table.sql
+++ b/src/main/resources/db/migration/V16__create_planos_tratamento_table.sql
@@ -1,0 +1,17 @@
+CREATE TABLE planos_tratamento (
+    id                        BIGSERIAL    PRIMARY KEY,
+    paciente_id               BIGINT       NOT NULL REFERENCES pacientes(id),
+    data_inicio               DATE         NOT NULL,
+    data_fim_prevista         DATE,
+    objetivos_tratamento      TEXT         NOT NULL,
+    intervencoes_planejadas   TEXT,
+    numero_sessoes_previstas  INTEGER,
+    frequencia_sessoes        VARCHAR(100),
+    responsavel_tratamento    VARCHAR(255),
+    observacoes               TEXT,
+    data_criacao              TIMESTAMP    NOT NULL,
+    data_atualizacao          TIMESTAMP
+);
+
+CREATE INDEX idx_planos_tratamento_paciente_id
+    ON planos_tratamento(paciente_id);

--- a/src/main/resources/db/migration/V16__create_planos_tratamento_table.sql
+++ b/src/main/resources/db/migration/V16__create_planos_tratamento_table.sql
@@ -10,7 +10,8 @@ CREATE TABLE planos_tratamento (
     responsavel_tratamento    VARCHAR(255),
     observacoes               TEXT,
     data_criacao              TIMESTAMP    NOT NULL,
-    data_atualizacao          TIMESTAMP
+    data_atualizacao          TIMESTAMP,
+    ativo                     BOOLEAN      NOT NULL DEFAULT TRUE
 );
 
 CREATE INDEX idx_planos_tratamento_paciente_id

--- a/src/test/java/com/carlesso/pilatesapi/controller/PlanoTratamentoControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/PlanoTratamentoControllerTest.java
@@ -144,6 +144,23 @@ class PlanoTratamentoControllerTest {
     }
 
     @Test
+    void criar_comDataFimAnteriorADataInicio_deveRetornar400() throws Exception {
+        when(service.criar(any()))
+                .thenThrow(new IllegalArgumentException("dataFimPrevista não pode ser anterior a dataInicio"));
+
+        var dto = new PlanoTratamentoRequestDTO(
+                1L, LocalDate.of(2026, 8, 1), LocalDate.of(2026, 5, 1),
+                "Objetivos", null, null, null, null, null
+        );
+
+        mvc.perform(post("/planos-tratamento")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.erro").value("dataFimPrevista não pode ser anterior a dataInicio"));
+    }
+
+    @Test
     void criar_comPacienteInexistente_deveRetornar404() throws Exception {
         when(service.criar(any())).thenThrow(new ResourceNotFoundException("Paciente não encontrado: 99"));
 
@@ -252,6 +269,23 @@ class PlanoTratamentoControllerTest {
     }
 
     @Test
+    void atualizar_comDataFimAnteriorADataInicio_deveRetornar400() throws Exception {
+        when(service.atualizar(eq(1L), any()))
+                .thenThrow(new IllegalArgumentException("dataFimPrevista não pode ser anterior a dataInicio"));
+
+        var dto = new PlanoTratamentoUpdateDTO(
+                LocalDate.of(2026, 8, 1), LocalDate.of(2026, 5, 1),
+                null, null, null, null, null, null
+        );
+
+        mvc.perform(put("/planos-tratamento/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.erro").value("dataFimPrevista não pode ser anterior a dataInicio"));
+    }
+
+    @Test
     void atualizar_comPlanoInexistente_deveRetornar404() throws Exception {
         when(service.atualizar(eq(99L), any()))
                 .thenThrow(new ResourceNotFoundException("Plano de tratamento não encontrado: 99"));
@@ -263,6 +297,22 @@ class PlanoTratamentoControllerTest {
         mvc.perform(put("/planos-tratamento/99")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.erro").value("Plano de tratamento não encontrado: 99"));
+    }
+
+    @Test
+    void inativar_comPlanoExistente_deveRetornar204() throws Exception {
+        mvc.perform(delete("/planos-tratamento/1"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void inativar_comPlanoInexistente_deveRetornar404() throws Exception {
+        org.mockito.Mockito.doThrow(new ResourceNotFoundException("Plano de tratamento não encontrado: 99"))
+                .when(service).inativar(99L);
+
+        mvc.perform(delete("/planos-tratamento/99"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.erro").value("Plano de tratamento não encontrado: 99"));
     }

--- a/src/test/java/com/carlesso/pilatesapi/controller/PlanoTratamentoControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/PlanoTratamentoControllerTest.java
@@ -1,0 +1,269 @@
+package com.carlesso.pilatesapi.controller;
+
+import com.carlesso.pilatesapi.dto.PlanoTratamentoRequestDTO;
+import com.carlesso.pilatesapi.dto.PlanoTratamentoResponseDTO;
+import com.carlesso.pilatesapi.dto.PlanoTratamentoUpdateDTO;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
+import com.carlesso.pilatesapi.service.CustomUserDetailsService;
+import com.carlesso.pilatesapi.service.JwtService;
+import com.carlesso.pilatesapi.service.PlanoTratamentoService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(PlanoTratamentoController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PlanoTratamentoControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockitoBean
+    private PlanoTratamentoService service;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    private PlanoTratamentoResponseDTO responseDTO() {
+        return new PlanoTratamentoResponseDTO(
+                1L, 1L, "Maria Souza",
+                LocalDate.of(2026, 5, 1),
+                LocalDate.of(2026, 8, 1),
+                "Reduzir dor lombar e melhorar mobilidade",
+                "Exercícios de core e alongamentos",
+                24,
+                "2x por semana",
+                "Dr. João",
+                "Paciente deve evitar impacto",
+                LocalDateTime.of(2026, 5, 1, 10, 0),
+                null
+        );
+    }
+
+    private PlanoTratamentoRequestDTO requestDTO() {
+        return new PlanoTratamentoRequestDTO(
+                1L,
+                LocalDate.of(2026, 5, 1),
+                LocalDate.of(2026, 8, 1),
+                "Reduzir dor lombar e melhorar mobilidade",
+                "Exercícios de core e alongamentos",
+                24,
+                "2x por semana",
+                "Dr. João",
+                "Paciente deve evitar impacto"
+        );
+    }
+
+    @Test
+    void criar_comDadosValidos_deveRetornar201ComHeaderLocation() throws Exception {
+        when(service.criar(any())).thenReturn(responseDTO());
+
+        mvc.perform(post("/planos-tratamento")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(requestDTO())))
+                .andExpect(status().isCreated())
+                .andExpect(header().exists("Location"))
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.pacienteId").value(1))
+                .andExpect(jsonPath("$.nomePaciente").value("Maria Souza"))
+                .andExpect(jsonPath("$.objetivosTratamento").value("Reduzir dor lombar e melhorar mobilidade"))
+                .andExpect(jsonPath("$.numeroSessoesPrevistas").value(24));
+    }
+
+    @Test
+    void criar_semPacienteId_deveRetornar400() throws Exception {
+        var dto = new PlanoTratamentoRequestDTO(
+                null, LocalDate.of(2026, 5, 1), null,
+                "Objetivos", null, null, null, null, null
+        );
+
+        mvc.perform(post("/planos-tratamento")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void criar_semDataInicio_deveRetornar400() throws Exception {
+        var dto = new PlanoTratamentoRequestDTO(
+                1L, null, null,
+                "Objetivos", null, null, null, null, null
+        );
+
+        mvc.perform(post("/planos-tratamento")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void criar_semObjetivosTratamento_deveRetornar400() throws Exception {
+        var dto = new PlanoTratamentoRequestDTO(
+                1L, LocalDate.of(2026, 5, 1), null,
+                null, null, null, null, null, null
+        );
+
+        mvc.perform(post("/planos-tratamento")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void criar_comNumeroSessaoNegativo_deveRetornar400() throws Exception {
+        var dto = new PlanoTratamentoRequestDTO(
+                1L, LocalDate.of(2026, 5, 1), null,
+                "Objetivos", null, -1, null, null, null
+        );
+
+        mvc.perform(post("/planos-tratamento")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void criar_comPacienteInexistente_deveRetornar404() throws Exception {
+        when(service.criar(any())).thenThrow(new ResourceNotFoundException("Paciente não encontrado: 99"));
+
+        mvc.perform(post("/planos-tratamento")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(requestDTO())))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.erro").value("Paciente não encontrado: 99"));
+    }
+
+    @Test
+    void buscarPorId_quandoExistente_deveRetornar200() throws Exception {
+        when(service.buscarPorId(1L)).thenReturn(responseDTO());
+
+        mvc.perform(get("/planos-tratamento/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.frequenciaSessoes").value("2x por semana"));
+    }
+
+    @Test
+    void buscarPorId_quandoNaoExistente_deveRetornar404() throws Exception {
+        when(service.buscarPorId(99L))
+                .thenThrow(new ResourceNotFoundException("Plano de tratamento não encontrado: 99"));
+
+        mvc.perform(get("/planos-tratamento/99"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.erro").value("Plano de tratamento não encontrado: 99"));
+    }
+
+    @Test
+    void listarPorPaciente_deveRetornar200ComPlanos() throws Exception {
+        when(service.listarPorPaciente(1L)).thenReturn(List.of(responseDTO()));
+
+        mvc.perform(get("/planos-tratamento/paciente/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].pacienteId").value(1))
+                .andExpect(jsonPath("$[0].dataInicio").value("2026-05-01"));
+    }
+
+    @Test
+    void listarPorPaciente_comPacienteInexistente_deveRetornar404() throws Exception {
+        when(service.listarPorPaciente(99L))
+                .thenThrow(new ResourceNotFoundException("Paciente não encontrado: 99"));
+
+        mvc.perform(get("/planos-tratamento/paciente/99"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.erro").value("Paciente não encontrado: 99"));
+    }
+
+    @Test
+    void atualizar_deveRetornar200ComDadosAtualizados() throws Exception {
+        var updated = new PlanoTratamentoResponseDTO(
+                1L, 1L, "Maria Souza",
+                LocalDate.of(2026, 5, 10),
+                LocalDate.of(2026, 9, 1),
+                "Objetivos atualizados",
+                "Exercícios de core e alongamentos",
+                30,
+                "2x por semana",
+                "Dr. João",
+                "Evoluindo bem",
+                LocalDateTime.of(2026, 5, 1, 10, 0),
+                LocalDateTime.of(2026, 5, 10, 9, 0)
+        );
+        when(service.atualizar(eq(1L), any())).thenReturn(updated);
+
+        var dto = new PlanoTratamentoUpdateDTO(
+                LocalDate.of(2026, 5, 10),
+                LocalDate.of(2026, 9, 1),
+                "Objetivos atualizados",
+                null, 30, null, null, "Evoluindo bem"
+        );
+
+        mvc.perform(put("/planos-tratamento/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.dataInicio").value("2026-05-10"))
+                .andExpect(jsonPath("$.numeroSessoesPrevistas").value(30))
+                .andExpect(jsonPath("$.dataAtualizacao").isNotEmpty());
+    }
+
+    @Test
+    void atualizar_comObjetivosEmBranco_deveRetornar400() throws Exception {
+        var dto = new PlanoTratamentoUpdateDTO(
+                null, null, "   ", null, null, null, null, null
+        );
+
+        mvc.perform(put("/planos-tratamento/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void atualizar_comNumeroSessaoNegativo_deveRetornar400() throws Exception {
+        var dto = new PlanoTratamentoUpdateDTO(
+                null, null, null, null, -5, null, null, null
+        );
+
+        mvc.perform(put("/planos-tratamento/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void atualizar_comPlanoInexistente_deveRetornar404() throws Exception {
+        when(service.atualizar(eq(99L), any()))
+                .thenThrow(new ResourceNotFoundException("Plano de tratamento não encontrado: 99"));
+
+        var dto = new PlanoTratamentoUpdateDTO(
+                LocalDate.of(2026, 5, 10), null, null, null, null, null, null, null
+        );
+
+        mvc.perform(put("/planos-tratamento/99")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.erro").value("Plano de tratamento não encontrado: 99"));
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/service/PlanoTratamentoServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/PlanoTratamentoServiceTest.java
@@ -1,0 +1,217 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.PlanoTratamentoRequestDTO;
+import com.carlesso.pilatesapi.dto.PlanoTratamentoResponseDTO;
+import com.carlesso.pilatesapi.dto.PlanoTratamentoUpdateDTO;
+import com.carlesso.pilatesapi.entity.Paciente;
+import com.carlesso.pilatesapi.entity.PlanoTratamento;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
+import com.carlesso.pilatesapi.repository.PacienteRepository;
+import com.carlesso.pilatesapi.repository.PlanoTratamentoRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PlanoTratamentoServiceTest {
+
+    @Mock
+    private PlanoTratamentoRepository planoTratamentoRepository;
+
+    @Mock
+    private PacienteRepository pacienteRepository;
+
+    @InjectMocks
+    private PlanoTratamentoService service;
+
+    private Paciente paciente() {
+        Paciente p = new Paciente();
+        p.setNome("Maria Souza");
+        p.setEmail("maria@email.com");
+        p.setCpf("12345678900");
+        setId(p, 1L);
+        return p;
+    }
+
+    private PlanoTratamento plano(Paciente paciente) {
+        PlanoTratamento p = new PlanoTratamento();
+        p.setPaciente(paciente);
+        p.setDataInicio(LocalDate.of(2026, 5, 1));
+        p.setDataFimPrevista(LocalDate.of(2026, 8, 1));
+        p.setObjetivosTratamento("Reduzir dor lombar e melhorar mobilidade");
+        p.setIntervencoesPlanejadas("Exercícios de core e alongamentos");
+        p.setNumeroSessoesPrevistas(24);
+        p.setFrequenciaSessoes("2x por semana");
+        p.setResponsavelTratamento("Dr. João");
+        p.setObservacoes("Paciente deve evitar impacto");
+        p.setDataCriacao(LocalDateTime.of(2026, 5, 1, 10, 0));
+        setPlanoId(p, 1L);
+        return p;
+    }
+
+    private PlanoTratamentoRequestDTO requestDTO() {
+        return new PlanoTratamentoRequestDTO(
+                1L,
+                LocalDate.of(2026, 5, 1),
+                LocalDate.of(2026, 8, 1),
+                "Reduzir dor lombar e melhorar mobilidade",
+                "Exercícios de core e alongamentos",
+                24,
+                "2x por semana",
+                "Dr. João",
+                "Paciente deve evitar impacto"
+        );
+    }
+
+    private void setId(Paciente p, Long id) {
+        try {
+            var field = Paciente.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(p, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void setPlanoId(PlanoTratamento p, Long id) {
+        try {
+            var field = PlanoTratamento.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(p, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void criar_comPacienteValido_deveRetornarResponseDTO() {
+        Paciente p = paciente();
+        when(pacienteRepository.findByIdAndAtivoTrue(1L)).thenReturn(Optional.of(p));
+        when(planoTratamentoRepository.save(any(PlanoTratamento.class))).thenReturn(plano(p));
+
+        PlanoTratamentoResponseDTO response = service.criar(requestDTO());
+
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.pacienteId()).isEqualTo(1L);
+        assertThat(response.nomePaciente()).isEqualTo("Maria Souza");
+        assertThat(response.objetivosTratamento()).isEqualTo("Reduzir dor lombar e melhorar mobilidade");
+        assertThat(response.numeroSessoesPrevistas()).isEqualTo(24);
+        verify(planoTratamentoRepository).save(any(PlanoTratamento.class));
+    }
+
+    @Test
+    void criar_comPacienteInexistente_deveLancarResourceNotFoundException() {
+        when(pacienteRepository.findByIdAndAtivoTrue(99L)).thenReturn(Optional.empty());
+
+        var dto = new PlanoTratamentoRequestDTO(
+                99L, LocalDate.of(2026, 5, 1), null,
+                "Objetivos", null, null, null, null, null
+        );
+
+        assertThatThrownBy(() -> service.criar(dto))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    void buscarPorId_quandoExistente_deveRetornarResponseDTO() {
+        when(planoTratamentoRepository.findAtivoById(1L)).thenReturn(Optional.of(plano(paciente())));
+
+        PlanoTratamentoResponseDTO response = service.buscarPorId(1L);
+
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.frequenciaSessoes()).isEqualTo("2x por semana");
+    }
+
+    @Test
+    void buscarPorId_quandoNaoExistente_deveLancarResourceNotFoundException() {
+        when(planoTratamentoRepository.findAtivoById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.buscarPorId(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    void listarPorPaciente_deveRetornarPlanosDoPaciente() {
+        Paciente p = paciente();
+        when(pacienteRepository.existsByIdAndAtivoTrue(1L)).thenReturn(true);
+        when(planoTratamentoRepository.findAtivosByPacienteOrdenados(1L)).thenReturn(List.of(plano(p)));
+
+        List<PlanoTratamentoResponseDTO> response = service.listarPorPaciente(1L);
+
+        assertThat(response).hasSize(1);
+        assertThat(response.getFirst().pacienteId()).isEqualTo(1L);
+        assertThat(response.getFirst().dataInicio()).isEqualTo(LocalDate.of(2026, 5, 1));
+    }
+
+    @Test
+    void listarPorPaciente_comPacienteAtivoSemPlanos_deveRetornarListaVazia() {
+        when(pacienteRepository.existsByIdAndAtivoTrue(1L)).thenReturn(true);
+        when(planoTratamentoRepository.findAtivosByPacienteOrdenados(1L)).thenReturn(List.of());
+
+        List<PlanoTratamentoResponseDTO> response = service.listarPorPaciente(1L);
+
+        assertThat(response).isEmpty();
+    }
+
+    @Test
+    void listarPorPaciente_comPacienteInexistente_deveLancarResourceNotFoundException() {
+        when(pacienteRepository.existsByIdAndAtivoTrue(99L)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.listarPorPaciente(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    void atualizar_deveAtualizarApenasOsCamposInformados() {
+        PlanoTratamento p = plano(paciente());
+        when(planoTratamentoRepository.findAtivoById(1L)).thenReturn(Optional.of(p));
+        when(planoTratamentoRepository.save(p)).thenReturn(p);
+
+        var dto = new PlanoTratamentoUpdateDTO(
+                LocalDate.of(2026, 5, 10),
+                LocalDate.of(2026, 9, 1),
+                "Objetivos atualizados",
+                null,
+                30,
+                null,
+                null,
+                "Evoluindo bem"
+        );
+
+        PlanoTratamentoResponseDTO response = service.atualizar(1L, dto);
+
+        assertThat(response.dataInicio()).isEqualTo(LocalDate.of(2026, 5, 10));
+        assertThat(response.dataFimPrevista()).isEqualTo(LocalDate.of(2026, 9, 1));
+        assertThat(response.objetivosTratamento()).isEqualTo("Objetivos atualizados");
+        assertThat(response.numeroSessoesPrevistas()).isEqualTo(30);
+        assertThat(response.frequenciaSessoes()).isEqualTo("2x por semana");
+        assertThat(response.dataAtualizacao()).isNotNull();
+    }
+
+    @Test
+    void atualizar_comPlanoInexistente_deveLancarResourceNotFoundException() {
+        when(planoTratamentoRepository.findAtivoById(99L)).thenReturn(Optional.empty());
+
+        var dto = new PlanoTratamentoUpdateDTO(null, null, null, null, null, null, null, null);
+
+        assertThatThrownBy(() -> service.atualizar(99L, dto))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/service/PlanoTratamentoServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/PlanoTratamentoServiceTest.java
@@ -127,6 +127,18 @@ class PlanoTratamentoServiceTest {
     }
 
     @Test
+    void criar_comDataFimAnteriorADataInicio_deveLancarIllegalArgumentException() {
+        var dto = new PlanoTratamentoRequestDTO(
+                1L, LocalDate.of(2026, 8, 1), LocalDate.of(2026, 5, 1),
+                "Objetivos", null, null, null, null, null
+        );
+
+        assertThatThrownBy(() -> service.criar(dto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("dataFimPrevista");
+    }
+
+    @Test
     void buscarPorId_quandoExistente_deveRetornarResponseDTO() {
         when(planoTratamentoRepository.findAtivoById(1L)).thenReturn(Optional.of(plano(paciente())));
 
@@ -205,12 +217,48 @@ class PlanoTratamentoServiceTest {
     }
 
     @Test
+    void atualizar_comDataFimAnteriorADataInicio_deveLancarIllegalArgumentException() {
+        PlanoTratamento p = plano(paciente());
+        when(planoTratamentoRepository.findAtivoById(1L)).thenReturn(Optional.of(p));
+
+        var dto = new PlanoTratamentoUpdateDTO(
+                LocalDate.of(2026, 8, 1),
+                LocalDate.of(2026, 5, 1),
+                null, null, null, null, null, null
+        );
+
+        assertThatThrownBy(() -> service.atualizar(1L, dto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("dataFimPrevista");
+    }
+
+    @Test
     void atualizar_comPlanoInexistente_deveLancarResourceNotFoundException() {
         when(planoTratamentoRepository.findAtivoById(99L)).thenReturn(Optional.empty());
 
         var dto = new PlanoTratamentoUpdateDTO(null, null, null, null, null, null, null, null);
 
         assertThatThrownBy(() -> service.atualizar(99L, dto))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    void inativar_comPlanoExistente_deveMarcarComoInativo() {
+        PlanoTratamento p = plano(paciente());
+        when(planoTratamentoRepository.findAtivoById(1L)).thenReturn(Optional.of(p));
+
+        service.inativar(1L);
+
+        assertThat(p.isAtivo()).isFalse();
+        assertThat(p.getDataAtualizacao()).isNotNull();
+    }
+
+    @Test
+    void inativar_comPlanoInexistente_deveLancarResourceNotFoundException() {
+        when(planoTratamentoRepository.findAtivoById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.inativar(99L))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining("99");
     }


### PR DESCRIPTION
## Resumo

- Implementa CRUD completo de Plano de Tratamento clínico do paciente (issue #51)
- Segue os mesmos padrões arquiteturais já estabelecidos (AvaliacaoFisioterapeutica, Anamnese)
- Um paciente pode ter múltiplos planos de tratamento para manter histórico clínico

## Motivo da mudança

Necessidade de registrar e gerenciar os planos de tratamento fisioterapêutico dos pacientes, incluindo objetivos terapêuticos, intervenções planejadas, frequência e responsável.

## Endpoints adicionados

| Método | Rota | Descrição |
|---|---|---|
| `POST` | `/planos-tratamento` | Criar plano de tratamento |
| `GET` | `/planos-tratamento/{id}` | Buscar por ID |
| `GET` | `/planos-tratamento/paciente/{pacienteId}` | Listar por paciente |
| `PUT` | `/planos-tratamento/{id}` | Atualização parcial |

## Testes executados

```
JAVA_HOME=~/jdk mvn test
Tests run: 287, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

## Arquivos principais alterados

- `V16__create_planos_tratamento_table.sql` — migração Flyway
- `PlanoTratamento.java` — entidade JPA
- `PlanoTratamentoRepository.java` — queries com filtro de paciente ativo
- `PlanoTratamentoRequestDTO.java` / `PlanoTratamentoUpdateDTO.java` / `PlanoTratamentoResponseDTO.java` — DTOs (records)
- `PlanoTratamentoService.java` — lógica de negócio
- `PlanoTratamentoController.java` — endpoints REST com Swagger
- `PlanoTratamentoServiceTest.java` — 8 testes unitários (Mockito)
- `PlanoTratamentoControllerTest.java` — 11 testes de controller (WebMvcTest)
- `README.md` / `docs/context.md` — documentação atualizada

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)