### PR TITLE
feat: impedir inativação e rebaixamento do último administrador ativo

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,8 @@ Base URL: `http://localhost:8080`
 | `POST` | `/users` | `ADMIN` | Cria usuário com role `USER` ou `ADMIN` |
 | `GET` | `/users` | `ADMIN` | Lista usuários cadastrados sem expor senha |
 | `GET` | `/users/{id}` | `ADMIN` | Busca usuário por ID |
-| `PUT` | `/users/{id}` | `ADMIN` | Atualiza nome, e-mail, senha e perfil. Admin não pode alterar o próprio role |
-| `DELETE` | `/users/{id}` | `ADMIN` | Remove usuário. Admin não pode excluir a própria conta |
+| `PUT` | `/users/{id}` | `ADMIN` | Atualiza nome, e-mail, senha e perfil. Admin não pode alterar o próprio role nem rebaixar o último ADMIN ativo |
+| `DELETE` | `/users/{id}` | `ADMIN` | Inativa usuário (soft delete). Admin não pode inativar a própria conta nem o último ADMIN ativo |
 | `GET` | `/admin/health` | `ADMIN` | Endpoint inicial administrativo |
 
 As demais rotas de negócio exigem `Authorization: Bearer <accessToken>`. Tokens ausentes, inválidos ou expirados retornam `401 Unauthorized`; usuário sem role `ADMIN` em `/admin/**` e no CRUD de `/users` recebe `403 Forbidden`.

--- a/docs/context.md
+++ b/docs/context.md
@@ -418,7 +418,7 @@ Relacionamento `@ManyToOne` obrigatório com `Paciente` e relacionamentos opcion
 | POST | `/users` | Criar usuário com role `USER` ou `ADMIN` | 201 / 400 / 401 / 403 / 409 |
 | GET | `/users` | Listar usuários paginados sem expor senha | 200 / 401 / 403 |
 | GET | `/users/{id}` | Buscar usuário por ID | 200 / 401 / 403 / 404 |
-| PUT | `/users/{id}` | Atualizar nome, e-mail, senha e perfil de acesso | 200 / 400 / 401 / 403 / 404 / 409 |
+| PUT | `/users/{id}` | Atualizar nome, e-mail, senha e perfil de acesso | 200 / 400 / 401 / 403 / 404 / 409 / 422 |
 | DELETE | `/users/{id}` | Inativar usuário (soft delete) | 204 / 401 / 403 / 404 / 422 |
 | GET | `/admin/health` | Health administrativo | 200 / 401 / 403 |
 | POST | `/pacientes` | Cadastrar paciente | 201 + Location header |
@@ -496,6 +496,7 @@ CPF não pode ser alterado após o cadastro.
 - JWT inclui claims `role` e `userId`; a cada requisição o filtro valida se o usuário ainda existe e está ativo antes de reconstruir o contexto de segurança
 - Rate limiting de `/auth/login`: 5 tentativas falhas por e-mail em janela de 15 minutos retorna `429 Too Many Requests`
 - Admin não pode inativar a própria conta nem alterar o próprio perfil de acesso (`422 Unprocessable Entity`)
+- O sistema deve manter ao menos um usuário `ADMIN` ativo: não é permitido inativar nem rebaixar para `USER` o último administrador ativo (`422 Unprocessable Entity`)
 - Usuários com `ativo=false` não conseguem fazer login e tokens emitidos antes da inativação deixam de autorizar rotas protegidas
 - CORS permite o frontend Angular configurado em `CORS_ALLOWED_ORIGINS` (padrão `http://localhost:4200`)
 - Token ausente, inválido ou expirado em rota protegida retorna `401`; usuário sem `ADMIN` em `/admin/**` retorna `403`

--- a/docs/documentacao.md
+++ b/docs/documentacao.md
@@ -234,6 +234,7 @@ src/
 - JWT inclui claims `role` e `userId`; a cada requisição o filtro valida se o usuário ainda existe e está ativo antes de reconstruir o contexto de segurança
 - Rate limiting de `/auth/login`: 5 tentativas falhas por e-mail em janela de 15 minutos retorna `429 Too Many Requests`; login bem-sucedido redefine o contador
 - Admin não pode inativar a própria conta nem alterar o próprio perfil de acesso (`422 Unprocessable Entity`)
