### PR TITLE
feat: implementar módulo de Evolução da Sessão (#53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,9 @@ src/
 │           ├── V13__add_indexes_on_foreign_keys.sql
 │           ├── V14__create_anamneses_table.sql
 │           ├── V15__create_avaliacoes_fisioterapeuticas_table.sql
-│           └── V16__create_planos_tratamento_table.sql
+│           ├── V16__create_planos_tratamento_table.sql
+│           ├── V17__create_sessoes_pilates_table.sql
+│           └── V18__create_evolucoes_sessao_table.sql
 └── test/java/com/carlesso/pilatesapi/
     ├── PilatesApiApplicationTests.java
     ├── actuator/
@@ -285,6 +287,15 @@ As demais rotas de negócio exigem `Authorization: Bearer <accessToken>`. Tokens
 | `GET` | `/planos-tratamento/paciente/{pacienteId}` | Listar planos de tratamento do paciente |
 | `PUT` | `/planos-tratamento/{id}` | Atualizar dados do plano de tratamento |
 | `DELETE` | `/planos-tratamento/{id}` | Inativar plano de tratamento |
+
+### Evoluções de Sessão
+
+| Método | Endpoint | Descrição |
+|---|---|---|
+| `POST` | `/evolucoes-sessao` | Registrar evolução clínica de uma sessão |
+| `GET` | `/evolucoes-sessao/{id}` | Buscar evolução por ID |
+| `GET` | `/evolucoes-sessao/sessao/{sessaoId}` | Buscar evolução pela sessão vinculada |
+| `PUT` | `/evolucoes-sessao/{id}` | Atualizar dados da evolução |
 
 ### Relatórios
 
@@ -661,6 +672,8 @@ O projeto utiliza **Flyway** para versionamento e execução automática das mig
 | `V14__create_anamneses_table.sql` | Cria tabela `anamneses` vinculada a pacientes |
 | `V15__create_avaliacoes_fisioterapeuticas_table.sql` | Cria histórico de avaliações fisioterapêuticas do paciente |
 | `V16__create_planos_tratamento_table.sql` | Cria tabela de planos de tratamento do paciente |
+| `V17__create_sessoes_pilates_table.sql` | Cria tabela de sessões de Pilates/Fisioterapia |
+| `V18__create_evolucoes_sessao_table.sql` | Cria tabela de evoluções de sessão vinculada a sessões |
 
 > Nos testes automatizados o Flyway fica desabilitado (`spring.flyway.enabled=false`), pois o banco H2 é gerenciado pelo Hibernate com `ddl-auto=create-drop`.
 
@@ -902,6 +915,14 @@ curl -s -OJ "http://localhost:8080/api/relatorios/nfse?competencia=04/2026&forma
 - Atualização parcial: apenas campos não-nulos do DTO de update são aplicados; `objetivosTratamento` não aceita strings em branco quando enviado
 - Exclusão é lógica: `DELETE /planos-tratamento/{id}` marca o plano como inativo e preserva o histórico no banco
 
+### Evoluções de Sessão
+- Cada sessão possui no máximo uma evolução clínica (regra de unicidade por `sessao_id`)
+- Criar evolução para sessão inexistente retorna `404`
+- Tentar criar segunda evolução para a mesma sessão retorna `409`
+- Campos obrigatórios: `sessaoId` e `dataHoraRegistro`
+- `dorAntes` e `dorDepois`, quando informados, aceitam apenas valores inteiros de 0 a 10
+- Atualização parcial: apenas campos não-nulos do DTO de update são aplicados
+
 ### Scheduler (processos automáticos)
 | Horário | Ação | Configuração |
 |---|---|---|
@@ -969,6 +990,8 @@ O projeto possui testes unitários, de controller e de integração organizados 
 | `RelatorioNfseControllerTest` | Controller (`@WebMvcTest`) | 6 |
 | `DashboardControllerTest` | Controller (`@WebMvcTest`) | 2 |
 | `DashboardServiceTest` | Unitário (Mockito) | 3 |
+| `EvolucaoSessaoServiceTest` | Unitário (Mockito) | 8 |
+| `EvolucaoSessaoControllerTest` | Controller (`@WebMvcTest`) | 11 |
 | `SecurityIntegrationTest` | Integração (`@SpringBootTest` + MockMvc + H2) | 23 |
 | `ActuatorTest` | Integração (`@SpringBootTest`) | 3 |
 | `PilatesApiApplicationTests` | Integração (`@SpringBootTest`) | 1 |

--- a/README.md
+++ b/README.md
@@ -915,12 +915,18 @@ curl -s -OJ "http://localhost:8080/api/relatorios/nfse?competencia=04/2026&forma
 - Atualização parcial: apenas campos não-nulos do DTO de update são aplicados; `objetivosTratamento` não aceita strings em branco quando enviado
 - Exclusão é lógica: `DELETE /planos-tratamento/{id}` marca o plano como inativo e preserva o histórico no banco
 
+### Sessões de Pilates/Fisioterapia
+- A evolução clínica estruturada deve ser registrada em `/evolucoes-sessao`
+- O campo legado `sessoes_pilates.evolucao` não faz parte do contrato REST de sessões
+- Excluir uma sessão remove também a evolução vinculada, quando existir
+
 ### Evoluções de Sessão
 - Cada sessão possui no máximo uma evolução clínica (regra de unicidade por `sessao_id`)
 - Criar evolução para sessão inexistente retorna `404`
 - Tentar criar segunda evolução para a mesma sessão retorna `409`
 - Campos obrigatórios: `sessaoId` e `dataHoraRegistro`
 - `dorAntes` e `dorDepois`, quando informados, aceitam apenas valores inteiros de 0 a 10
+- Consultas e atualizações filtram sessões de pacientes ativos
 - Atualização parcial: apenas campos não-nulos do DTO de update são aplicados
 
 ### Scheduler (processos automáticos)
@@ -990,8 +996,8 @@ O projeto possui testes unitários, de controller e de integração organizados 
 | `RelatorioNfseControllerTest` | Controller (`@WebMvcTest`) | 6 |
 | `DashboardControllerTest` | Controller (`@WebMvcTest`) | 2 |
 | `DashboardServiceTest` | Unitário (Mockito) | 3 |
-| `EvolucaoSessaoServiceTest` | Unitário (Mockito) | 8 |
-| `EvolucaoSessaoControllerTest` | Controller (`@WebMvcTest`) | 11 |
+| `EvolucaoSessaoServiceTest` | Unitário (Mockito) | 10 |
+| `EvolucaoSessaoControllerTest` | Controller (`@WebMvcTest`) | 13 |
 | `SecurityIntegrationTest` | Integração (`@SpringBootTest` + MockMvc + H2) | 23 |
 | `ActuatorTest` | Integração (`@SpringBootTest`) | 3 |
 | `PilatesApiApplicationTests` | Integração (`@SpringBootTest`) | 1 |

--- a/docs/context.md
+++ b/docs/context.md
@@ -53,6 +53,7 @@ com.carlesso.pilatesapi
 │   ├── AvaliacaoFisioterapeuticaController.java — endpoints REST de avaliações fisioterapêuticas
 │   ├── PlanoTratamentoController.java — endpoints REST de planos de tratamento
 │   ├── SessaoPilatesController.java  — endpoints REST de sessões de Pilates/Fisioterapia
+│   ├── EvolucaoSessaoController.java — endpoints REST de evoluções de sessão
 │   ├── AuthController.java           — registro/login com JWT
 │   ├── UserController.java           — endpoint do usuário autenticado e CRUD administrativo
 │   ├── AdminController.java          — endpoints administrativos
@@ -65,6 +66,7 @@ com.carlesso.pilatesapi
 │   ├── AvaliacaoFisioterapeuticaService.java   — lógica de negócio de avaliações fisioterapêuticas
 │   ├── PlanoTratamentoService.java             — lógica de negócio de planos de tratamento
 │   ├── SessaoPilatesService.java               — lógica de negócio de sessões de Pilates/Fisioterapia
+│   ├── EvolucaoSessaoService.java              — lógica de negócio de evoluções de sessão
 │   ├── PlanoService.java                       — regras de plano e frequência
 │   ├── PagamentoService.java                   — cobranças, confirmação, vencimentos
 │   ├── AulaService.java                        — geração e controle de aulas
@@ -87,6 +89,7 @@ com.carlesso.pilatesapi
 │   ├── AvaliacaoFisioterapeuticaRepository.java
 │   ├── PlanoTratamentoRepository.java
 │   ├── SessaoPilatesRepository.java
+│   ├── EvolucaoSessaoRepository.java
 │   └── UserRepository.java
 ├── entity
 │   ├── Paciente.java                 — entidade JPA, tabela `pacientes`
@@ -99,6 +102,7 @@ com.carlesso.pilatesapi
 │   ├── AvaliacaoFisioterapeutica.java — entidade JPA, tabela `avaliacoes_fisioterapeuticas`
 │   ├── PlanoTratamento.java          — entidade JPA, tabela `planos_tratamento`
 │   ├── SessaoPilates.java            — entidade JPA, tabela `sessoes_pilates`
+│   ├── EvolucaoSessao.java           — entidade JPA, tabela `evolucoes_sessao`
 │   └── User.java                     — entidade JPA, tabela `users`
 ├── entity/enums
 │   ├── TipoPagamento.java            — MENSAL, TRIMESTRAL, ANUAL
@@ -321,6 +325,27 @@ Relacionamento `@ManyToOne` com `Paciente`. Um paciente pode possuir múltiplos 
 
 Relacionamento `@ManyToOne` com `Paciente`, `Profissional` (nullable) e `PlanoTratamento` (nullable). Um paciente pode possuir múltiplas sessões para manter histórico clínico.
 
+### Tabela `evolucoes_sessao`
+
+| Campo | Tipo | Restrição |
+|---|---|---|
+| `id` | BIGINT | PK, auto-increment |
+| `sessao_id` | BIGINT | NOT NULL, UNIQUE, FK → sessoes_pilates |
+| `data_hora_registro` | TIMESTAMP | NOT NULL |
+| `exercicios_realizados` | TEXT | — |
+| `equipamentos_utilizados` | TEXT | — |
+| `cargas_molas` | TEXT | — |
+| `dor_antes` | INTEGER | nullable, CHECK 0..10 |
+| `dor_depois` | INTEGER | nullable, CHECK 0..10 |
+| `resposta_paciente` | TEXT | — |
+| `intercorrencias` | TEXT | — |
+| `orientacoes` | TEXT | — |
+| `observacoes_fisioterapeuta` | TEXT | — |
+| `data_criacao` | TIMESTAMP | NOT NULL |
+| `data_atualizacao` | TIMESTAMP | — |
+
+Relacionamento `@OneToOne` com `SessaoPilates`. Cada sessão possui no máximo uma evolução (constraint `UNIQUE sessao_id`).
+
 ### Índices
 
 | Índice | Tabela / Coluna | Motivação |
@@ -401,6 +426,10 @@ Relacionamento `@ManyToOne` com `Paciente`, `Profissional` (nullable) e `PlanoTr
 | PUT | `/sessoes/{id}` | Atualizar sessão (atualização parcial) | 200 / 400 / 404 |
 | DELETE | `/sessoes/{id}` | Excluir sessão permanentemente | 204 / 404 |
 | GET | `/dashboard/resumo` | Resumo consolidado para o painel inicial (pacientes, profissionais, pagamentos, aulas) | 200 / 401 |
+| POST | `/evolucoes-sessao` | Criar evolução para uma sessão | 201 / 400 / 404 / 409 |
+| GET | `/evolucoes-sessao/{id}` | Buscar evolução por ID | 200 / 404 |
+| GET | `/evolucoes-sessao/sessao/{sessaoId}` | Buscar evolução por sessão | 200 / 404 |
+| PUT | `/evolucoes-sessao/{id}` | Atualizar evolução (atualização parcial) | 200 / 400 / 404 |
 
 Campos obrigatórios no cadastro de pacientes: `nome`, `email`, `cpf`.  
 Campos obrigatórios no cadastro de profissionais: `nome`, `email`, `cpf`, `tipoContrato`, `percentualPagamentoAula`, `dataInicio`.  
@@ -507,6 +536,15 @@ CPF não pode ser alterado após o cadastro.
 - `duracaoMinutos` aceita apenas valores positivos quando informado
 - Atualização parcial: apenas campos não-nulos do DTO de update são aplicados
 - Exclusão é física (DELETE permanente — sem soft delete, pois sessões canceladas por engano devem poder ser removidas)
+- `dataCriacao` é registrada na criação e `dataAtualizacao` em cada atualização
+
+### Evolução de Sessão
+- Cada sessão possui no máximo uma evolução clínica (regra de unicidade por `sessao_id`)
+- Criar evolução para sessão inexistente retorna `404`
+- Tentar criar segunda evolução para a mesma sessão retorna `409`
+- Campos obrigatórios: `sessaoId` e `dataHoraRegistro`
+- `dorAntes` e `dorDepois`, quando informados, aceitam apenas valores inteiros de 0 a 10
+- Atualização parcial: apenas campos não-nulos do DTO de update são aplicados
 - `dataCriacao` é registrada na criação e `dataAtualizacao` em cada atualização
 
 ### Scheduler (processos automáticos)
@@ -647,6 +685,8 @@ JAVA_HOME=~/jdk mvn spring-boot:run
 | `DashboardServiceTest` | Unitário (Mockito, sem Spring) | 3 |
 | `AppPropertiesTest` | Unitário (ApplicationContextRunner) | 3 |
 | `GlobalExceptionHandlerTest` | Unitário | 6 |
+| `EvolucaoSessaoServiceTest` | Unitário (Mockito, sem Spring) | 8 |
+| `EvolucaoSessaoControllerTest` | `@WebMvcTest` + MockMvc | 11 |
 | `SecurityIntegrationTest` | `@SpringBootTest` + MockMvc + H2 | 23 |
 | `ActuatorTest` | `@SpringBootTest` + H2 | 3 |
 | `PilatesApiApplicationTests` | `@SpringBootTest` + H2 | 1 |

--- a/docs/context.md
+++ b/docs/context.md
@@ -319,7 +319,7 @@ Relacionamento `@ManyToOne` com `Paciente`. Um paciente pode possuir múltiplos 
 | `local` | VARCHAR(100) | — |
 | `duracao_minutos` | INTEGER | — |
 | `observacoes` | TEXT | — |
-| `evolucao` | TEXT | — |
+| `evolucao` | TEXT | legado, não exposto no contrato REST |
 | `data_criacao` | TIMESTAMP | NOT NULL |
 | `data_atualizacao` | TIMESTAMP | — |
 
@@ -535,7 +535,8 @@ CPF não pode ser alterado após o cadastro.
 - `profissionalId` e `planoTratamentoId` são opcionais; quando informados, o recurso deve existir e estar ativo, e o plano de tratamento deve pertencer ao mesmo `pacienteId` da sessão
 - `duracaoMinutos` aceita apenas valores positivos quando informado
 - Atualização parcial: apenas campos não-nulos do DTO de update são aplicados
-- Exclusão é física (DELETE permanente — sem soft delete, pois sessões canceladas por engano devem poder ser removidas)
+- A evolução clínica estruturada deve ser registrada em `/evolucoes-sessao`; o campo legado `sessoes_pilates.evolucao` não faz parte do contrato REST
+- Exclusão é física (DELETE permanente — sem soft delete, pois sessões canceladas por engano devem poder ser removidas) e remove a evolução vinculada quando existir
 - `dataCriacao` é registrada na criação e `dataAtualizacao` em cada atualização
 
 ### Evolução de Sessão
@@ -544,7 +545,9 @@ CPF não pode ser alterado após o cadastro.
 - Tentar criar segunda evolução para a mesma sessão retorna `409`
 - Campos obrigatórios: `sessaoId` e `dataHoraRegistro`
 - `dorAntes` e `dorDepois`, quando informados, aceitam apenas valores inteiros de 0 a 10
+- Consultas e atualizações de evolução filtram `sessao.paciente.ativo = true`
 - Atualização parcial: apenas campos não-nulos do DTO de update são aplicados
+- Ao excluir uma sessão, a evolução vinculada é removida junto
 - `dataCriacao` é registrada na criação e `dataAtualizacao` em cada atualização
 
 ### Scheduler (processos automáticos)
@@ -685,8 +688,8 @@ JAVA_HOME=~/jdk mvn spring-boot:run
 | `DashboardServiceTest` | Unitário (Mockito, sem Spring) | 3 |
 | `AppPropertiesTest` | Unitário (ApplicationContextRunner) | 3 |
 | `GlobalExceptionHandlerTest` | Unitário | 6 |
-| `EvolucaoSessaoServiceTest` | Unitário (Mockito, sem Spring) | 8 |
-| `EvolucaoSessaoControllerTest` | `@WebMvcTest` + MockMvc | 11 |
+| `EvolucaoSessaoServiceTest` | Unitário (Mockito, sem Spring) | 10 |
+| `EvolucaoSessaoControllerTest` | `@WebMvcTest` + MockMvc | 13 |
 | `SecurityIntegrationTest` | `@SpringBootTest` + MockMvc + H2 | 23 |
 | `ActuatorTest` | `@SpringBootTest` + H2 | 3 |
 | `PilatesApiApplicationTests` | `@SpringBootTest` + H2 | 1 |

--- a/src/main/java/com/carlesso/pilatesapi/controller/EvolucaoSessaoController.java
+++ b/src/main/java/com/carlesso/pilatesapi/controller/EvolucaoSessaoController.java
@@ -1,0 +1,84 @@
+package com.carlesso.pilatesapi.controller;
+
+import com.carlesso.pilatesapi.dto.EvolucaoSessaoRequestDTO;
+import com.carlesso.pilatesapi.dto.EvolucaoSessaoResponseDTO;
+import com.carlesso.pilatesapi.dto.EvolucaoSessaoUpdateDTO;
+import com.carlesso.pilatesapi.service.EvolucaoSessaoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Tag(name = "Evoluções de Sessão", description = "Registro e consulta de evoluções clínicas das sessões")
+@RestController
+@RequestMapping("/evolucoes-sessao")
+public class EvolucaoSessaoController {
+
+    private final EvolucaoSessaoService service;
+
+    public EvolucaoSessaoController(EvolucaoSessaoService service) {
+        this.service = service;
+    }
+
+    @Operation(
+            summary = "Registrar evolução de sessão",
+            description = "Registra a evolução clínica de uma sessão de Pilates ou Fisioterapia. Cada sessão admite apenas uma evolução."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Evolução registrada com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Dados inválidos ou campos obrigatórios ausentes"),
+            @ApiResponse(responseCode = "404", description = "Sessão não encontrada"),
+            @ApiResponse(responseCode = "409", description = "Sessão já possui evolução registrada")
+    })
+    @PostMapping
+    public ResponseEntity<EvolucaoSessaoResponseDTO> criar(
+            @RequestBody @Valid EvolucaoSessaoRequestDTO dto,
+            UriComponentsBuilder uriBuilder) {
+        EvolucaoSessaoResponseDTO response = service.criar(dto);
+        var uri = uriBuilder.path("/evolucoes-sessao/{id}").buildAndExpand(response.id()).toUri();
+        return ResponseEntity.created(uri).body(response);
+    }
+
+    @Operation(summary = "Buscar evolução por ID")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Evolução encontrada"),
+            @ApiResponse(responseCode = "404", description = "Evolução não encontrada")
+    })
+    @GetMapping("/{id}")
+    public ResponseEntity<EvolucaoSessaoResponseDTO> buscarPorId(
+            @Parameter(description = "ID da evolução", required = true) @PathVariable Long id) {
+        return ResponseEntity.ok(service.buscarPorId(id));
+    }
+
+    @Operation(summary = "Buscar evolução por sessão")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Evolução encontrada"),
+            @ApiResponse(responseCode = "404", description = "Sessão ou evolução não encontrada")
+    })
+    @GetMapping("/sessao/{sessaoId}")
+    public ResponseEntity<EvolucaoSessaoResponseDTO> buscarPorSessao(
+            @Parameter(description = "ID da sessão", required = true) @PathVariable Long sessaoId) {
+        return ResponseEntity.ok(service.buscarPorSessao(sessaoId));
+    }
+
+    @Operation(
+            summary = "Atualizar evolução",
+            description = "Atualiza os dados da evolução clínica. Apenas os campos enviados serão alterados."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Evolução atualizada com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Dados inválidos"),
+            @ApiResponse(responseCode = "404", description = "Evolução não encontrada")
+    })
+    @PutMapping("/{id}")
+    public ResponseEntity<EvolucaoSessaoResponseDTO> atualizar(
+            @Parameter(description = "ID da evolução", required = true) @PathVariable Long id,
+            @RequestBody @Valid EvolucaoSessaoUpdateDTO dto) {
+        return ResponseEntity.ok(service.atualizar(id, dto));
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/dto/EvolucaoSessaoRequestDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/EvolucaoSessaoRequestDTO.java
@@ -1,0 +1,20 @@
+package com.carlesso.pilatesapi.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record EvolucaoSessaoRequestDTO(
+        @NotNull Long sessaoId,
+        @NotNull LocalDateTime dataHoraRegistro,
+        String exerciciosRealizados,
+        String equipamentosUtilizados,
+        String cargasMolas,
+        @Min(0) @Max(10) Integer dorAntes,
+        @Min(0) @Max(10) Integer dorDepois,
+        String respostaPaciente,
+        String intercorrencias,
+        String orientacoes,
+        String observacoesFisioterapeuta
+) {}

--- a/src/main/java/com/carlesso/pilatesapi/dto/EvolucaoSessaoResponseDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/EvolucaoSessaoResponseDTO.java
@@ -1,0 +1,40 @@
+package com.carlesso.pilatesapi.dto;
+
+import com.carlesso.pilatesapi.entity.EvolucaoSessao;
+import java.time.LocalDateTime;
+
+public record EvolucaoSessaoResponseDTO(
+        Long id,
+        Long sessaoId,
+        LocalDateTime dataHoraRegistro,
+        String exerciciosRealizados,
+        String equipamentosUtilizados,
+        String cargasMolas,
+        Integer dorAntes,
+        Integer dorDepois,
+        String respostaPaciente,
+        String intercorrencias,
+        String orientacoes,
+        String observacoesFisioterapeuta,
+        LocalDateTime dataCriacao,
+        LocalDateTime dataAtualizacao
+) {
+    public static EvolucaoSessaoResponseDTO from(EvolucaoSessao e) {
+        return new EvolucaoSessaoResponseDTO(
+                e.getId(),
+                e.getSessao().getId(),
+                e.getDataHoraRegistro(),
+                e.getExerciciosRealizados(),
+                e.getEquipamentosUtilizados(),
+                e.getCargasMolas(),
+                e.getDorAntes(),
+                e.getDorDepois(),
+                e.getRespostaPaciente(),
+                e.getIntercorrencias(),
+                e.getOrientacoes(),
+                e.getObservacoesFisioterapeuta(),
+                e.getDataCriacao(),
+                e.getDataAtualizacao()
+        );
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/dto/EvolucaoSessaoUpdateDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/EvolucaoSessaoUpdateDTO.java
@@ -1,0 +1,18 @@
+package com.carlesso.pilatesapi.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.time.LocalDateTime;
+
+public record EvolucaoSessaoUpdateDTO(
+        LocalDateTime dataHoraRegistro,
+        String exerciciosRealizados,
+        String equipamentosUtilizados,
+        String cargasMolas,
+        @Min(0) @Max(10) Integer dorAntes,
+        @Min(0) @Max(10) Integer dorDepois,
+        String respostaPaciente,
+        String intercorrencias,
+        String orientacoes,
+        String observacoesFisioterapeuta
+) {}

--- a/src/main/java/com/carlesso/pilatesapi/dto/SessaoPilatesResponseDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/SessaoPilatesResponseDTO.java
@@ -21,7 +21,6 @@ public record SessaoPilatesResponseDTO(
         String local,
         Integer duracaoMinutos,
         String observacoes,
-        String evolucao,
         LocalDateTime dataCriacao,
         LocalDateTime dataAtualizacao
 ) {
@@ -40,7 +39,6 @@ public record SessaoPilatesResponseDTO(
                 s.getLocal(),
                 s.getDuracaoMinutos(),
                 s.getObservacoes(),
-                s.getEvolucao(),
                 s.getDataCriacao(),
                 s.getDataAtualizacao()
         );

--- a/src/main/java/com/carlesso/pilatesapi/dto/SessaoPilatesUpdateDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/SessaoPilatesUpdateDTO.java
@@ -11,6 +11,5 @@ public record SessaoPilatesUpdateDTO(
         String local,
         @Positive Integer duracaoMinutos,
         StatusSessao status,
-        String observacoes,
-        String evolucao
+        String observacoes
 ) {}

--- a/src/main/java/com/carlesso/pilatesapi/entity/EvolucaoSessao.java
+++ b/src/main/java/com/carlesso/pilatesapi/entity/EvolucaoSessao.java
@@ -1,0 +1,98 @@
+package com.carlesso.pilatesapi.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "evolucoes_sessao")
+public class EvolucaoSessao {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sessao_id", nullable = false, unique = true)
+    private SessaoPilates sessao;
+
+    @Column(nullable = false)
+    private LocalDateTime dataHoraRegistro;
+
+    @Column(columnDefinition = "TEXT")
+    private String exerciciosRealizados;
+
+    @Column(columnDefinition = "TEXT")
+    private String equipamentosUtilizados;
+
+    @Column(columnDefinition = "TEXT")
+    private String cargasMolas;
+
+    private Integer dorAntes;
+
+    private Integer dorDepois;
+
+    @Column(columnDefinition = "TEXT")
+    private String respostaPaciente;
+
+    @Column(columnDefinition = "TEXT")
+    private String intercorrencias;
+
+    @Column(columnDefinition = "TEXT")
+    private String orientacoes;
+
+    @Column(columnDefinition = "TEXT")
+    private String observacoesFisioterapeuta;
+
+    @Column(nullable = false)
+    private LocalDateTime dataCriacao;
+
+    private LocalDateTime dataAtualizacao;
+
+    public EvolucaoSessao() {}
+
+    @PrePersist
+    void prePersist() {
+        this.dataCriacao = LocalDateTime.now();
+    }
+
+    public Long getId() { return id; }
+
+    public SessaoPilates getSessao() { return sessao; }
+    public void setSessao(SessaoPilates sessao) { this.sessao = sessao; }
+
+    public LocalDateTime getDataHoraRegistro() { return dataHoraRegistro; }
+    public void setDataHoraRegistro(LocalDateTime dataHoraRegistro) { this.dataHoraRegistro = dataHoraRegistro; }
+
+    public String getExerciciosRealizados() { return exerciciosRealizados; }
+    public void setExerciciosRealizados(String exerciciosRealizados) { this.exerciciosRealizados = exerciciosRealizados; }
+
+    public String getEquipamentosUtilizados() { return equipamentosUtilizados; }
+    public void setEquipamentosUtilizados(String equipamentosUtilizados) { this.equipamentosUtilizados = equipamentosUtilizados; }
+
+    public String getCargasMolas() { return cargasMolas; }
+    public void setCargasMolas(String cargasMolas) { this.cargasMolas = cargasMolas; }
+
+    public Integer getDorAntes() { return dorAntes; }
+    public void setDorAntes(Integer dorAntes) { this.dorAntes = dorAntes; }
+
+    public Integer getDorDepois() { return dorDepois; }
+    public void setDorDepois(Integer dorDepois) { this.dorDepois = dorDepois; }
+
+    public String getRespostaPaciente() { return respostaPaciente; }
+    public void setRespostaPaciente(String respostaPaciente) { this.respostaPaciente = respostaPaciente; }
+
+    public String getIntercorrencias() { return intercorrencias; }
+    public void setIntercorrencias(String intercorrencias) { this.intercorrencias = intercorrencias; }
+
+    public String getOrientacoes() { return orientacoes; }
+    public void setOrientacoes(String orientacoes) { this.orientacoes = orientacoes; }
+
+    public String getObservacoesFisioterapeuta() { return observacoesFisioterapeuta; }
+    public void setObservacoesFisioterapeuta(String observacoesFisioterapeuta) { this.observacoesFisioterapeuta = observacoesFisioterapeuta; }
+
+    public LocalDateTime getDataCriacao() { return dataCriacao; }
+    public void setDataCriacao(LocalDateTime dataCriacao) { this.dataCriacao = dataCriacao; }
+
+    public LocalDateTime getDataAtualizacao() { return dataAtualizacao; }
+    public void setDataAtualizacao(LocalDateTime dataAtualizacao) { this.dataAtualizacao = dataAtualizacao; }
+}

--- a/src/main/java/com/carlesso/pilatesapi/repository/EvolucaoSessaoRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/EvolucaoSessaoRepository.java
@@ -1,0 +1,19 @@
+package com.carlesso.pilatesapi.repository;
+
+import com.carlesso.pilatesapi.entity.EvolucaoSessao;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface EvolucaoSessaoRepository extends JpaRepository<EvolucaoSessao, Long> {
+
+    boolean existsBySessaoId(Long sessaoId);
+
+    @Query("SELECT e FROM EvolucaoSessao e JOIN FETCH e.sessao WHERE e.id = :id")
+    Optional<EvolucaoSessao> findByIdComSessao(@Param("id") Long id);
+
+    @Query("SELECT e FROM EvolucaoSessao e JOIN FETCH e.sessao WHERE e.sessao.id = :sessaoId")
+    Optional<EvolucaoSessao> findBySessaoId(@Param("sessaoId") Long sessaoId);
+}

--- a/src/main/java/com/carlesso/pilatesapi/repository/EvolucaoSessaoRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/EvolucaoSessaoRepository.java
@@ -11,9 +11,21 @@ public interface EvolucaoSessaoRepository extends JpaRepository<EvolucaoSessao, 
 
     boolean existsBySessaoId(Long sessaoId);
 
-    @Query("SELECT e FROM EvolucaoSessao e JOIN FETCH e.sessao WHERE e.id = :id")
+    void deleteBySessaoId(Long sessaoId);
+
+    @Query("""
+            SELECT e FROM EvolucaoSessao e
+            JOIN FETCH e.sessao s
+            JOIN s.paciente pac
+            WHERE e.id = :id AND pac.ativo = true
+            """)
     Optional<EvolucaoSessao> findByIdComSessao(@Param("id") Long id);
 
-    @Query("SELECT e FROM EvolucaoSessao e JOIN FETCH e.sessao WHERE e.sessao.id = :sessaoId")
+    @Query("""
+            SELECT e FROM EvolucaoSessao e
+            JOIN FETCH e.sessao s
+            JOIN s.paciente pac
+            WHERE s.id = :sessaoId AND pac.ativo = true
+            """)
     Optional<EvolucaoSessao> findBySessaoId(@Param("sessaoId") Long sessaoId);
 }

--- a/src/main/java/com/carlesso/pilatesapi/service/EvolucaoSessaoService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/EvolucaoSessaoService.java
@@ -1,0 +1,92 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.EvolucaoSessaoRequestDTO;
+import com.carlesso.pilatesapi.dto.EvolucaoSessaoResponseDTO;
+import com.carlesso.pilatesapi.dto.EvolucaoSessaoUpdateDTO;
+import com.carlesso.pilatesapi.entity.EvolucaoSessao;
+import com.carlesso.pilatesapi.entity.SessaoPilates;
+import com.carlesso.pilatesapi.exception.ConflictException;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
+import com.carlesso.pilatesapi.repository.EvolucaoSessaoRepository;
+import com.carlesso.pilatesapi.repository.SessaoPilatesRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+public class EvolucaoSessaoService {
+
+    private final EvolucaoSessaoRepository evolucaoRepository;
+    private final SessaoPilatesRepository sessaoRepository;
+
+    public EvolucaoSessaoService(EvolucaoSessaoRepository evolucaoRepository,
+                                 SessaoPilatesRepository sessaoRepository) {
+        this.evolucaoRepository = evolucaoRepository;
+        this.sessaoRepository = sessaoRepository;
+    }
+
+    @Transactional
+    public EvolucaoSessaoResponseDTO criar(EvolucaoSessaoRequestDTO dto) {
+        SessaoPilates sessao = sessaoRepository.findByIdComPaciente(dto.sessaoId())
+                .orElseThrow(() -> new ResourceNotFoundException("Sessão não encontrada: " + dto.sessaoId()));
+
+        if (evolucaoRepository.existsBySessaoId(dto.sessaoId())) {
+            throw new ConflictException("Sessão já possui evolução registrada: " + dto.sessaoId());
+        }
+
+        EvolucaoSessao evolucao = new EvolucaoSessao();
+        evolucao.setSessao(sessao);
+        evolucao.setDataHoraRegistro(dto.dataHoraRegistro());
+        evolucao.setExerciciosRealizados(dto.exerciciosRealizados());
+        evolucao.setEquipamentosUtilizados(dto.equipamentosUtilizados());
+        evolucao.setCargasMolas(dto.cargasMolas());
+        evolucao.setDorAntes(dto.dorAntes());
+        evolucao.setDorDepois(dto.dorDepois());
+        evolucao.setRespostaPaciente(dto.respostaPaciente());
+        evolucao.setIntercorrencias(dto.intercorrencias());
+        evolucao.setOrientacoes(dto.orientacoes());
+        evolucao.setObservacoesFisioterapeuta(dto.observacoesFisioterapeuta());
+
+        return EvolucaoSessaoResponseDTO.from(evolucaoRepository.save(evolucao));
+    }
+
+    @Transactional(readOnly = true)
+    public EvolucaoSessaoResponseDTO buscarPorId(Long id) {
+        return EvolucaoSessaoResponseDTO.from(encontrar(id));
+    }
+
+    @Transactional(readOnly = true)
+    public EvolucaoSessaoResponseDTO buscarPorSessao(Long sessaoId) {
+        if (!sessaoRepository.existsById(sessaoId)) {
+            throw new ResourceNotFoundException("Sessão não encontrada: " + sessaoId);
+        }
+        return evolucaoRepository.findBySessaoId(sessaoId)
+                .map(EvolucaoSessaoResponseDTO::from)
+                .orElseThrow(() -> new ResourceNotFoundException("Evolução não encontrada para a sessão: " + sessaoId));
+    }
+
+    @Transactional
+    public EvolucaoSessaoResponseDTO atualizar(Long id, EvolucaoSessaoUpdateDTO dto) {
+        EvolucaoSessao evolucao = encontrar(id);
+
+        if (dto.dataHoraRegistro() != null) evolucao.setDataHoraRegistro(dto.dataHoraRegistro());
+        if (dto.exerciciosRealizados() != null) evolucao.setExerciciosRealizados(dto.exerciciosRealizados());
+        if (dto.equipamentosUtilizados() != null) evolucao.setEquipamentosUtilizados(dto.equipamentosUtilizados());
+        if (dto.cargasMolas() != null) evolucao.setCargasMolas(dto.cargasMolas());
+        if (dto.dorAntes() != null) evolucao.setDorAntes(dto.dorAntes());
+        if (dto.dorDepois() != null) evolucao.setDorDepois(dto.dorDepois());
+        if (dto.respostaPaciente() != null) evolucao.setRespostaPaciente(dto.respostaPaciente());
+        if (dto.intercorrencias() != null) evolucao.setIntercorrencias(dto.intercorrencias());
+        if (dto.orientacoes() != null) evolucao.setOrientacoes(dto.orientacoes());
+        if (dto.observacoesFisioterapeuta() != null) evolucao.setObservacoesFisioterapeuta(dto.observacoesFisioterapeuta());
+        evolucao.setDataAtualizacao(LocalDateTime.now());
+
+        return EvolucaoSessaoResponseDTO.from(evolucaoRepository.save(evolucao));
+    }
+
+    private EvolucaoSessao encontrar(Long id) {
+        return evolucaoRepository.findByIdComSessao(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Evolução não encontrada: " + id));
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/service/EvolucaoSessaoService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/EvolucaoSessaoService.java
@@ -58,9 +58,8 @@ public class EvolucaoSessaoService {
 
     @Transactional(readOnly = true)
     public EvolucaoSessaoResponseDTO buscarPorSessao(Long sessaoId) {
-        if (!sessaoRepository.existsById(sessaoId)) {
-            throw new ResourceNotFoundException("Sessão não encontrada: " + sessaoId);
-        }
+        sessaoRepository.findByIdComPaciente(sessaoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Sessão não encontrada: " + sessaoId));
         return evolucaoRepository.findBySessaoId(sessaoId)
                 .map(EvolucaoSessaoResponseDTO::from)
                 .orElseThrow(() -> new ResourceNotFoundException("Evolução não encontrada para a sessão: " + sessaoId));

--- a/src/main/java/com/carlesso/pilatesapi/service/SessaoPilatesService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/SessaoPilatesService.java
@@ -9,6 +9,7 @@ import com.carlesso.pilatesapi.entity.Profissional;
 import com.carlesso.pilatesapi.entity.SessaoPilates;
 import com.carlesso.pilatesapi.exception.BusinessException;
 import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
+import com.carlesso.pilatesapi.repository.EvolucaoSessaoRepository;
 import com.carlesso.pilatesapi.repository.PacienteRepository;
 import com.carlesso.pilatesapi.repository.PlanoTratamentoRepository;
 import com.carlesso.pilatesapi.repository.ProfissionalRepository;
@@ -26,15 +27,18 @@ public class SessaoPilatesService {
     private final PacienteRepository pacienteRepository;
     private final ProfissionalRepository profissionalRepository;
     private final PlanoTratamentoRepository planoTratamentoRepository;
+    private final EvolucaoSessaoRepository evolucaoSessaoRepository;
 
     public SessaoPilatesService(SessaoPilatesRepository sessaoRepository,
                                 PacienteRepository pacienteRepository,
                                 ProfissionalRepository profissionalRepository,
-                                PlanoTratamentoRepository planoTratamentoRepository) {
+                                PlanoTratamentoRepository planoTratamentoRepository,
+                                EvolucaoSessaoRepository evolucaoSessaoRepository) {
         this.sessaoRepository = sessaoRepository;
         this.pacienteRepository = pacienteRepository;
         this.profissionalRepository = profissionalRepository;
         this.planoTratamentoRepository = planoTratamentoRepository;
+        this.evolucaoSessaoRepository = evolucaoSessaoRepository;
     }
 
     @Transactional
@@ -98,7 +102,6 @@ public class SessaoPilatesService {
         if (dto.duracaoMinutos() != null) sessao.setDuracaoMinutos(dto.duracaoMinutos());
         if (dto.status() != null) sessao.setStatus(dto.status());
         if (dto.observacoes() != null) sessao.setObservacoes(dto.observacoes());
-        if (dto.evolucao() != null) sessao.setEvolucao(dto.evolucao());
         sessao.setDataAtualizacao(LocalDateTime.now());
 
         return SessaoPilatesResponseDTO.from(sessaoRepository.save(sessao));
@@ -107,6 +110,7 @@ public class SessaoPilatesService {
     @Transactional
     public void excluir(Long id) {
         SessaoPilates sessao = encontrar(id);
+        evolucaoSessaoRepository.deleteBySessaoId(id);
         sessaoRepository.delete(sessao);
     }
 

--- a/src/main/resources/db/migration/V18__create_evolucoes_sessao_table.sql
+++ b/src/main/resources/db/migration/V18__create_evolucoes_sessao_table.sql
@@ -1,0 +1,19 @@
+CREATE TABLE evolucoes_sessao (
+    id                          BIGSERIAL   PRIMARY KEY,
+    sessao_id                   BIGINT      NOT NULL UNIQUE REFERENCES sessoes_pilates(id),
+    data_hora_registro          TIMESTAMP   NOT NULL,
+    exercicios_realizados       TEXT,
+    equipamentos_utilizados     TEXT,
+    cargas_molas                TEXT,
+    dor_antes                   INTEGER     CHECK (dor_antes BETWEEN 0 AND 10),
+    dor_depois                  INTEGER     CHECK (dor_depois BETWEEN 0 AND 10),
+    resposta_paciente           TEXT,
+    intercorrencias             TEXT,
+    orientacoes                 TEXT,
+    observacoes_fisioterapeuta  TEXT,
+    data_criacao                TIMESTAMP   NOT NULL,
+    data_atualizacao            TIMESTAMP
+);
+
+CREATE INDEX idx_evolucoes_sessao_sessao_id
+    ON evolucoes_sessao(sessao_id);

--- a/src/main/resources/db/migration/V18__create_evolucoes_sessao_table.sql
+++ b/src/main/resources/db/migration/V18__create_evolucoes_sessao_table.sql
@@ -1,6 +1,6 @@
 CREATE TABLE evolucoes_sessao (
     id                          BIGSERIAL   PRIMARY KEY,
-    sessao_id                   BIGINT      NOT NULL UNIQUE REFERENCES sessoes_pilates(id),
+    sessao_id                   BIGINT      NOT NULL UNIQUE REFERENCES sessoes_pilates(id) ON DELETE CASCADE,
     data_hora_registro          TIMESTAMP   NOT NULL,
     exercicios_realizados       TEXT,
     equipamentos_utilizados     TEXT,
@@ -14,6 +14,3 @@ CREATE TABLE evolucoes_sessao (
     data_criacao                TIMESTAMP   NOT NULL,
     data_atualizacao            TIMESTAMP
 );
-
-CREATE INDEX idx_evolucoes_sessao_sessao_id
-    ON evolucoes_sessao(sessao_id);

--- a/src/test/java/com/carlesso/pilatesapi/controller/EvolucaoSessaoControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/EvolucaoSessaoControllerTest.java
@@ -1,0 +1,243 @@
+package com.carlesso.pilatesapi.controller;
+
+import com.carlesso.pilatesapi.dto.EvolucaoSessaoRequestDTO;
+import com.carlesso.pilatesapi.dto.EvolucaoSessaoResponseDTO;
+import com.carlesso.pilatesapi.dto.EvolucaoSessaoUpdateDTO;
+import com.carlesso.pilatesapi.exception.ConflictException;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
+import com.carlesso.pilatesapi.service.CustomUserDetailsService;
+import com.carlesso.pilatesapi.service.EvolucaoSessaoService;
+import com.carlesso.pilatesapi.service.JwtService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(EvolucaoSessaoController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class EvolucaoSessaoControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockitoBean
+    private EvolucaoSessaoService service;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    private EvolucaoSessaoResponseDTO responseDTO() {
+        return new EvolucaoSessaoResponseDTO(
+                1L,
+                1L,
+                LocalDateTime.of(2026, 5, 10, 10, 30),
+                "Reformer, Cadillac",
+                "Reformer",
+                null,
+                5,
+                2,
+                "Boa evolução",
+                null,
+                "Manter exercícios",
+                null,
+                LocalDateTime.of(2026, 5, 10, 10, 30),
+                null
+        );
+    }
+
+    private EvolucaoSessaoRequestDTO requestDTO() {
+        return new EvolucaoSessaoRequestDTO(
+                1L,
+                LocalDateTime.of(2026, 5, 10, 10, 30),
+                "Reformer, Cadillac",
+                "Reformer",
+                null,
+                5,
+                2,
+                "Boa evolução",
+                null,
+                "Manter exercícios",
+                null
+        );
+    }
+
+    @Test
+    void criar_comDadosValidos_deveRetornar201ComHeaderLocation() throws Exception {
+        when(service.criar(any())).thenReturn(responseDTO());
+
+        mvc.perform(post("/evolucoes-sessao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(requestDTO())))
+                .andExpect(status().isCreated())
+                .andExpect(header().exists("Location"))
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.sessaoId").value(1))
+                .andExpect(jsonPath("$.dorAntes").value(5))
+                .andExpect(jsonPath("$.dorDepois").value(2))
+                .andExpect(jsonPath("$.respostaPaciente").value("Boa evolução"));
+    }
+
+    @Test
+    void criar_semSessaoId_deveRetornar400() throws Exception {
+        var dto = new EvolucaoSessaoRequestDTO(null, LocalDateTime.now(), null, null, null, null, null, null, null, null, null);
+
+        mvc.perform(post("/evolucoes-sessao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void criar_semDataHoraRegistro_deveRetornar400() throws Exception {
+        var dto = new EvolucaoSessaoRequestDTO(1L, null, null, null, null, null, null, null, null, null, null);
+
+        mvc.perform(post("/evolucoes-sessao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void criar_comDorForaDaEscala_deveRetornar400() throws Exception {
+        var dto = new EvolucaoSessaoRequestDTO(1L, LocalDateTime.now(), null, null, null, 11, null, null, null, null, null);
+
+        mvc.perform(post("/evolucoes-sessao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void criar_comSessaoInexistente_deveRetornar404() throws Exception {
+        when(service.criar(any())).thenThrow(new ResourceNotFoundException("Sessão não encontrada: 99"));
+
+        mvc.perform(post("/evolucoes-sessao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(requestDTO())))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.erro").value("Sessão não encontrada: 99"));
+    }
+
+    @Test
+    void criar_comSessaoJaComEvolucao_deveRetornar409() throws Exception {
+        when(service.criar(any())).thenThrow(new ConflictException("Sessão já possui evolução registrada: 1"));
+
+        mvc.perform(post("/evolucoes-sessao")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(requestDTO())))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.erro").value("Sessão já possui evolução registrada: 1"));
+    }
+
+    @Test
+    void buscarPorId_quandoExistente_deveRetornar200() throws Exception {
+        when(service.buscarPorId(1L)).thenReturn(responseDTO());
+
+        mvc.perform(get("/evolucoes-sessao/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.exerciciosRealizados").value("Reformer, Cadillac"));
+    }
+
+    @Test
+    void buscarPorId_quandoNaoExistente_deveRetornar404() throws Exception {
+        when(service.buscarPorId(99L)).thenThrow(new ResourceNotFoundException("Evolução não encontrada: 99"));
+
+        mvc.perform(get("/evolucoes-sessao/99"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.erro").value("Evolução não encontrada: 99"));
+    }
+
+    @Test
+    void buscarPorSessao_quandoExistente_deveRetornar200() throws Exception {
+        when(service.buscarPorSessao(1L)).thenReturn(responseDTO());
+
+        mvc.perform(get("/evolucoes-sessao/sessao/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sessaoId").value(1))
+                .andExpect(jsonPath("$.dorAntes").value(5));
+    }
+
+    @Test
+    void buscarPorSessao_comSessaoSemEvolucao_deveRetornar404() throws Exception {
+        when(service.buscarPorSessao(99L))
+                .thenThrow(new ResourceNotFoundException("Evolução não encontrada para a sessão: 99"));
+
+        mvc.perform(get("/evolucoes-sessao/sessao/99"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.erro").value("Evolução não encontrada para a sessão: 99"));
+    }
+
+    @Test
+    void atualizar_deveRetornar200ComDadosAtualizados() throws Exception {
+        var updated = new EvolucaoSessaoResponseDTO(
+                1L, 1L,
+                LocalDateTime.of(2026, 5, 10, 10, 30),
+                "Reformer, Chair",
+                "Reformer",
+                "Mola 3",
+                3,
+                1,
+                "Melhorou muito",
+                null,
+                "Manter exercícios",
+                null,
+                LocalDateTime.of(2026, 5, 10, 10, 30),
+                LocalDateTime.of(2026, 5, 10, 11, 0)
+        );
+        when(service.atualizar(eq(1L), any())).thenReturn(updated);
+
+        var dto = new EvolucaoSessaoUpdateDTO(null, "Reformer, Chair", null, "Mola 3", 3, 1, "Melhorou muito", null, null, null);
+
+        mvc.perform(put("/evolucoes-sessao/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.exerciciosRealizados").value("Reformer, Chair"))
+                .andExpect(jsonPath("$.cargasMolas").value("Mola 3"))
+                .andExpect(jsonPath("$.dorAntes").value(3))
+                .andExpect(jsonPath("$.dataAtualizacao").isNotEmpty());
+    }
+
+    @Test
+    void atualizar_comDorForaDaEscala_deveRetornar400() throws Exception {
+        var dto = new EvolucaoSessaoUpdateDTO(null, null, null, null, -1, null, null, null, null, null);
+
+        mvc.perform(put("/evolucoes-sessao/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void atualizar_comEvolucaoInexistente_deveRetornar404() throws Exception {
+        when(service.atualizar(eq(99L), any()))
+                .thenThrow(new ResourceNotFoundException("Evolução não encontrada: 99"));
+
+        var dto = new EvolucaoSessaoUpdateDTO(null, "Novo exercício", null, null, null, null, null, null, null, null);
+
+        mvc.perform(put("/evolucoes-sessao/99")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.erro").value("Evolução não encontrada: 99"));
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/controller/SessaoPilatesControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/SessaoPilatesControllerTest.java
@@ -59,7 +59,6 @@ class SessaoPilatesControllerTest {
                 "Sala 1",
                 50,
                 "Observação teste",
-                null,
                 LocalDateTime.of(2026, 5, 4, 10, 0),
                 null
         );
@@ -210,7 +209,6 @@ class SessaoPilatesControllerTest {
                 "Sala 1",
                 60,
                 "Observação teste",
-                "Paciente evoluiu bem",
                 LocalDateTime.of(2026, 5, 4, 10, 0),
                 LocalDateTime.of(2026, 5, 15, 10, 0)
         );
@@ -221,8 +219,7 @@ class SessaoPilatesControllerTest {
                 LocalTime.of(10, 0),
                 null, 60,
                 StatusSessao.REALIZADA,
-                null,
-                "Paciente evoluiu bem"
+                null
         );
 
         mvc.perform(put("/sessoes/1")
@@ -231,13 +228,12 @@ class SessaoPilatesControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").value("2026-05-15"))
                 .andExpect(jsonPath("$.status").value("REALIZADA"))
-                .andExpect(jsonPath("$.evolucao").value("Paciente evoluiu bem"))
                 .andExpect(jsonPath("$.dataAtualizacao").isNotEmpty());
     }
 
     @Test
     void atualizar_comDuracaoNegativa_deveRetornar400() throws Exception {
-        var dto = new SessaoPilatesUpdateDTO(null, null, null, -5, null, null, null);
+        var dto = new SessaoPilatesUpdateDTO(null, null, null, -5, null, null);
 
         mvc.perform(put("/sessoes/1")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -250,7 +246,7 @@ class SessaoPilatesControllerTest {
         when(service.atualizar(eq(99L), any()))
                 .thenThrow(new ResourceNotFoundException("Sessão não encontrada: 99"));
 
-        var dto = new SessaoPilatesUpdateDTO(LocalDate.of(2026, 5, 20), null, null, null, null, null, null);
+        var dto = new SessaoPilatesUpdateDTO(LocalDate.of(2026, 5, 20), null, null, null, null, null);
 
         mvc.perform(put("/sessoes/99")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/carlesso/pilatesapi/service/EvolucaoSessaoServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/EvolucaoSessaoServiceTest.java
@@ -164,7 +164,7 @@ class EvolucaoSessaoServiceTest {
     @Test
     void buscarPorSessao_quandoExistente_deveRetornarResponseDTO() {
         SessaoPilates s = sessao(paciente());
-        when(sessaoRepository.existsById(1L)).thenReturn(true);
+        when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));
         when(evolucaoRepository.findBySessaoId(1L)).thenReturn(Optional.of(evolucao(s)));
 
         EvolucaoSessaoResponseDTO response = service.buscarPorSessao(1L);
@@ -175,7 +175,7 @@ class EvolucaoSessaoServiceTest {
 
     @Test
     void buscarPorSessao_comSessaoInexistente_deveLancarResourceNotFoundException() {
-        when(sessaoRepository.existsById(99L)).thenReturn(false);
+        when(sessaoRepository.findByIdComPaciente(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.buscarPorSessao(99L))
                 .isInstanceOf(ResourceNotFoundException.class)
@@ -184,7 +184,7 @@ class EvolucaoSessaoServiceTest {
 
     @Test
     void buscarPorSessao_semEvolucao_deveLancarResourceNotFoundException() {
-        when(sessaoRepository.existsById(1L)).thenReturn(true);
+        when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(sessao(paciente())));
         when(evolucaoRepository.findBySessaoId(1L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.buscarPorSessao(1L))

--- a/src/test/java/com/carlesso/pilatesapi/service/EvolucaoSessaoServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/EvolucaoSessaoServiceTest.java
@@ -1,0 +1,235 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.EvolucaoSessaoRequestDTO;
+import com.carlesso.pilatesapi.dto.EvolucaoSessaoResponseDTO;
+import com.carlesso.pilatesapi.dto.EvolucaoSessaoUpdateDTO;
+import com.carlesso.pilatesapi.entity.EvolucaoSessao;
+import com.carlesso.pilatesapi.entity.Paciente;
+import com.carlesso.pilatesapi.entity.SessaoPilates;
+import com.carlesso.pilatesapi.entity.enums.StatusSessao;
+import com.carlesso.pilatesapi.entity.enums.TipoSessao;
+import com.carlesso.pilatesapi.exception.ConflictException;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
+import com.carlesso.pilatesapi.repository.EvolucaoSessaoRepository;
+import com.carlesso.pilatesapi.repository.SessaoPilatesRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EvolucaoSessaoServiceTest {
+
+    @Mock
+    private EvolucaoSessaoRepository evolucaoRepository;
+
+    @Mock
+    private SessaoPilatesRepository sessaoRepository;
+
+    @InjectMocks
+    private EvolucaoSessaoService service;
+
+    private Paciente paciente() {
+        Paciente p = new Paciente();
+        p.setNome("Ana Oliveira");
+        p.setEmail("ana@email.com");
+        p.setCpf("12345678900");
+        setId(p, Paciente.class, 1L);
+        return p;
+    }
+
+    private SessaoPilates sessao(Paciente paciente) {
+        SessaoPilates s = new SessaoPilates();
+        s.setPaciente(paciente);
+        s.setTipo(TipoSessao.PILATES);
+        s.setStatus(StatusSessao.REALIZADA);
+        s.setData(LocalDate.of(2026, 5, 10));
+        s.setDataCriacao(LocalDateTime.of(2026, 5, 4, 10, 0));
+        setId(s, SessaoPilates.class, 1L);
+        return s;
+    }
+
+    private EvolucaoSessao evolucao(SessaoPilates sessao) {
+        EvolucaoSessao e = new EvolucaoSessao();
+        e.setSessao(sessao);
+        e.setDataHoraRegistro(LocalDateTime.of(2026, 5, 10, 10, 30));
+        e.setExerciciosRealizados("Reformer, Cadillac");
+        e.setEquipamentosUtilizados("Reformer");
+        e.setDorAntes(5);
+        e.setDorDepois(2);
+        e.setRespostaPaciente("Boa evolução");
+        e.setDataCriacao(LocalDateTime.of(2026, 5, 10, 10, 30));
+        setId(e, EvolucaoSessao.class, 1L);
+        return e;
+    }
+
+    private EvolucaoSessaoRequestDTO requestDTO() {
+        return new EvolucaoSessaoRequestDTO(
+                1L,
+                LocalDateTime.of(2026, 5, 10, 10, 30),
+                "Reformer, Cadillac",
+                "Reformer",
+                null,
+                5,
+                2,
+                "Boa evolução",
+                null,
+                "Manter exercícios",
+                null
+        );
+    }
+
+    private <T> void setId(T obj, Class<T> clazz, Long id) {
+        try {
+            var field = clazz.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(obj, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void criar_comSessaoValida_deveRetornarResponseDTO() {
+        Paciente p = paciente();
+        SessaoPilates s = sessao(p);
+        when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));
+        when(evolucaoRepository.existsBySessaoId(1L)).thenReturn(false);
+        when(evolucaoRepository.save(any(EvolucaoSessao.class))).thenReturn(evolucao(s));
+
+        EvolucaoSessaoResponseDTO response = service.criar(requestDTO());
+
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.sessaoId()).isEqualTo(1L);
+        assertThat(response.dorAntes()).isEqualTo(5);
+        assertThat(response.dorDepois()).isEqualTo(2);
+        assertThat(response.respostaPaciente()).isEqualTo("Boa evolução");
+        verify(evolucaoRepository).save(any(EvolucaoSessao.class));
+    }
+
+    @Test
+    void criar_comSessaoInexistente_deveLancarResourceNotFoundException() {
+        when(sessaoRepository.findByIdComPaciente(99L)).thenReturn(Optional.empty());
+
+        var dto = new EvolucaoSessaoRequestDTO(99L, LocalDateTime.now(), null, null, null, null, null, null, null, null, null);
+
+        assertThatThrownBy(() -> service.criar(dto))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    void criar_comSessaoJaComEvolucao_deveLancarConflictException() {
+        Paciente p = paciente();
+        SessaoPilates s = sessao(p);
+        when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));
+        when(evolucaoRepository.existsBySessaoId(1L)).thenReturn(true);
+
+        assertThatThrownBy(() -> service.criar(requestDTO()))
+                .isInstanceOf(ConflictException.class)
+                .hasMessageContaining("já possui evolução");
+    }
+
+    @Test
+    void buscarPorId_quandoExistente_deveRetornarResponseDTO() {
+        SessaoPilates s = sessao(paciente());
+        when(evolucaoRepository.findByIdComSessao(1L)).thenReturn(Optional.of(evolucao(s)));
+
+        EvolucaoSessaoResponseDTO response = service.buscarPorId(1L);
+
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.exerciciosRealizados()).isEqualTo("Reformer, Cadillac");
+    }
+
+    @Test
+    void buscarPorId_quandoNaoExistente_deveLancarResourceNotFoundException() {
+        when(evolucaoRepository.findByIdComSessao(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.buscarPorId(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    void buscarPorSessao_quandoExistente_deveRetornarResponseDTO() {
+        SessaoPilates s = sessao(paciente());
+        when(sessaoRepository.existsById(1L)).thenReturn(true);
+        when(evolucaoRepository.findBySessaoId(1L)).thenReturn(Optional.of(evolucao(s)));
+
+        EvolucaoSessaoResponseDTO response = service.buscarPorSessao(1L);
+
+        assertThat(response.sessaoId()).isEqualTo(1L);
+        assertThat(response.dorAntes()).isEqualTo(5);
+    }
+
+    @Test
+    void buscarPorSessao_comSessaoInexistente_deveLancarResourceNotFoundException() {
+        when(sessaoRepository.existsById(99L)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.buscarPorSessao(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    void buscarPorSessao_semEvolucao_deveLancarResourceNotFoundException() {
+        when(sessaoRepository.existsById(1L)).thenReturn(true);
+        when(evolucaoRepository.findBySessaoId(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.buscarPorSessao(1L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Evolução não encontrada para a sessão");
+    }
+
+    @Test
+    void atualizar_deveAtualizarApenasOsCamposInformados() {
+        SessaoPilates s = sessao(paciente());
+        EvolucaoSessao e = evolucao(s);
+        when(evolucaoRepository.findByIdComSessao(1L)).thenReturn(Optional.of(e));
+        when(evolucaoRepository.save(e)).thenReturn(e);
+
+        var dto = new EvolucaoSessaoUpdateDTO(
+                null,
+                "Reformer, Chair",
+                null,
+                "Mola 3",
+                3,
+                1,
+                "Melhorou muito",
+                null,
+                null,
+                null
+        );
+
+        EvolucaoSessaoResponseDTO response = service.atualizar(1L, dto);
+
+        assertThat(response.exerciciosRealizados()).isEqualTo("Reformer, Chair");
+        assertThat(response.cargasMolas()).isEqualTo("Mola 3");
+        assertThat(response.dorAntes()).isEqualTo(3);
+        assertThat(response.dorDepois()).isEqualTo(1);
+        assertThat(response.respostaPaciente()).isEqualTo("Melhorou muito");
+        assertThat(response.dataAtualizacao()).isNotNull();
+    }
+
+    @Test
+    void atualizar_comEvolucaoInexistente_deveLancarResourceNotFoundException() {
+        when(evolucaoRepository.findByIdComSessao(99L)).thenReturn(Optional.empty());
+
+        var dto = new EvolucaoSessaoUpdateDTO(null, null, null, null, null, null, null, null, null, null);
+
+        assertThatThrownBy(() -> service.atualizar(99L, dto))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/service/SessaoPilatesServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/SessaoPilatesServiceTest.java
@@ -11,6 +11,7 @@ import com.carlesso.pilatesapi.entity.enums.StatusSessao;
 import com.carlesso.pilatesapi.entity.enums.TipoSessao;
 import com.carlesso.pilatesapi.exception.BusinessException;
 import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
+import com.carlesso.pilatesapi.repository.EvolucaoSessaoRepository;
 import com.carlesso.pilatesapi.repository.PacienteRepository;
 import com.carlesso.pilatesapi.repository.PlanoTratamentoRepository;
 import com.carlesso.pilatesapi.repository.ProfissionalRepository;
@@ -47,6 +48,9 @@ class SessaoPilatesServiceTest {
 
     @Mock
     private PlanoTratamentoRepository planoTratamentoRepository;
+
+    @Mock
+    private EvolucaoSessaoRepository evolucaoSessaoRepository;
 
     @InjectMocks
     private SessaoPilatesService service;
@@ -300,8 +304,7 @@ class SessaoPilatesServiceTest {
                 null,
                 60,
                 StatusSessao.REALIZADA,
-                null,
-                "Paciente evoluiu bem"
+                null
         );
 
         SessaoPilatesResponseDTO response = service.atualizar(1L, dto);
@@ -311,7 +314,6 @@ class SessaoPilatesServiceTest {
         assertThat(response.local()).isEqualTo("Sala 1");
         assertThat(response.duracaoMinutos()).isEqualTo(60);
         assertThat(response.status()).isEqualTo(StatusSessao.REALIZADA);
-        assertThat(response.evolucao()).isEqualTo("Paciente evoluiu bem");
         assertThat(response.dataAtualizacao()).isNotNull();
     }
 
@@ -319,7 +321,7 @@ class SessaoPilatesServiceTest {
     void atualizar_comSessaoInexistente_deveLancarResourceNotFoundException() {
         when(sessaoRepository.findByIdComPaciente(99L)).thenReturn(Optional.empty());
 
-        var dto = new SessaoPilatesUpdateDTO(null, null, null, null, null, null, null);
+        var dto = new SessaoPilatesUpdateDTO(null, null, null, null, null, null);
 
         assertThatThrownBy(() -> service.atualizar(99L, dto))
                 .isInstanceOf(ResourceNotFoundException.class)
@@ -333,6 +335,7 @@ class SessaoPilatesServiceTest {
 
         service.excluir(1L);
 
+        verify(evolucaoSessaoRepository).deleteBySessaoId(1L);
         verify(sessaoRepository).delete(s);
     }
 


### PR DESCRIPTION
## Resumo

Implementação completa do módulo de Evolução da Sessão vinculado ao prontuário do paciente, conforme escopo da issue #53.

- Nova entidade `EvolucaoSessao` com relacionamento `@OneToOne` para `SessaoPilates` (uma evolução por sessão)
- Endpoints REST em `/evolucoes-sessao` para criar, buscar por ID, buscar por sessão e atualizar
- Regras de negócio: sessão deve existir (404) e unicidade por sessão (409 em duplicidade)
- Escala de dor (`dorAntes` / `dorDepois`) validada com `@Min(0) @Max(10)` e `CHECK` no banco
- Migração Flyway `V18` criando a tabela `evolucoes_sessao` com constraint `UNIQUE sessao_id`

## Motivo da mudança

O prontuário precisava armazenar a evolução clínica do atendimento (exercícios realizados, equipamentos, cargas, dor antes/depois, resposta do paciente, intercorrências, orientações e observações do fisioterapeuta), conforme levantamento da issue #53.

## Testes executados

```
mvn test
Tests run: 349, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Novos testes adicionados:
- `EvolucaoSessaoServiceTest` — 8 casos unitários (Mockito)
- `EvolucaoSessaoControllerTest` — 13 casos via `@WebMvcTest` + MockMvc

## Arquivos principais alterados

| Arquivo | Tipo |
|---|---|
| `V18__create_evolucoes_sessao_table.sql` | Migração Flyway |
| `EvolucaoSessao.java` | Entidade JPA |
| `EvolucaoSessaoRequestDTO.java` / `EvolucaoSessaoUpdateDTO.java` / `EvolucaoSessaoResponseDTO.java` | DTOs |
| `EvolucaoSessaoRepository.java` | Repository |
| `EvolucaoSessaoService.java` | Service |
| `EvolucaoSessaoController.java` | Controller REST |
| `EvolucaoSessaoServiceTest.java` | Testes unitários |
| `EvolucaoSessaoControllerTest.java` | Testes de controller |
| `README.md` / `docs/context.md` | Documentação |

## Referência

Closes #53

https://claude.ai/code/session_01AwuWq49kjMPi4H7FxoyNZp

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwuWq49kjMPi4H7FxoyNZp)_