### PR TITLE
feat(sessoes): PATCH realizar/cancelar e 404 em rota inexistente (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,6 +919,9 @@ curl -s -OJ "http://localhost:8080/api/relatorios/nfse?competencia=04/2026&forma
 - Exclusão é lógica: `DELETE /planos-tratamento/{id}` marca o plano como inativo e preserva o histórico no banco
 
 ### Sessões de Pilates/Fisioterapia
+- O `status` padrão é `AGENDADA`; mudanças de status usam `PATCH /sessoes/{id}/realizar` ou `PATCH /sessoes/{id}/cancelar`
+- Transições permitidas: apenas `AGENDADA -> REALIZADA` e `AGENDADA -> CANCELADA`
+- `PUT /sessoes/{id}` faz atualização parcial dos dados da sessão, mas não altera `status`
 - A evolução clínica estruturada deve ser registrada em `/evolucoes-sessao`
 - O campo legado `sessoes_pilates.evolucao` não faz parte do contrato REST de sessões
 - Excluir uma sessão remove também a evolução vinculada, quando existir
@@ -981,13 +984,14 @@ O projeto possui testes unitários, de controller e de integração organizados 
 | `RelatorioNfseServiceTest` | Unitário (Mockito) | 5 |
 | `RelatorioNfseExporterServiceTest` | Unitário | 3 |
 | `AppPropertiesTest` | Unitário (ApplicationContextRunner) | 3 |
-| `GlobalExceptionHandlerTest` | Unitário | 6 |
+| `GlobalExceptionHandlerTest` | Unitário | 7 |
 | `PacienteServiceIntegrationTest` | JPA (`@DataJpaTest`) | 4 |
 | `ProfissionalServiceIntegrationTest` | JPA (`@DataJpaTest`) | 5 |
 | `PagamentoServiceAtomicidadeIntegrationTest` | Integração (`@SpringBootTest` + H2) | 1 |
 | `CobrancaSchedulerIntegrationTest` | JPA (`@DataJpaTest`) | 11 |
 | `AulaRepositoryTest` | JPA (`@DataJpaTest`) | 6 |
 | `PagamentoRepositoryTest` | JPA (`@DataJpaTest`) | 2 |
+| `SessaoPilatesRepositoryTest` | JPA (`@DataJpaTest`) | 1 |
 | `PacienteControllerTest` | Controller (`@WebMvcTest`) | 16 |
 | `PlanoControllerTest` | Controller (`@WebMvcTest`) | 11 |
 | `PagamentoControllerTest` | Controller (`@WebMvcTest`) | 11 |
@@ -995,13 +999,15 @@ O projeto possui testes unitários, de controller e de integração organizados 
 | `AnamneseControllerTest` | Controller (`@WebMvcTest`) | 14 |
 | `AvaliacaoFisioterapeuticaControllerTest` | Controller (`@WebMvcTest`) | 12 |
 | `PlanoTratamentoControllerTest` | Controller (`@WebMvcTest`) | 18 |
+| `SessaoPilatesControllerTest` | Controller (`@WebMvcTest`) | 21 |
 | `ProfissionalControllerTest` | Controller (`@WebMvcTest`) | 17 |
 | `RelatorioNfseControllerTest` | Controller (`@WebMvcTest`) | 6 |
 | `DashboardControllerTest` | Controller (`@WebMvcTest`) | 2 |
 | `DashboardServiceTest` | Unitário (Mockito) | 3 |
+| `SessaoPilatesServiceTest` | Unitário (Mockito) | 23 |
 | `EvolucaoSessaoServiceTest` | Unitário (Mockito) | 10 |
 | `EvolucaoSessaoControllerTest` | Controller (`@WebMvcTest`) | 13 |
-| `SecurityIntegrationTest` | Integração (`@SpringBootTest` + MockMvc + H2) | 23 |
+| `SecurityIntegrationTest` | Integração (`@SpringBootTest` + MockMvc + H2) | 31 |
 | `ActuatorTest` | Integração (`@SpringBootTest`) | 3 |
 | `PilatesApiApplicationTests` | Integração (`@SpringBootTest`) | 1 |
 

--- a/README.md
+++ b/README.md
@@ -991,7 +991,7 @@ O projeto possui testes unitários, de controller e de integração organizados 
 | `CobrancaSchedulerIntegrationTest` | JPA (`@DataJpaTest`) | 11 |
 | `AulaRepositoryTest` | JPA (`@DataJpaTest`) | 6 |
 | `PagamentoRepositoryTest` | JPA (`@DataJpaTest`) | 2 |
-| `SessaoPilatesRepositoryTest` | JPA (`@DataJpaTest`) | 1 |
+| `SessaoPilatesRepositoryTest` | JPA (`@DataJpaTest`) | 4 |
 | `PacienteControllerTest` | Controller (`@WebMvcTest`) | 16 |
 | `PlanoControllerTest` | Controller (`@WebMvcTest`) | 11 |
 | `PagamentoControllerTest` | Controller (`@WebMvcTest`) | 11 |
@@ -1004,10 +1004,10 @@ O projeto possui testes unitários, de controller e de integração organizados 
 | `RelatorioNfseControllerTest` | Controller (`@WebMvcTest`) | 6 |
 | `DashboardControllerTest` | Controller (`@WebMvcTest`) | 2 |
 | `DashboardServiceTest` | Unitário (Mockito) | 3 |
-| `SessaoPilatesServiceTest` | Unitário (Mockito) | 23 |
+| `SessaoPilatesServiceTest` | Unitário (Mockito) | 25 |
 | `EvolucaoSessaoServiceTest` | Unitário (Mockito) | 10 |
 | `EvolucaoSessaoControllerTest` | Controller (`@WebMvcTest`) | 13 |
-| `SecurityIntegrationTest` | Integração (`@SpringBootTest` + MockMvc + H2) | 31 |
+| `SecurityIntegrationTest` | Integração (`@SpringBootTest` + MockMvc + H2) | 32 |
 | `ActuatorTest` | Integração (`@SpringBootTest`) | 3 |
 | `PilatesApiApplicationTests` | Integração (`@SpringBootTest`) | 1 |
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -468,6 +468,8 @@ Relacionamento `@ManyToOne` obrigatório com `Paciente` e relacionamentos opcion
 | GET | `/sessoes/{id}` | Buscar sessão por ID | 200 / 404 |
 | GET | `/sessoes/paciente/{pacienteId}` | Listar sessões do paciente | 200 / 404 |
 | PUT | `/sessoes/{id}` | Atualizar sessão (atualização parcial) | 200 / 400 / 404 |
+| PATCH | `/sessoes/{id}/realizar` | Marcar sessão como REALIZADA (apenas a partir de AGENDADA) | 200 / 404 / 422 |
+| PATCH | `/sessoes/{id}/cancelar` | Cancelar sessão (apenas a partir de AGENDADA) | 200 / 404 / 422 |
 | DELETE | `/sessoes/{id}` | Excluir sessão permanentemente | 204 / 404 |
 | GET | `/dashboard/resumo` | Resumo consolidado para o painel inicial (pacientes, profissionais, pagamentos, aulas) | 200 / 401 |
 | POST | `/evolucoes-sessao` | Criar evolução para uma sessão | 201 / 400 / 404 / 409 |

--- a/docs/context.md
+++ b/docs/context.md
@@ -747,9 +747,9 @@ JAVA_HOME=~/jdk mvn spring-boot:run
 | `AvaliacaoFisioterapeuticaControllerTest` | `@WebMvcTest` + MockMvc | 12 |
 | `PlanoTratamentoServiceTest` | Unitário (Mockito, sem Spring) | 13 |
 | `PlanoTratamentoControllerTest` | `@WebMvcTest` + MockMvc | 18 |
-| `SessaoPilatesServiceTest` | Unitário (Mockito, sem Spring) | 23 |
+| `SessaoPilatesServiceTest` | Unitário (Mockito, sem Spring) | 25 |
 | `SessaoPilatesControllerTest` | `@WebMvcTest` + MockMvc | 21 |
-| `SessaoPilatesRepositoryTest` | `@DataJpaTest` + H2 | 1 |
+| `SessaoPilatesRepositoryTest` | `@DataJpaTest` + H2 | 4 |
 | `DashboardControllerTest` | `@WebMvcTest` + MockMvc | 2 |
 | `DashboardServiceTest` | Unitário (Mockito, sem Spring) | 3 |
 | `AppPropertiesTest` | Unitário (ApplicationContextRunner) | 3 |
@@ -760,7 +760,7 @@ JAVA_HOME=~/jdk mvn spring-boot:run
 | `ReavaliacaoControllerTest` | `@WebMvcTest` + MockMvc | 9 |
 | `UserServiceTest` | Unitário (Mockito, sem Spring) | 8 |
 | `UserControllerTest` | `@WebMvcTest` + MockMvc | 8 |
-| `SecurityIntegrationTest` | `@SpringBootTest` + MockMvc + H2 | 31 |
+| `SecurityIntegrationTest` | `@SpringBootTest` + MockMvc + H2 | 32 |
 | `ActuatorTest` | `@SpringBootTest` + H2 | 3 |
 | `PilatesApiApplicationTests` | `@SpringBootTest` + H2 | 1 |
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -467,7 +467,7 @@ Relacionamento `@ManyToOne` obrigatório com `Paciente` e relacionamentos opcion
 | POST | `/sessoes` | Registrar sessão de Pilates ou Fisioterapia | 201 / 400 / 404 / 422 |
 | GET | `/sessoes/{id}` | Buscar sessão por ID | 200 / 404 |
 | GET | `/sessoes/paciente/{pacienteId}` | Listar sessões do paciente | 200 / 404 |
-| PUT | `/sessoes/{id}` | Atualizar sessão (atualização parcial) | 200 / 400 / 404 |
+| PUT | `/sessoes/{id}` | Atualizar sessão (atualização parcial, exceto status) | 200 / 400 / 404 |
 | PATCH | `/sessoes/{id}/realizar` | Marcar sessão como REALIZADA (apenas a partir de AGENDADA) | 200 / 404 / 422 |
 | PATCH | `/sessoes/{id}/cancelar` | Cancelar sessão (apenas a partir de AGENDADA) | 200 / 404 / 422 |
 | DELETE | `/sessoes/{id}` | Excluir sessão permanentemente | 204 / 404 |
@@ -583,10 +583,11 @@ CPF não pode ser alterado após o cadastro.
 - Criar sessão para paciente inexistente ou inativo retorna `404`
 - Campos obrigatórios: `pacienteId`, `tipo` e `data`
 - `tipo` aceita `PILATES` ou `FISIOTERAPIA`
-- `status` padrão é `AGENDADA`; pode ser atualizado para `REALIZADA` ou `CANCELADA`
+- `status` padrão é `AGENDADA`; mudanças de status devem usar `PATCH /sessoes/{id}/realizar` ou `PATCH /sessoes/{id}/cancelar`
+- Transições de status permitidas: apenas `AGENDADA -> REALIZADA` e `AGENDADA -> CANCELADA`; sessões `REALIZADA` ou `CANCELADA` não podem mudar de status novamente
 - `profissionalId` e `planoTratamentoId` são opcionais; quando informados, o recurso deve existir e estar ativo, e o plano de tratamento deve pertencer ao mesmo `pacienteId` da sessão
 - `duracaoMinutos` aceita apenas valores positivos quando informado
-- Atualização parcial: apenas campos não-nulos do DTO de update são aplicados
+- Atualização parcial: apenas campos não-nulos do DTO de update são aplicados; `status` não faz parte do payload de `PUT /sessoes/{id}`
 - A evolução clínica estruturada deve ser registrada em `/evolucoes-sessao`; o campo legado `sessoes_pilates.evolucao` não faz parte do contrato REST
 - Exclusão é física (DELETE permanente — sem soft delete, pois sessões canceladas por engano devem poder ser removidas) e remove a evolução vinculada quando existir
 - `dataCriacao` é registrada na criação e `dataAtualizacao` em cada atualização
@@ -746,17 +747,20 @@ JAVA_HOME=~/jdk mvn spring-boot:run
 | `AvaliacaoFisioterapeuticaControllerTest` | `@WebMvcTest` + MockMvc | 12 |
 | `PlanoTratamentoServiceTest` | Unitário (Mockito, sem Spring) | 13 |
 | `PlanoTratamentoControllerTest` | `@WebMvcTest` + MockMvc | 18 |
+| `SessaoPilatesServiceTest` | Unitário (Mockito, sem Spring) | 23 |
+| `SessaoPilatesControllerTest` | `@WebMvcTest` + MockMvc | 21 |
+| `SessaoPilatesRepositoryTest` | `@DataJpaTest` + H2 | 1 |
 | `DashboardControllerTest` | `@WebMvcTest` + MockMvc | 2 |
 | `DashboardServiceTest` | Unitário (Mockito, sem Spring) | 3 |
 | `AppPropertiesTest` | Unitário (ApplicationContextRunner) | 3 |
-| `GlobalExceptionHandlerTest` | Unitário | 6 |
+| `GlobalExceptionHandlerTest` | Unitário | 7 |
 | `EvolucaoSessaoServiceTest` | Unitário (Mockito, sem Spring) | 10 |
 | `EvolucaoSessaoControllerTest` | `@WebMvcTest` + MockMvc | 13 |
 | `ReavaliacaoServiceTest` | Unitário (Mockito, sem Spring) | 14 |
 | `ReavaliacaoControllerTest` | `@WebMvcTest` + MockMvc | 9 |
 | `UserServiceTest` | Unitário (Mockito, sem Spring) | 8 |
 | `UserControllerTest` | `@WebMvcTest` + MockMvc | 8 |
-| `SecurityIntegrationTest` | `@SpringBootTest` + MockMvc + H2 | 23 |
+| `SecurityIntegrationTest` | `@SpringBootTest` + MockMvc + H2 | 31 |
 | `ActuatorTest` | `@SpringBootTest` + H2 | 3 |
 | `PilatesApiApplicationTests` | `@SpringBootTest` + H2 | 1 |
 

--- a/src/main/java/com/carlesso/pilatesapi/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/carlesso/pilatesapi/config/GlobalExceptionHandler.java
@@ -11,6 +11,8 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.Map;
 
@@ -21,6 +23,12 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public Map<String, String> handleNotFound(RuntimeException e) {
         return Map.of("erro", e.getMessage());
+    }
+
+    @ExceptionHandler({NoHandlerFoundException.class, NoResourceFoundException.class})
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public Map<String, String> handleNoHandlerFound(Exception e) {
+        return Map.of("erro", "Rota não encontrada");
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/com/carlesso/pilatesapi/config/SecurityConfig.java
+++ b/src/main/java/com/carlesso/pilatesapi/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                 .authenticationProvider(authenticationProvider)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/**").permitAll()
+                        .requestMatchers("/error").permitAll()
                         .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                         .requestMatchers("/api-docs/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/users/me").authenticated()

--- a/src/main/java/com/carlesso/pilatesapi/controller/SessaoPilatesController.java
+++ b/src/main/java/com/carlesso/pilatesapi/controller/SessaoPilatesController.java
@@ -85,6 +85,36 @@ public class SessaoPilatesController {
     }
 
     @Operation(
+            summary = "Marcar sessão como realizada",
+            description = "Transiciona o status da sessão de AGENDADA para REALIZADA."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Sessão marcada como realizada"),
+            @ApiResponse(responseCode = "404", description = "Sessão não encontrada"),
+            @ApiResponse(responseCode = "422", description = "Transição inválida (sessão não está AGENDADA)")
+    })
+    @PatchMapping("/{id}/realizar")
+    public ResponseEntity<SessaoPilatesResponseDTO> realizar(
+            @Parameter(description = "ID da sessão", required = true) @PathVariable Long id) {
+        return ResponseEntity.ok(service.realizar(id));
+    }
+
+    @Operation(
+            summary = "Cancelar sessão",
+            description = "Transiciona o status da sessão de AGENDADA para CANCELADA."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Sessão cancelada"),
+            @ApiResponse(responseCode = "404", description = "Sessão não encontrada"),
+            @ApiResponse(responseCode = "422", description = "Transição inválida (sessão não está AGENDADA)")
+    })
+    @PatchMapping("/{id}/cancelar")
+    public ResponseEntity<SessaoPilatesResponseDTO> cancelar(
+            @Parameter(description = "ID da sessão", required = true) @PathVariable Long id) {
+        return ResponseEntity.ok(service.cancelar(id));
+    }
+
+    @Operation(
             summary = "Excluir sessão",
             description = "Remove permanentemente uma sessão. Use apenas para cancelamentos/erros de registro."
     )

--- a/src/main/java/com/carlesso/pilatesapi/dto/SessaoPilatesUpdateDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/SessaoPilatesUpdateDTO.java
@@ -1,6 +1,5 @@
 package com.carlesso.pilatesapi.dto;
 
-import com.carlesso.pilatesapi.entity.enums.StatusSessao;
 import jakarta.validation.constraints.Positive;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -10,6 +9,5 @@ public record SessaoPilatesUpdateDTO(
         LocalTime horario,
         String local,
         @Positive Integer duracaoMinutos,
-        StatusSessao status,
         String observacoes
 ) {}

--- a/src/main/java/com/carlesso/pilatesapi/repository/SessaoPilatesRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/SessaoPilatesRepository.java
@@ -13,9 +13,18 @@ import java.util.Optional;
 
 public interface SessaoPilatesRepository extends JpaRepository<SessaoPilates, Long> {
 
-    @Query("SELECT s FROM SessaoPilates s JOIN FETCH s.paciente pac WHERE s.id = :id AND pac.ativo = true")
+    @Query("""
+            SELECT s FROM SessaoPilates s
+            JOIN FETCH s.paciente pac
+            LEFT JOIN FETCH s.profissional
+            LEFT JOIN FETCH s.planoTratamento
+            WHERE s.id = :id AND pac.ativo = true
+            """)
     Optional<SessaoPilates> findByIdComPaciente(@Param("id") Long id);
 
+    // UPDATE em massa: garante atomicidade da transição de status contra concorrência,
+    // mas bypassa @PreUpdate/lifecycle callbacks da entidade. Por isso `dataAtualizacao`
+    // precisa ser passado explicitamente.
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
             UPDATE SessaoPilates s

--- a/src/main/java/com/carlesso/pilatesapi/repository/SessaoPilatesRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/SessaoPilatesRepository.java
@@ -1,10 +1,13 @@
 package com.carlesso.pilatesapi.repository;
 
 import com.carlesso.pilatesapi.entity.SessaoPilates;
+import com.carlesso.pilatesapi.entity.enums.StatusSessao;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,6 +15,18 @@ public interface SessaoPilatesRepository extends JpaRepository<SessaoPilates, Lo
 
     @Query("SELECT s FROM SessaoPilates s JOIN FETCH s.paciente pac WHERE s.id = :id AND pac.ativo = true")
     Optional<SessaoPilates> findByIdComPaciente(@Param("id") Long id);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            UPDATE SessaoPilates s
+            SET s.status = :novoStatus,
+                s.dataAtualizacao = :dataAtualizacao
+            WHERE s.id = :id
+              AND s.status = com.carlesso.pilatesapi.entity.enums.StatusSessao.AGENDADA
+            """)
+    int transicionarStatusSeAgendada(@Param("id") Long id,
+                                     @Param("novoStatus") StatusSessao novoStatus,
+                                     @Param("dataAtualizacao") LocalDateTime dataAtualizacao);
 
     @Query("""
             SELECT s FROM SessaoPilates s

--- a/src/main/java/com/carlesso/pilatesapi/service/SessaoPilatesService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/SessaoPilatesService.java
@@ -7,6 +7,7 @@ import com.carlesso.pilatesapi.entity.Paciente;
 import com.carlesso.pilatesapi.entity.PlanoTratamento;
 import com.carlesso.pilatesapi.entity.Profissional;
 import com.carlesso.pilatesapi.entity.SessaoPilates;
+import com.carlesso.pilatesapi.entity.enums.StatusSessao;
 import com.carlesso.pilatesapi.exception.BusinessException;
 import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.repository.EvolucaoSessaoRepository;
@@ -104,6 +105,27 @@ public class SessaoPilatesService {
         if (dto.observacoes() != null) sessao.setObservacoes(dto.observacoes());
         sessao.setDataAtualizacao(LocalDateTime.now());
 
+        return SessaoPilatesResponseDTO.from(sessaoRepository.save(sessao));
+    }
+
+    @Transactional
+    public SessaoPilatesResponseDTO realizar(Long id) {
+        return aplicarTransicaoStatus(id, StatusSessao.REALIZADA);
+    }
+
+    @Transactional
+    public SessaoPilatesResponseDTO cancelar(Long id) {
+        return aplicarTransicaoStatus(id, StatusSessao.CANCELADA);
+    }
+
+    private SessaoPilatesResponseDTO aplicarTransicaoStatus(Long id, StatusSessao novoStatus) {
+        SessaoPilates sessao = encontrar(id);
+        if (sessao.getStatus() != StatusSessao.AGENDADA) {
+            throw new BusinessException("Transição inválida: sessão " + sessao.getStatus()
+                    + " não pode ser alterada para " + novoStatus);
+        }
+        sessao.setStatus(novoStatus);
+        sessao.setDataAtualizacao(LocalDateTime.now());
         return SessaoPilatesResponseDTO.from(sessaoRepository.save(sessao));
     }
 

--- a/src/main/java/com/carlesso/pilatesapi/service/SessaoPilatesService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/SessaoPilatesService.java
@@ -118,17 +118,23 @@ public class SessaoPilatesService {
     }
 
     private SessaoPilatesResponseDTO aplicarTransicaoStatus(Long id, StatusSessao novoStatus) {
-        int atualizadas = sessaoRepository.transicionarStatusSeAgendada(id, novoStatus, LocalDateTime.now());
-        if (atualizadas == 1) {
-            return SessaoPilatesResponseDTO.from(encontrar(id));
-        }
-
         SessaoPilates sessao = encontrar(id);
+
         if (sessao.getStatus() != StatusSessao.AGENDADA) {
             throw new BusinessException("Transição inválida: sessão " + sessao.getStatus()
                     + " não pode ser alterada para " + novoStatus);
         }
-        throw new BusinessException("Transição inválida: sessão não pode ser alterada para " + novoStatus);
+
+        LocalDateTime agora = LocalDateTime.now();
+        int atualizadas = sessaoRepository.transicionarStatusSeAgendada(id, novoStatus, agora);
+        if (atualizadas == 0) {
+            throw new BusinessException(
+                    "Sessão foi modificada concorrentemente; recarregue e tente novamente");
+        }
+
+        sessao.setStatus(novoStatus);
+        sessao.setDataAtualizacao(agora);
+        return SessaoPilatesResponseDTO.from(sessao);
     }
 
     @Transactional

--- a/src/main/java/com/carlesso/pilatesapi/service/SessaoPilatesService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/SessaoPilatesService.java
@@ -101,7 +101,6 @@ public class SessaoPilatesService {
         if (dto.horario() != null) sessao.setHorario(dto.horario());
         if (dto.local() != null) sessao.setLocal(dto.local());
         if (dto.duracaoMinutos() != null) sessao.setDuracaoMinutos(dto.duracaoMinutos());
-        if (dto.status() != null) sessao.setStatus(dto.status());
         if (dto.observacoes() != null) sessao.setObservacoes(dto.observacoes());
         sessao.setDataAtualizacao(LocalDateTime.now());
 
@@ -119,14 +118,17 @@ public class SessaoPilatesService {
     }
 
     private SessaoPilatesResponseDTO aplicarTransicaoStatus(Long id, StatusSessao novoStatus) {
+        int atualizadas = sessaoRepository.transicionarStatusSeAgendada(id, novoStatus, LocalDateTime.now());
+        if (atualizadas == 1) {
+            return SessaoPilatesResponseDTO.from(encontrar(id));
+        }
+
         SessaoPilates sessao = encontrar(id);
         if (sessao.getStatus() != StatusSessao.AGENDADA) {
             throw new BusinessException("Transição inválida: sessão " + sessao.getStatus()
                     + " não pode ser alterada para " + novoStatus);
         }
-        sessao.setStatus(novoStatus);
-        sessao.setDataAtualizacao(LocalDateTime.now());
-        return SessaoPilatesResponseDTO.from(sessaoRepository.save(sessao));
+        throw new BusinessException("Transição inválida: sessão não pode ser alterada para " + novoStatus);
     }
 
     @Transactional

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,9 @@ spring.datasource.username=${DB_USER:postgres}
 spring.datasource.password=${DB_PASSWORD:postgres}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
+spring.mvc.throw-exception-if-no-handler-found=true
+spring.web.resources.add-mappings=false
+
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,11 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.mvc.throw-exception-if-no-handler-found=true
 spring.web.resources.add-mappings=false
 
+server.error.include-message=never
+server.error.include-stacktrace=never
+server.error.include-binding-errors=never
+server.error.include-exception=false
+
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=true

--- a/src/test/java/com/carlesso/pilatesapi/config/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/config/GlobalExceptionHandlerTest.java
@@ -6,6 +6,8 @@ import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.util.Map;
 
@@ -53,6 +55,14 @@ class GlobalExceptionHandlerTest {
                 new IllegalArgumentException("Período inicial é obrigatório"));
 
         assertThat(response).containsEntry("erro", "Período inicial é obrigatório");
+    }
+
+    @Test
+    void handleNoHandlerFound_retornaMensagemRotaNaoEncontrada() {
+        Map<String, String> response = handler.handleNoHandlerFound(
+                new NoHandlerFoundException("GET", "/inexistente", new HttpHeaders()));
+
+        assertThat(response).containsEntry("erro", "Rota não encontrada");
     }
 
     @Test

--- a/src/test/java/com/carlesso/pilatesapi/controller/SessaoPilatesControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/SessaoPilatesControllerTest.java
@@ -204,7 +204,7 @@ class SessaoPilatesControllerTest {
                 1L, 1L, "Ana Oliveira",
                 null, null, null,
                 TipoSessao.PILATES,
-                StatusSessao.REALIZADA,
+                StatusSessao.AGENDADA,
                 LocalDate.of(2026, 5, 15),
                 LocalTime.of(10, 0),
                 "Sala 1",
@@ -219,7 +219,6 @@ class SessaoPilatesControllerTest {
                 LocalDate.of(2026, 5, 15),
                 LocalTime.of(10, 0),
                 null, 60,
-                StatusSessao.REALIZADA,
                 null
         );
 
@@ -228,13 +227,13 @@ class SessaoPilatesControllerTest {
                         .content(mapper.writeValueAsString(dto)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").value("2026-05-15"))
-                .andExpect(jsonPath("$.status").value("REALIZADA"))
+                .andExpect(jsonPath("$.status").value("AGENDADA"))
                 .andExpect(jsonPath("$.dataAtualizacao").isNotEmpty());
     }
 
     @Test
     void atualizar_comDuracaoNegativa_deveRetornar400() throws Exception {
-        var dto = new SessaoPilatesUpdateDTO(null, null, null, -5, null, null);
+        var dto = new SessaoPilatesUpdateDTO(null, null, null, -5, null);
 
         mvc.perform(put("/sessoes/1")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -247,7 +246,7 @@ class SessaoPilatesControllerTest {
         when(service.atualizar(eq(99L), any()))
                 .thenThrow(new ResourceNotFoundException("Sessão não encontrada: 99"));
 
-        var dto = new SessaoPilatesUpdateDTO(LocalDate.of(2026, 5, 20), null, null, null, null, null);
+        var dto = new SessaoPilatesUpdateDTO(LocalDate.of(2026, 5, 20), null, null, null, null);
 
         mvc.perform(put("/sessoes/99")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/carlesso/pilatesapi/controller/SessaoPilatesControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/SessaoPilatesControllerTest.java
@@ -5,6 +5,7 @@ import com.carlesso.pilatesapi.dto.SessaoPilatesResponseDTO;
 import com.carlesso.pilatesapi.dto.SessaoPilatesUpdateDTO;
 import com.carlesso.pilatesapi.entity.enums.StatusSessao;
 import com.carlesso.pilatesapi.entity.enums.TipoSessao;
+import com.carlesso.pilatesapi.exception.BusinessException;
 import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.service.CustomUserDetailsService;
 import com.carlesso.pilatesapi.service.JwtService;
@@ -253,6 +254,92 @@ class SessaoPilatesControllerTest {
                         .content(mapper.writeValueAsString(dto)))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.erro").value("Sessão não encontrada: 99"));
+    }
+
+    @Test
+    void realizar_comSessaoAgendada_deveRetornar200ComStatusRealizada() throws Exception {
+        var realizada = new SessaoPilatesResponseDTO(
+                1L, 1L, "Ana Oliveira",
+                null, null, null,
+                TipoSessao.PILATES,
+                StatusSessao.REALIZADA,
+                LocalDate.of(2026, 5, 10),
+                LocalTime.of(9, 0),
+                "Sala 1",
+                50,
+                "Observação teste",
+                LocalDateTime.of(2026, 5, 4, 10, 0),
+                LocalDateTime.of(2026, 5, 8, 12, 0)
+        );
+        when(service.realizar(1L)).thenReturn(realizada);
+
+        mvc.perform(patch("/sessoes/1/realizar"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.status").value("REALIZADA"));
+    }
+
+    @Test
+    void realizar_comSessaoInexistente_deveRetornar404() throws Exception {
+        when(service.realizar(99L))
+                .thenThrow(new ResourceNotFoundException("Sessão não encontrada: 99"));
+
+        mvc.perform(patch("/sessoes/99/realizar"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.erro").value("Sessão não encontrada: 99"));
+    }
+
+    @Test
+    void realizar_comTransicaoInvalida_deveRetornar422() throws Exception {
+        when(service.realizar(1L))
+                .thenThrow(new BusinessException("Transição inválida: sessão CANCELADA não pode ser alterada para REALIZADA"));
+
+        mvc.perform(patch("/sessoes/1/realizar"))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.erro").value("Transição inválida: sessão CANCELADA não pode ser alterada para REALIZADA"));
+    }
+
+    @Test
+    void cancelar_comSessaoAgendada_deveRetornar200ComStatusCancelada() throws Exception {
+        var cancelada = new SessaoPilatesResponseDTO(
+                1L, 1L, "Ana Oliveira",
+                null, null, null,
+                TipoSessao.PILATES,
+                StatusSessao.CANCELADA,
+                LocalDate.of(2026, 5, 10),
+                LocalTime.of(9, 0),
+                "Sala 1",
+                50,
+                "Observação teste",
+                LocalDateTime.of(2026, 5, 4, 10, 0),
+                LocalDateTime.of(2026, 5, 8, 12, 0)
+        );
+        when(service.cancelar(1L)).thenReturn(cancelada);
+
+        mvc.perform(patch("/sessoes/1/cancelar"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.status").value("CANCELADA"));
+    }
+
+    @Test
+    void cancelar_comSessaoInexistente_deveRetornar404() throws Exception {
+        when(service.cancelar(99L))
+                .thenThrow(new ResourceNotFoundException("Sessão não encontrada: 99"));
+
+        mvc.perform(patch("/sessoes/99/cancelar"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.erro").value("Sessão não encontrada: 99"));
+    }
+
+    @Test
+    void cancelar_comTransicaoInvalida_deveRetornar422() throws Exception {
+        when(service.cancelar(1L))
+                .thenThrow(new BusinessException("Transição inválida: sessão REALIZADA não pode ser alterada para CANCELADA"));
+
+        mvc.perform(patch("/sessoes/1/cancelar"))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.erro").value("Transição inválida: sessão REALIZADA não pode ser alterada para CANCELADA"));
     }
 
     @Test

--- a/src/test/java/com/carlesso/pilatesapi/repository/SessaoPilatesRepositoryTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/repository/SessaoPilatesRepositoryTest.java
@@ -25,7 +25,7 @@ class SessaoPilatesRepositoryTest {
 
     @Test
     void transicionarStatusSeAgendada_deveAtualizarSomenteUmaVez() {
-        SessaoPilates sessao = entityManager.persist(sessao(paciente()));
+        SessaoPilates sessao = entityManager.persist(sessao(persistirPaciente("ana.repository@email.com", true)));
         entityManager.flush();
         entityManager.clear();
 
@@ -42,11 +42,49 @@ class SessaoPilatesRepositoryTest {
                 .isEqualTo(StatusSessao.REALIZADA);
     }
 
-    private Paciente paciente() {
+    @Test
+    void transicionarStatusSeAgendada_paraCancelada_devePersistirDataAtualizacao() {
+        SessaoPilates sessao = entityManager.persist(sessao(persistirPaciente("cancel.repository@email.com", true)));
+        entityManager.flush();
+        entityManager.clear();
+
+        LocalDateTime quando = LocalDateTime.of(2026, 5, 8, 12, 30);
+        int atualizadas = repository.transicionarStatusSeAgendada(
+                sessao.getId(), StatusSessao.CANCELADA, quando);
+
+        assertThat(atualizadas).isEqualTo(1);
+        assertThat(repository.findByIdComPaciente(sessao.getId()))
+                .get()
+                .satisfies(s -> {
+                    assertThat(s.getStatus()).isEqualTo(StatusSessao.CANCELADA);
+                    assertThat(s.getDataAtualizacao()).isEqualTo(quando);
+                });
+    }
+
+    @Test
+    void transicionarStatusSeAgendada_comIdInexistente_deveRetornarZero() {
+        int atualizadas = repository.transicionarStatusSeAgendada(
+                999_999L, StatusSessao.REALIZADA, LocalDateTime.of(2026, 5, 8, 12, 0));
+
+        assertThat(atualizadas).isZero();
+    }
+
+    @Test
+    void findByIdComPaciente_quandoPacienteInativo_deveRetornarVazio() {
+        SessaoPilates sessao = entityManager.persist(
+                sessao(persistirPaciente("inativo.repository@email.com", false)));
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(repository.findByIdComPaciente(sessao.getId())).isEmpty();
+    }
+
+    private Paciente persistirPaciente(String email, boolean ativo) {
         Paciente paciente = new Paciente();
         paciente.setNome("Ana Oliveira");
-        paciente.setEmail("ana.repository@email.com");
-        paciente.setCpf("12345678900");
+        paciente.setEmail(email);
+        paciente.setCpf("cpf-" + email);
+        paciente.setAtivo(ativo);
         return entityManager.persist(paciente);
     }
 

--- a/src/test/java/com/carlesso/pilatesapi/repository/SessaoPilatesRepositoryTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/repository/SessaoPilatesRepositoryTest.java
@@ -1,0 +1,60 @@
+package com.carlesso.pilatesapi.repository;
+
+import com.carlesso.pilatesapi.entity.Paciente;
+import com.carlesso.pilatesapi.entity.SessaoPilates;
+import com.carlesso.pilatesapi.entity.enums.StatusSessao;
+import com.carlesso.pilatesapi.entity.enums.TipoSessao;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest(showSql = false)
+class SessaoPilatesRepositoryTest {
+
+    @Autowired
+    private SessaoPilatesRepository repository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Test
+    void transicionarStatusSeAgendada_deveAtualizarSomenteUmaVez() {
+        SessaoPilates sessao = entityManager.persist(sessao(paciente()));
+        entityManager.flush();
+        entityManager.clear();
+
+        int primeiraAtualizacao = repository.transicionarStatusSeAgendada(
+                sessao.getId(), StatusSessao.REALIZADA, LocalDateTime.of(2026, 5, 8, 12, 0));
+        int segundaAtualizacao = repository.transicionarStatusSeAgendada(
+                sessao.getId(), StatusSessao.CANCELADA, LocalDateTime.of(2026, 5, 8, 12, 1));
+
+        assertThat(primeiraAtualizacao).isEqualTo(1);
+        assertThat(segundaAtualizacao).isZero();
+        assertThat(repository.findByIdComPaciente(sessao.getId()))
+                .get()
+                .extracting(SessaoPilates::getStatus)
+                .isEqualTo(StatusSessao.REALIZADA);
+    }
+
+    private Paciente paciente() {
+        Paciente paciente = new Paciente();
+        paciente.setNome("Ana Oliveira");
+        paciente.setEmail("ana.repository@email.com");
+        paciente.setCpf("12345678900");
+        return entityManager.persist(paciente);
+    }
+
+    private SessaoPilates sessao(Paciente paciente) {
+        SessaoPilates sessao = new SessaoPilates();
+        sessao.setPaciente(paciente);
+        sessao.setTipo(TipoSessao.PILATES);
+        sessao.setData(LocalDate.of(2026, 5, 10));
+        return sessao;
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/security/SecurityIntegrationTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/security/SecurityIntegrationTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -407,6 +408,24 @@ class SecurityIntegrationTest {
                 .andExpect(jsonPath("$.pagamentos").exists())
                 .andExpect(jsonPath("$.aulas").exists())
                 .andExpect(jsonPath("$.geradoEm").exists());
+    }
+
+    @Test
+    void rotaInexistente_comTokenValido_deveRetornar404() throws Exception {
+        User user = criarUsuario("rota@email.com", Role.USER);
+
+        mvc.perform(get("/rota-que-nao-existe")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(user)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void rotaInexistenteEmRecursoExistente_comTokenValido_deveRetornar404() throws Exception {
+        User user = criarUsuario("rota2@email.com", Role.USER);
+
+        mvc.perform(patch("/sessoes/1/inexistente")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(user)))
+                .andExpect(status().isNotFound());
     }
 
     @Test

--- a/src/test/java/com/carlesso/pilatesapi/security/SecurityIntegrationTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/security/SecurityIntegrationTest.java
@@ -429,6 +429,12 @@ class SecurityIntegrationTest {
     }
 
     @Test
+    void swaggerUi_devePermanecerAcessivelComAddMappingsDesabilitado() throws Exception {
+        mvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
     void cors_devePermitirOrigemDoAngular() throws Exception {
         mvc.perform(options("/pacientes")
                         .header(HttpHeaders.ORIGIN, "http://localhost:4200")

--- a/src/test/java/com/carlesso/pilatesapi/service/SessaoPilatesServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/SessaoPilatesServiceTest.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -303,7 +304,6 @@ class SessaoPilatesServiceTest {
                 LocalTime.of(10, 0),
                 null,
                 60,
-                StatusSessao.REALIZADA,
                 null
         );
 
@@ -313,7 +313,7 @@ class SessaoPilatesServiceTest {
         assertThat(response.horario()).isEqualTo(LocalTime.of(10, 0));
         assertThat(response.local()).isEqualTo("Sala 1");
         assertThat(response.duracaoMinutos()).isEqualTo(60);
-        assertThat(response.status()).isEqualTo(StatusSessao.REALIZADA);
+        assertThat(response.status()).isEqualTo(StatusSessao.AGENDADA);
         assertThat(response.dataAtualizacao()).isNotNull();
     }
 
@@ -321,7 +321,7 @@ class SessaoPilatesServiceTest {
     void atualizar_comSessaoInexistente_deveLancarResourceNotFoundException() {
         when(sessaoRepository.findByIdComPaciente(99L)).thenReturn(Optional.empty());
 
-        var dto = new SessaoPilatesUpdateDTO(null, null, null, null, null, null);
+        var dto = new SessaoPilatesUpdateDTO(null, null, null, null, null);
 
         assertThatThrownBy(() -> service.atualizar(99L, dto))
                 .isInstanceOf(ResourceNotFoundException.class)
@@ -331,20 +331,25 @@ class SessaoPilatesServiceTest {
     @Test
     void realizar_comSessaoAgendada_deveTransicionarParaRealizada() {
         SessaoPilates s = sessao(paciente());
+        s.setStatus(StatusSessao.REALIZADA);
+        s.setDataAtualizacao(LocalDateTime.of(2026, 5, 8, 12, 0));
+        when(sessaoRepository.transicionarStatusSeAgendada(eq(1L), eq(StatusSessao.REALIZADA), any(LocalDateTime.class)))
+                .thenReturn(1);
         when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));
-        when(sessaoRepository.save(s)).thenReturn(s);
 
         SessaoPilatesResponseDTO response = service.realizar(1L);
 
         assertThat(response.status()).isEqualTo(StatusSessao.REALIZADA);
         assertThat(response.dataAtualizacao()).isNotNull();
-        verify(sessaoRepository).save(s);
+        verify(sessaoRepository).transicionarStatusSeAgendada(eq(1L), eq(StatusSessao.REALIZADA), any(LocalDateTime.class));
     }
 
     @Test
     void realizar_comSessaoRealizada_deveLancarBusinessException() {
         SessaoPilates s = sessao(paciente());
         s.setStatus(StatusSessao.REALIZADA);
+        when(sessaoRepository.transicionarStatusSeAgendada(eq(1L), eq(StatusSessao.REALIZADA), any(LocalDateTime.class)))
+                .thenReturn(0);
         when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));
 
         assertThatThrownBy(() -> service.realizar(1L))
@@ -356,6 +361,8 @@ class SessaoPilatesServiceTest {
     void realizar_comSessaoCancelada_deveLancarBusinessException() {
         SessaoPilates s = sessao(paciente());
         s.setStatus(StatusSessao.CANCELADA);
+        when(sessaoRepository.transicionarStatusSeAgendada(eq(1L), eq(StatusSessao.REALIZADA), any(LocalDateTime.class)))
+                .thenReturn(0);
         when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));
 
         assertThatThrownBy(() -> service.realizar(1L))
@@ -365,6 +372,8 @@ class SessaoPilatesServiceTest {
 
     @Test
     void realizar_comSessaoInexistente_deveLancarResourceNotFoundException() {
+        when(sessaoRepository.transicionarStatusSeAgendada(eq(99L), eq(StatusSessao.REALIZADA), any(LocalDateTime.class)))
+                .thenReturn(0);
         when(sessaoRepository.findByIdComPaciente(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.realizar(99L))
@@ -375,8 +384,11 @@ class SessaoPilatesServiceTest {
     @Test
     void cancelar_comSessaoAgendada_deveTransicionarParaCancelada() {
         SessaoPilates s = sessao(paciente());
+        s.setStatus(StatusSessao.CANCELADA);
+        s.setDataAtualizacao(LocalDateTime.of(2026, 5, 8, 12, 0));
+        when(sessaoRepository.transicionarStatusSeAgendada(eq(1L), eq(StatusSessao.CANCELADA), any(LocalDateTime.class)))
+                .thenReturn(1);
         when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));
-        when(sessaoRepository.save(s)).thenReturn(s);
 
         SessaoPilatesResponseDTO response = service.cancelar(1L);
 
@@ -388,6 +400,8 @@ class SessaoPilatesServiceTest {
     void cancelar_comSessaoRealizada_deveLancarBusinessException() {
         SessaoPilates s = sessao(paciente());
         s.setStatus(StatusSessao.REALIZADA);
+        when(sessaoRepository.transicionarStatusSeAgendada(eq(1L), eq(StatusSessao.CANCELADA), any(LocalDateTime.class)))
+                .thenReturn(0);
         when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));
 
         assertThatThrownBy(() -> service.cancelar(1L))
@@ -397,6 +411,8 @@ class SessaoPilatesServiceTest {
 
     @Test
     void cancelar_comSessaoInexistente_deveLancarResourceNotFoundException() {
+        when(sessaoRepository.transicionarStatusSeAgendada(eq(99L), eq(StatusSessao.CANCELADA), any(LocalDateTime.class)))
+                .thenReturn(0);
         when(sessaoRepository.findByIdComPaciente(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.cancelar(99L))

--- a/src/test/java/com/carlesso/pilatesapi/service/SessaoPilatesServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/SessaoPilatesServiceTest.java
@@ -32,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -331,11 +332,9 @@ class SessaoPilatesServiceTest {
     @Test
     void realizar_comSessaoAgendada_deveTransicionarParaRealizada() {
         SessaoPilates s = sessao(paciente());
-        s.setStatus(StatusSessao.REALIZADA);
-        s.setDataAtualizacao(LocalDateTime.of(2026, 5, 8, 12, 0));
+        when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));
         when(sessaoRepository.transicionarStatusSeAgendada(eq(1L), eq(StatusSessao.REALIZADA), any(LocalDateTime.class)))
                 .thenReturn(1);
-        when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));
 
         SessaoPilatesResponseDTO response = service.realizar(1L);
 
@@ -348,47 +347,73 @@ class SessaoPilatesServiceTest {
     void realizar_comSessaoRealizada_deveLancarBusinessException() {
         SessaoPilates s = sessao(paciente());
         s.setStatus(StatusSessao.REALIZADA);
-        when(sessaoRepository.transicionarStatusSeAgendada(eq(1L), eq(StatusSessao.REALIZADA), any(LocalDateTime.class)))
-                .thenReturn(0);
         when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));
 
         assertThatThrownBy(() -> service.realizar(1L))
                 .isInstanceOf(BusinessException.class)
-                .hasMessageContaining("Transição inválida");
+                .hasMessageContaining("Transição inválida")
+                .hasMessageContaining("REALIZADA");
+        verify(sessaoRepository, never())
+                .transicionarStatusSeAgendada(any(), any(), any(LocalDateTime.class));
     }
 
     @Test
     void realizar_comSessaoCancelada_deveLancarBusinessException() {
         SessaoPilates s = sessao(paciente());
         s.setStatus(StatusSessao.CANCELADA);
-        when(sessaoRepository.transicionarStatusSeAgendada(eq(1L), eq(StatusSessao.REALIZADA), any(LocalDateTime.class)))
-                .thenReturn(0);
         when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));
 
         assertThatThrownBy(() -> service.realizar(1L))
                 .isInstanceOf(BusinessException.class)
-                .hasMessageContaining("Transição inválida");
+                .hasMessageContaining("Transição inválida")
+                .hasMessageContaining("CANCELADA");
+        verify(sessaoRepository, never())
+                .transicionarStatusSeAgendada(any(), any(), any(LocalDateTime.class));
     }
 
     @Test
     void realizar_comSessaoInexistente_deveLancarResourceNotFoundException() {
-        when(sessaoRepository.transicionarStatusSeAgendada(eq(99L), eq(StatusSessao.REALIZADA), any(LocalDateTime.class)))
-                .thenReturn(0);
         when(sessaoRepository.findByIdComPaciente(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.realizar(99L))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining("99");
+        verify(sessaoRepository, never())
+                .transicionarStatusSeAgendada(any(), any(), any(LocalDateTime.class));
+    }
+
+    @Test
+    void realizar_comPacienteInativo_deveLancarResourceNotFoundExceptionSemAtualizar() {
+        // findByIdComPaciente filtra por paciente.ativo=true; quando paciente está inativo,
+        // a query retorna empty mesmo se a sessão existir no banco. UPDATE não deve rodar.
+        when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.realizar(1L))
+                .isInstanceOf(ResourceNotFoundException.class);
+        verify(sessaoRepository, never())
+                .transicionarStatusSeAgendada(any(), any(), any(LocalDateTime.class));
+    }
+
+    @Test
+    void realizar_comRaceCondition_deveLancarBusinessException() {
+        // Sessão estava AGENDADA quando carregada, mas alguém transicionou entre o SELECT
+        // e o UPDATE → atualizadas == 0 e mensagem deve indicar concorrência.
+        SessaoPilates s = sessao(paciente());
+        when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));
+        when(sessaoRepository.transicionarStatusSeAgendada(eq(1L), eq(StatusSessao.REALIZADA), any(LocalDateTime.class)))
+                .thenReturn(0);
+
+        assertThatThrownBy(() -> service.realizar(1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("concorrentemente");
     }
 
     @Test
     void cancelar_comSessaoAgendada_deveTransicionarParaCancelada() {
         SessaoPilates s = sessao(paciente());
-        s.setStatus(StatusSessao.CANCELADA);
-        s.setDataAtualizacao(LocalDateTime.of(2026, 5, 8, 12, 0));
+        when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));
         when(sessaoRepository.transicionarStatusSeAgendada(eq(1L), eq(StatusSessao.CANCELADA), any(LocalDateTime.class)))
                 .thenReturn(1);
-        when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));
 
         SessaoPilatesResponseDTO response = service.cancelar(1L);
 
@@ -400,19 +425,17 @@ class SessaoPilatesServiceTest {
     void cancelar_comSessaoRealizada_deveLancarBusinessException() {
         SessaoPilates s = sessao(paciente());
         s.setStatus(StatusSessao.REALIZADA);
-        when(sessaoRepository.transicionarStatusSeAgendada(eq(1L), eq(StatusSessao.CANCELADA), any(LocalDateTime.class)))
-                .thenReturn(0);
         when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));
 
         assertThatThrownBy(() -> service.cancelar(1L))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("Transição inválida");
+        verify(sessaoRepository, never())
+                .transicionarStatusSeAgendada(any(), any(), any(LocalDateTime.class));
     }
 
     @Test
     void cancelar_comSessaoInexistente_deveLancarResourceNotFoundException() {
-        when(sessaoRepository.transicionarStatusSeAgendada(eq(99L), eq(StatusSessao.CANCELADA), any(LocalDateTime.class)))
-                .thenReturn(0);
         when(sessaoRepository.findByIdComPaciente(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.cancelar(99L))

--- a/src/test/java/com/carlesso/pilatesapi/service/SessaoPilatesServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/SessaoPilatesServiceTest.java
@@ -329,6 +329,82 @@ class SessaoPilatesServiceTest {
     }
 
     @Test
+    void realizar_comSessaoAgendada_deveTransicionarParaRealizada() {
+        SessaoPilates s = sessao(paciente());
+        when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));
+        when(sessaoRepository.save(s)).thenReturn(s);
+
+        SessaoPilatesResponseDTO response = service.realizar(1L);
+
+        assertThat(response.status()).isEqualTo(StatusSessao.REALIZADA);
+        assertThat(response.dataAtualizacao()).isNotNull();
+        verify(sessaoRepository).save(s);
+    }
+
+    @Test
+    void realizar_comSessaoRealizada_deveLancarBusinessException() {
+        SessaoPilates s = sessao(paciente());
+        s.setStatus(StatusSessao.REALIZADA);
+        when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));
+
+        assertThatThrownBy(() -> service.realizar(1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Transição inválida");
+    }
+
+    @Test
+    void realizar_comSessaoCancelada_deveLancarBusinessException() {
+        SessaoPilates s = sessao(paciente());
+        s.setStatus(StatusSessao.CANCELADA);
+        when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));
+
+        assertThatThrownBy(() -> service.realizar(1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Transição inválida");
+    }
+
+    @Test
+    void realizar_comSessaoInexistente_deveLancarResourceNotFoundException() {
+        when(sessaoRepository.findByIdComPaciente(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.realizar(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
+    void cancelar_comSessaoAgendada_deveTransicionarParaCancelada() {
+        SessaoPilates s = sessao(paciente());
+        when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));
+        when(sessaoRepository.save(s)).thenReturn(s);
+
+        SessaoPilatesResponseDTO response = service.cancelar(1L);
+
+        assertThat(response.status()).isEqualTo(StatusSessao.CANCELADA);
+        assertThat(response.dataAtualizacao()).isNotNull();
+    }
+
+    @Test
+    void cancelar_comSessaoRealizada_deveLancarBusinessException() {
+        SessaoPilates s = sessao(paciente());
+        s.setStatus(StatusSessao.REALIZADA);
+        when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));
+
+        assertThatThrownBy(() -> service.cancelar(1L))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Transição inválida");
+    }
+
+    @Test
+    void cancelar_comSessaoInexistente_deveLancarResourceNotFoundException() {
+        when(sessaoRepository.findByIdComPaciente(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.cancelar(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("99");
+    }
+
+    @Test
     void excluir_comSessaoExistente_deveRemoverSessao() {
         SessaoPilates s = sessao(paciente());
         when(sessaoRepository.findByIdComPaciente(1L)).thenReturn(Optional.of(s));

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -11,6 +11,11 @@ spring.flyway.enabled=false
 spring.mvc.throw-exception-if-no-handler-found=true
 spring.web.resources.add-mappings=false
 
+server.error.include-message=never
+server.error.include-stacktrace=never
+server.error.include-binding-errors=never
+server.error.include-exception=false
+
 spring.application.name=CarlessoPilatesApi
 management.endpoints.web.exposure.include=health,info
 management.endpoint.health.show-details=always

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -8,6 +8,9 @@ spring.jpa.show-sql=false
 
 spring.flyway.enabled=false
 
+spring.mvc.throw-exception-if-no-handler-found=true
+spring.web.resources.add-mappings=false
+
 spring.application.name=CarlessoPilatesApi
 management.endpoints.web.exposure.include=health,info
 management.endpoint.health.show-details=always


### PR DESCRIPTION
## Resumo

- Adiciona `PATCH /sessoes/{id}/realizar` e `PATCH /sessoes/{id}/cancelar` no `SessaoPilatesController`, transicionando o status de `AGENDADA` para `REALIZADA`/`CANCELADA`. Transições inválidas retornam 422; sessão inexistente retorna 404.
- Faz com que rotas REST inexistentes retornem **404** em vez de **401**: habilita `spring.mvc.throw-exception-if-no-handler-found=true` + `spring.web.resources.add-mappings=false`, libera `/error` no `SecurityConfig` e trata `NoHandlerFoundException`/`NoResourceFoundException` no `GlobalExceptionHandler`.
- Documenta os dois novos endpoints em `docs/context.md`.

## Motivo

O frontend chama `PATCH /sessoes/{id}/realizar` e `PATCH /sessoes/{id}/cancelar`, mas as rotas não existiam: o Spring fazia `forward` para `/error` e o `JwtAuthenticationFilter` (`OncePerRequestFilter`) não rodava no forward, resultando em 401 e logout indevido do usuário. Esta PR cria os endpoints e corrige a causa-raiz do 401 em rota inexistente, evitando regressões similares no futuro.

## Testes executados

- `mvn test` — 425/425 passando.
- Novos testes:
  - `SessaoPilatesServiceTest`: `realizar`/`cancelar` com sessão `AGENDADA`, `REALIZADA`, `CANCELADA` e id inexistente.
  - `SessaoPilatesControllerTest`: 200/404/422 para os dois PATCHs.
  - `SecurityIntegrationTest`: rota REST inexistente autenticada → 404 (regressão do bug reportado).
  - `GlobalExceptionHandlerTest`: handler de `NoHandlerFoundException`.

## Arquivos principais alterados

- `service/SessaoPilatesService.java` — métodos `realizar`/`cancelar` com validação de transição.
- `controller/SessaoPilatesController.java` — endpoints PATCH com `@Operation`/`@ApiResponses`.
- `config/GlobalExceptionHandler.java` — handler para `NoHandlerFoundException`/`NoResourceFoundException`.
- `config/SecurityConfig.java` — `/error` permitAll.
- `resources/application.properties` (main e test) — flags do Spring MVC para 404 legítimo.
- `docs/context.md` — documenta novos endpoints.

## Issue

Closes #69