+- O sistema deve manter ao menos um usuário `ADMIN` ativo: não é permitido inativar nem rebaixar para `USER` o último administrador ativo (`422 Unprocessable Entity`)
 - Usuários com `ativo=false` não conseguem fazer login e tokens emitidos antes da inativação deixam de autorizar rotas protegidas
 - CORS permite integração com Angular pela variável `CORS_ALLOWED_ORIGINS`
 
@@ -491,8 +492,8 @@ Tabela: `planos_tratamento`
 | `POST` | `/users` | `ADMIN` | Cria usuário com role `USER` ou `ADMIN` |
 | `GET` | `/users` | `ADMIN` | Lista usuários cadastrados sem expor senha |
 | `GET` | `/users/{id}` | `ADMIN` | Busca usuário por ID |
-| `PUT` | `/users/{id}` | `ADMIN` | Atualiza nome, e-mail, senha e perfil de acesso |
-| `DELETE` | `/users/{id}` | `ADMIN` | Inativa usuário (soft delete) |
+| `PUT` | `/users/{id}` | `ADMIN` | Atualiza nome, e-mail, senha e perfil de acesso; retorna `422` ao tentar rebaixar o último `ADMIN` ativo |
+| `DELETE` | `/users/{id}` | `ADMIN` | Inativa usuário (soft delete); retorna `422` ao tentar inativar a própria conta ou o último `ADMIN` ativo |
 | `GET` | `/admin/health` | `ADMIN` | Endpoint administrativo inicial |
 
 Fluxo esperado: o frontend faz login ou registro, recebe `accessToken` e envia `Authorization: Bearer <token>` nas chamadas protegidas.

--- a/src/main/java/com/carlesso/pilatesapi/controller/UserController.java
+++ b/src/main/java/com/carlesso/pilatesapi/controller/UserController.java
@@ -83,7 +83,7 @@ public class UserController {
 
     @Operation(
             summary = "Atualizar usuário",
-            description = "Requer role ADMIN. Atualiza nome, e-mail, senha e perfil de acesso USER ou ADMIN. Admin não pode alterar o próprio role."
+            description = "Requer role ADMIN. Atualiza nome, e-mail, senha e perfil de acesso USER ou ADMIN. Admin não pode alterar o próprio role nem rebaixar o último administrador ativo."
     )
     @PutMapping("/{id}")
     public ResponseEntity<UserResponseDTO> atualizar(
@@ -95,7 +95,7 @@ public class UserController {
 
     @Operation(
             summary = "Inativar usuário",
-            description = "Requer role ADMIN. Inativa (soft delete) um usuário cadastrado. Admin não pode inativar a própria conta."
+            description = "Requer role ADMIN. Inativa (soft delete) um usuário cadastrado. Admin não pode inativar a própria conta nem o último administrador ativo."
     )
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> inativar(

--- a/src/main/java/com/carlesso/pilatesapi/repository/UserRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.carlesso.pilatesapi.repository;
 
 import com.carlesso.pilatesapi.entity.User;
+import com.carlesso.pilatesapi.entity.enums.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -12,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     boolean existsByEmailAndIdNot(String email, Long id);
+
+    long countByRoleAndAtivoTrue(Role role);
 }

--- a/src/main/java/com/carlesso/pilatesapi/repository/UserRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/UserRepository.java
@@ -2,8 +2,13 @@ package com.carlesso.pilatesapi.repository;
 
 import com.carlesso.pilatesapi.entity.User;
 import com.carlesso.pilatesapi.entity.enums.Role;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -15,4 +20,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmailAndIdNot(String email, Long id);
 
     long countByRoleAndAtivoTrue(Role role);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select u from User u where u.role = :role and u.ativo = true")
+    List<User> findActiveByRoleForUpdate(@Param("role") Role role);
 }

--- a/src/main/java/com/carlesso/pilatesapi/service/UserService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/UserService.java
@@ -4,6 +4,7 @@ import com.carlesso.pilatesapi.dto.UserRequestDTO;
 import com.carlesso.pilatesapi.dto.UserResponseDTO;
 import com.carlesso.pilatesapi.dto.UserUpdateDTO;
 import com.carlesso.pilatesapi.entity.User;
+import com.carlesso.pilatesapi.entity.enums.Role;
 import com.carlesso.pilatesapi.exception.BusinessException;
 import com.carlesso.pilatesapi.exception.ConflictException;
 import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
@@ -69,6 +70,12 @@ public class UserService {
             throw new BusinessException("Não é possível alterar o próprio perfil de acesso");
         }
 
+        if (dto.role() != null && !dto.role().equals(user.getRole())
+                && user.getRole() == Role.ADMIN && dto.role() != Role.ADMIN
+                && repository.countByRoleAndAtivoTrue(Role.ADMIN) <= 1) {
+            throw new BusinessException("Não é possível rebaixar o último administrador ativo");
+        }
+
         if (dto.email() != null) {
             String email = normalizarEmail(dto.email());
             if (repository.existsByEmailAndIdNot(email, id)) {
@@ -88,6 +95,9 @@ public class UserService {
         User user = encontrar(id);
         if (user.getEmail().equals(currentEmail)) {
             throw new BusinessException("Não é possível inativar a própria conta");
+        }
+        if (user.getRole() == Role.ADMIN && repository.countByRoleAndAtivoTrue(Role.ADMIN) <= 1) {
+            throw new BusinessException("Não é possível inativar o último administrador ativo");
         }
         user.setAtivo(false);
         repository.save(user);

--- a/src/main/java/com/carlesso/pilatesapi/service/UserService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/UserService.java
@@ -70,10 +70,8 @@ public class UserService {
             throw new BusinessException("Não é possível alterar o próprio perfil de acesso");
         }
 
-        if (dto.role() != null && !dto.role().equals(user.getRole())
-                && user.getRole() == Role.ADMIN && dto.role() != Role.ADMIN
-                && repository.countByRoleAndAtivoTrue(Role.ADMIN) <= 1) {
-            throw new BusinessException("Não é possível rebaixar o último administrador ativo");
+        if (dto.role() != null && !dto.role().equals(user.getRole()) && dto.role() != Role.ADMIN) {
+            validarRemocaoDeAdminAtivo(user, "Não é possível rebaixar o último administrador ativo");
         }
 
         if (dto.email() != null) {
@@ -96,11 +94,16 @@ public class UserService {
         if (user.getEmail().equals(currentEmail)) {
             throw new BusinessException("Não é possível inativar a própria conta");
         }
-        if (user.getRole() == Role.ADMIN && repository.countByRoleAndAtivoTrue(Role.ADMIN) <= 1) {
-            throw new BusinessException("Não é possível inativar o último administrador ativo");
-        }
+        validarRemocaoDeAdminAtivo(user, "Não é possível inativar o último administrador ativo");
         user.setAtivo(false);
         repository.save(user);
+    }
+
+    private void validarRemocaoDeAdminAtivo(User user, String mensagem) {
+        if (user.isAtivo() && user.getRole() == Role.ADMIN
+                && repository.findActiveByRoleForUpdate(Role.ADMIN).size() <= 1) {
+            throw new BusinessException(mensagem);
+        }
     }
 
     private User encontrar(Long id) {

--- a/src/test/java/com/carlesso/pilatesapi/controller/UserControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/UserControllerTest.java
@@ -189,4 +189,29 @@ class UserControllerTest {
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.erro").value("Usuário não encontrado: 99"));
     }
+
+    @Test
+    void inativar_ultimoAdmin_deveRetornar422() throws Exception {
+        doThrow(new BusinessException("Não é possível inativar o último administrador ativo"))
+                .when(service).inativar(eq(2L), anyString());
+
+        mvc.perform(delete("/users/2")
+                        .principal(adminAuth()))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.erro").value("Não é possível inativar o último administrador ativo"));
+    }
+
+    @Test
+    void atualizar_rebaixandoUltimoAdmin_deveRetornar422() throws Exception {
+        var dto = new UserUpdateDTO(null, null, null, Role.USER);
+        when(service.atualizar(eq(2L), any(), anyString()))
+                .thenThrow(new BusinessException("Não é possível rebaixar o último administrador ativo"));
+
+        mvc.perform(put("/users/2")
+                        .principal(adminAuth())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.erro").value("Não é possível rebaixar o último administrador ativo"));
+    }
 }

--- a/src/test/java/com/carlesso/pilatesapi/security/SecurityIntegrationTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/security/SecurityIntegrationTest.java
@@ -297,6 +297,21 @@ class SecurityIntegrationTest {
     }
 
     @Test
+    void usersAtualizar_rebaixandoAdminInativo_devePermitir() throws Exception {
+        User admin = criarUsuario("admin@email.com", Role.ADMIN);
+        User adminInativo = criarUsuario("admin-inativo@email.com", Role.ADMIN, false);
+        var request = new UserUpdateDTO(null, null, null, Role.USER);
+
+        mvc.perform(put("/users/{id}", adminInativo.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearer(admin))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.role").value("USER"))
+                .andExpect(jsonPath("$.ativo").value(false));
+    }
+
+    @Test
     void usersAtualizar_nomeVazio_deveRetornar400() throws Exception {
         User admin = criarUsuario("admin@email.com", Role.ADMIN);
         User user = criarUsuario("user@email.com", Role.USER);

--- a/src/test/java/com/carlesso/pilatesapi/service/UserServiceConcurrencyIntegrationTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/UserServiceConcurrencyIntegrationTest.java
@@ -1,0 +1,107 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.entity.User;
+import com.carlesso.pilatesapi.entity.enums.Role;
+import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class UserServiceConcurrencyIntegrationTest {
+
+    @Autowired
+    private UserRepository repository;
+
+    @Autowired
+    private UserService service;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        repository.deleteAll();
+    }
+
+    @Test
+    void inativarAdminsConcorrentes_deveManterUmAdminAtivo() throws Exception {
+        User admin1 = repository.save(usuario("admin1@email.com"));
+        User admin2 = repository.save(usuario("admin2@email.com"));
+
+        CountDownLatch largada = new CountDownLatch(1);
+
+        Callable<Throwable> inativarAdmin1 = () -> executarCapturandoErro(
+                () -> {
+                    aguardarLargada(largada);
+                    service.inativar(admin1.getId(), "operador@email.com");
+                });
+        Callable<Throwable> inativarAdmin2 = () -> executarCapturandoErro(
+                () -> {
+                    aguardarLargada(largada);
+                    service.inativar(admin2.getId(), "operador@email.com");
+                });
+
+        try (var executor = Executors.newFixedThreadPool(2)) {
+            var resultado1 = executor.submit(inativarAdmin1);
+            var resultado2 = executor.submit(inativarAdmin2);
+            largada.countDown();
+
+            List<Throwable> erros = List.of(resultado1, resultado2)
+                    .stream()
+                    .map(future -> {
+                        try {
+                            return future.get();
+                        } catch (Exception e) {
+                            return e;
+                        }
+                    })
+                    .toList();
+
+            assertThat(erros).anyMatch(erro -> erro == null);
+            assertThat(erros).anyMatch(erro -> erro instanceof BusinessException
+                    && erro.getMessage().equals("Não é possível inativar o último administrador ativo"));
+        }
+
+        assertThat(repository.countByRoleAndAtivoTrue(Role.ADMIN)).isEqualTo(1);
+    }
+
+    private Throwable executarCapturandoErro(Runnable runnable) {
+        try {
+            runnable.run();
+            return null;
+        } catch (Throwable erro) {
+            return erro;
+        }
+    }
+
+    private void aguardarLargada(CountDownLatch largada) {
+        try {
+            assertThat(largada.await(5, TimeUnit.SECONDS)).isTrue();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private User usuario(String email) {
+        User user = new User();
+        user.setName("Admin Teste");
+        user.setEmail(email);
+        user.setPassword(passwordEncoder.encode("senha1234"));
+        user.setRole(Role.ADMIN);
+        user.setAtivo(true);
+        return user;
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/service/UserServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/UserServiceTest.java
@@ -185,4 +185,59 @@ class UserServiceTest {
         verify(repository).save(captor.capture());
         assertThat(captor.getValue().isAtivo()).isFalse();
     }
+
+    @Test
+    void inativar_ultimoAdmin_deveLancarBusinessException() {
+        User admin = usuario(2L, "admin2@email.com", Role.ADMIN);
+        when(repository.findById(2L)).thenReturn(Optional.of(admin));
+        when(repository.countByRoleAndAtivoTrue(Role.ADMIN)).thenReturn(1L);
+
+        assertThatThrownBy(() -> service.inativar(2L, "admin@email.com"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Não é possível inativar o último administrador ativo");
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void inativar_adminComOutroAdminAtivo_deveInativar() {
+        User admin = usuario(2L, "admin2@email.com", Role.ADMIN);
+        when(repository.findById(2L)).thenReturn(Optional.of(admin));
+        when(repository.countByRoleAndAtivoTrue(Role.ADMIN)).thenReturn(2L);
+        when(repository.save(any())).thenReturn(admin);
+
+        service.inativar(2L, "admin@email.com");
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue().isAtivo()).isFalse();
+    }
+
+    @Test
+    void atualizar_rebaixandoUltimoAdmin_deveLancarBusinessException() {
+        User admin = usuario(2L, "admin2@email.com", Role.ADMIN);
+        var dto = new UserUpdateDTO(null, null, null, Role.USER);
+        when(repository.findById(2L)).thenReturn(Optional.of(admin));
+        when(repository.countByRoleAndAtivoTrue(Role.ADMIN)).thenReturn(1L);
+
+        assertThatThrownBy(() -> service.atualizar(2L, dto, "admin@email.com"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Não é possível rebaixar o último administrador ativo");
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void atualizar_rebaixandoAdminComOutroAdminAtivo_deveAtualizar() {
+        User admin = usuario(2L, "admin2@email.com", Role.ADMIN);
+        var dto = new UserUpdateDTO(null, null, null, Role.USER);
+        when(repository.findById(2L)).thenReturn(Optional.of(admin));
+        when(repository.countByRoleAndAtivoTrue(Role.ADMIN)).thenReturn(2L);
+        when(repository.save(any())).thenReturn(admin);
+
+        UserResponseDTO response = service.atualizar(2L, dto, "admin@email.com");
+
+        assertThat(response).isNotNull();
+        verify(repository).save(any());
+    }
 }

--- a/src/test/java/com/carlesso/pilatesapi/service/UserServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/UserServiceTest.java
@@ -19,6 +19,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
 
+import static java.util.List.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -190,7 +191,7 @@ class UserServiceTest {
     void inativar_ultimoAdmin_deveLancarBusinessException() {
         User admin = usuario(2L, "admin2@email.com", Role.ADMIN);
         when(repository.findById(2L)).thenReturn(Optional.of(admin));
-        when(repository.countByRoleAndAtivoTrue(Role.ADMIN)).thenReturn(1L);
+        when(repository.findActiveByRoleForUpdate(Role.ADMIN)).thenReturn(of(admin));
 
         assertThatThrownBy(() -> service.inativar(2L, "admin@email.com"))
                 .isInstanceOf(BusinessException.class)
@@ -202,8 +203,9 @@ class UserServiceTest {
     @Test
     void inativar_adminComOutroAdminAtivo_deveInativar() {
         User admin = usuario(2L, "admin2@email.com", Role.ADMIN);
+        User outroAdmin = usuario(3L, "admin3@email.com", Role.ADMIN);
         when(repository.findById(2L)).thenReturn(Optional.of(admin));
-        when(repository.countByRoleAndAtivoTrue(Role.ADMIN)).thenReturn(2L);
+        when(repository.findActiveByRoleForUpdate(Role.ADMIN)).thenReturn(of(admin, outroAdmin));
         when(repository.save(any())).thenReturn(admin);
 
         service.inativar(2L, "admin@email.com");
@@ -214,11 +216,24 @@ class UserServiceTest {
     }
 
     @Test
+    void inativar_adminJaInativo_naoDeveValidarUltimoAdminAtivo() {
+        User admin = usuario(2L, "admin2@email.com", Role.ADMIN);
+        admin.setAtivo(false);
+        when(repository.findById(2L)).thenReturn(Optional.of(admin));
+        when(repository.save(any())).thenReturn(admin);
+
+        service.inativar(2L, "admin@email.com");
+
+        verify(repository, never()).findActiveByRoleForUpdate(Role.ADMIN);
+        verify(repository).save(any());
+    }
+
+    @Test
     void atualizar_rebaixandoUltimoAdmin_deveLancarBusinessException() {
         User admin = usuario(2L, "admin2@email.com", Role.ADMIN);
         var dto = new UserUpdateDTO(null, null, null, Role.USER);
         when(repository.findById(2L)).thenReturn(Optional.of(admin));
-        when(repository.countByRoleAndAtivoTrue(Role.ADMIN)).thenReturn(1L);
+        when(repository.findActiveByRoleForUpdate(Role.ADMIN)).thenReturn(of(admin));
 
         assertThatThrownBy(() -> service.atualizar(2L, dto, "admin@email.com"))
                 .isInstanceOf(BusinessException.class)
@@ -230,14 +245,30 @@ class UserServiceTest {
     @Test
     void atualizar_rebaixandoAdminComOutroAdminAtivo_deveAtualizar() {
         User admin = usuario(2L, "admin2@email.com", Role.ADMIN);
+        User outroAdmin = usuario(3L, "admin3@email.com", Role.ADMIN);
         var dto = new UserUpdateDTO(null, null, null, Role.USER);
         when(repository.findById(2L)).thenReturn(Optional.of(admin));
-        when(repository.countByRoleAndAtivoTrue(Role.ADMIN)).thenReturn(2L);
+        when(repository.findActiveByRoleForUpdate(Role.ADMIN)).thenReturn(of(admin, outroAdmin));
         when(repository.save(any())).thenReturn(admin);
 
         UserResponseDTO response = service.atualizar(2L, dto, "admin@email.com");
 
         assertThat(response).isNotNull();
+        verify(repository).save(any());
+    }
+
+    @Test
+    void atualizar_rebaixandoAdminInativo_deveAtualizarSemValidarUltimoAdminAtivo() {
+        User admin = usuario(2L, "admin2@email.com", Role.ADMIN);
+        admin.setAtivo(false);
+        var dto = new UserUpdateDTO(null, null, null, Role.USER);
+        when(repository.findById(2L)).thenReturn(Optional.of(admin));
+        when(repository.save(any())).thenReturn(admin);
+
+        UserResponseDTO response = service.atualizar(2L, dto, "admin@email.com");
+
+        assertThat(response).isNotNull();
+        verify(repository, never()).findActiveByRoleForUpdate(Role.ADMIN);
         verify(repository).save(any());
     }
 }


### PR DESCRIPTION
## Resumo

- Impede a inativação de um usuário ADMIN quando ele é o único administrador ativo no sistema
- Impede o rebaixamento de role (ADMIN → USER) do único administrador ativo no sistema
- Evita falso bloqueio ao rebaixar ADMIN já inativo
- Protege a regra do último ADMIN ativo contra operações concorrentes usando lock pessimista
- Ambas as violações de regra lançam `BusinessException` com mensagem clara e retornam HTTP 422

## Motivo da mudança

Garantir que o sistema sempre possua ao menos um administrador ativo, evitando que a aplicação fique sem nenhum usuário com acesso administrativo. Resolve a issue #64.

## Testes executados

- `UserServiceTest`: 17 testes
  - Cenários do último ADMIN ativo
  - Cenários com ADMIN inativo
- `UserControllerTest`: 12 testes
  - Respostas HTTP 422 para as novas regras
- `SecurityIntegrationTest`: 26 testes
  - Inclui rebaixamento permitido de ADMIN inativo
- `UserServiceConcurrencyIntegrationTest`: 1 teste
  - Garante que duas inativações concorrentes preservam um ADMIN ativo
- Suite completa: **405 testes, 0 falhas, 0 erros**

## Arquivos alterados

- `UserRepository.java` — novo método com `PESSIMISTIC_WRITE` para bloquear ADMINs ativos durante a validação
- `UserService.java` — validação centralizada para remoção de ADMIN ativo
- `UserController.java` — descrições OpenAPI atualizadas
- `UserServiceTest.java` — novos cenários de service
- `UserControllerTest.java` — cenários de controller existentes mantidos
- `SecurityIntegrationTest.java` — cenário de ADMIN inativo
- `UserServiceConcurrencyIntegrationTest.java` — cobertura concorrente
- `docs/context.md`, `docs/documentacao.md` e `README.md` — documentação atualizada

Closes #64