### PR TITLE
feat(users): preferências do usuário (idioma, tema, notificações)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ Base URL: `http://localhost:8080`
 | `POST` | `/auth/login` | Público | Valida e-mail/senha e retorna JWT. Retorna `429` após 5 tentativas falhas em 15 min |
 | `GET` | `/users/me` | Autenticado | Retorna dados seguros do usuário autenticado |
 | `PUT` | `/users/me/senha` | Autenticado | Troca a própria senha informando `senhaAtual`, `novaSenha` (mín. 8 caracteres) e `confirmacaoNovaSenha`. Retorna `422` para senha atual incorreta, confirmação divergente ou reuso da senha atual. Tokens emitidos antes da troca deixam de autorizar rotas protegidas |
+| `GET` | `/users/me/preferencias` | Autenticado | Retorna as preferências do usuário autenticado (idioma, tema e notificações). Usuário sem preferências salvas recebe os valores padrão |
+| `PUT` | `/users/me/preferencias` | Autenticado | Atualiza as preferências do usuário autenticado. Valida `idioma` (`PT_BR`, `EN_US`, `ES_ES`) e `tema` (`CLARO`, `ESCURO`); valores inválidos retornam `400` |
 | `POST` | `/users` | `ADMIN` | Cria usuário com role `USER` ou `ADMIN` |
 | `GET` | `/users` | `ADMIN` | Lista usuários cadastrados sem expor senha |
 | `GET` | `/users/roles` | `ADMIN` | Lista as roles disponíveis (`value` e `label`) para uso em formulários administrativos |
@@ -555,6 +557,19 @@ Todos os campos são opcionais. Apenas os campos enviados serão atualizados.
 
 > Campos obrigatórios: `pacienteId`, `dataAvaliacao`, `queixaFuncional`, `escalaDor` e `diagnosticoFisioterapeutico`. `escalaDor` deve estar entre 0 e 10.
 
+### PUT /users/me/preferencias — corpo da requisição
+
+```json
+{
+  "idioma": "PT_BR",
+  "tema": "CLARO",
+  "notificacoesEmail": true,
+  "notificacoesPush": false
+}
+```
+
+> Campos obrigatórios: todos. `idioma` aceita `PT_BR`, `EN_US`, `ES_ES`. `tema` aceita `CLARO`, `ESCURO`. Quando o usuário ainda não tem preferências salvas, `GET /users/me/preferencias` retorna os valores padrão (`idioma=PT_BR`, `tema=CLARO`, `notificacoesEmail=true`, `notificacoesPush=false`).
+
 ---
 
 ## Como rodar
@@ -705,6 +720,8 @@ O projeto utiliza **Flyway** para versionamento e execução automática das mig
 | `V21__insert_admin_inicial.sql` | Mantém a versão Flyway reservada; o admin inicial de produção é criado pela aplicação com `APP_INITIAL_ADMIN_PASSWORD` |
 | `V22__alter_pacientes_email_cpf_nullable.sql` | Torna `email` e `cpf` opcionais (drop NOT NULL e drop das constraints únicas totais) para suportar importação de pacientes de sistemas externos sem esses dados |
 | `V23__add_pacientes_email_cpf_partial_unique.sql` | Recria a unicidade como índice **parcial** (`WHERE col IS NOT NULL`) — múltiplos pacientes podem ter `email`/`cpf` nulos, mas valores preenchidos seguem únicos. `PacienteService.cadastrar` também valida e retorna 409 antes de chegar no banco |
+| `V24__add_token_version_to_users.sql` | Adiciona coluna `token_version` em `users` para invalidar JWTs anteriores após troca/redefinição de senha |
+| `V25__create_preferencias_usuario_table.sql` | Cria tabela `preferencias_usuario` (1:1 com `users`) para idioma, tema e preferências de notificação |
 
 ### Migrations de seed (`db/seed/`) — apenas perfil `dev`
 
@@ -1097,6 +1114,8 @@ O projeto possui testes unitários, de controller e de integração organizados 
 | `SessaoPilatesServiceTest` | Unitário (Mockito) | 25 |
 | `EvolucaoSessaoServiceTest` | Unitário (Mockito) | 10 |
 | `EvolucaoSessaoControllerTest` | Controller (`@WebMvcTest`) | 13 |
+| `PreferenciasUsuarioServiceTest` | Unitário (Mockito) | 7 |
+| `PreferenciasUsuarioControllerTest` | Controller (`@WebMvcTest`) | 5 |
 | `SecurityIntegrationTest` | Integração (`@SpringBootTest` + MockMvc + H2) | 32 |
 | `ActuatorTest` | Integração (`@SpringBootTest`) | 3 |
 | `PilatesApiApplicationTests` | Integração (`@SpringBootTest`) | 1 |

--- a/README.md
+++ b/README.md
@@ -1115,8 +1115,9 @@ O projeto possui testes unitários, de controller e de integração organizados 
 | `EvolucaoSessaoServiceTest` | Unitário (Mockito) | 10 |
 | `EvolucaoSessaoControllerTest` | Controller (`@WebMvcTest`) | 13 |
 | `PreferenciasUsuarioServiceTest` | Unitário (Mockito) | 7 |
-| `PreferenciasUsuarioControllerTest` | Controller (`@WebMvcTest`) | 5 |
-| `SecurityIntegrationTest` | Integração (`@SpringBootTest` + MockMvc + H2) | 32 |
+| `PreferenciasUsuarioControllerTest` | Controller (`@WebMvcTest`) | 6 |
+| `PreferenciasUsuarioRepositoryTest` | Repositório (`@DataJpaTest` + H2) | 5 |
+| `SecurityIntegrationTest` | Integração (`@SpringBootTest` + MockMvc + H2) | 42 |
 | `ActuatorTest` | Integração (`@SpringBootTest`) | 3 |
 | `PilatesApiApplicationTests` | Integração (`@SpringBootTest`) | 1 |
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -59,7 +59,8 @@ com.carlesso.pilatesapi
 │   ├── UserController.java           — endpoint do usuário autenticado e CRUD administrativo
 │   ├── AdminController.java          — endpoints administrativos
 │   ├── RelatorioNfseController.java  — endpoint de relatório de emissão de NFSEs
-│   └── DashboardController.java      — endpoint de resumo para o painel inicial
+│   ├── DashboardController.java      — endpoint de resumo para o painel inicial
+│   └── PreferenciasUsuarioController.java — endpoints REST das preferências do usuário autenticado
 ├── service
 │   ├── PacienteService.java                    — lógica de negócio de pacientes
 │   ├── ProfissionalService.java                — lógica de negócio de profissionais
@@ -80,7 +81,8 @@ com.carlesso.pilatesapi
 │   ├── UserService.java                        — CRUD de usuários e definição de perfis de acesso
 │   ├── JwtService.java                         — geração (claims role/userId) e validação de JWT
 │   ├── LoginAttemptService.java                — rate limiting in-memory por e-mail (5 tentativas / 15 min)
-│   └── CustomUserDetailsService.java           — carregamento de usuários para Spring Security
+│   ├── CustomUserDetailsService.java           — carregamento de usuários para Spring Security
+│   └── PreferenciasUsuarioService.java         — leitura/atualização das preferências do usuário com defaults centralizados
 ├── repository
 │   ├── PacienteRepository.java       — acesso ao banco via Spring Data JPA
 │   ├── ProfissionalRepository.java   — acesso ao banco via Spring Data JPA
@@ -93,7 +95,8 @@ com.carlesso.pilatesapi
 │   ├── SessaoPilatesRepository.java
 │   ├── EvolucaoSessaoRepository.java
 │   ├── ReavaliacaoRepository.java
-│   └── UserRepository.java
+│   ├── UserRepository.java
+│   └── PreferenciasUsuarioRepository.java
 ├── entity
 │   ├── Paciente.java                 — entidade JPA, tabela `pacientes`
 │   ├── Endereco.java                 — @Embeddable, colunas embutidas em `pacientes`
@@ -107,7 +110,8 @@ com.carlesso.pilatesapi
 │   ├── SessaoPilates.java            — entidade JPA, tabela `sessoes_pilates`
 │   ├── EvolucaoSessao.java           — entidade JPA, tabela `evolucoes_sessao`
 │   ├── Reavaliacao.java              — entidade JPA, tabela `reavaliacoes`
-│   └── User.java                     — entidade JPA, tabela `users`
+│   ├── User.java                     — entidade JPA, tabela `users`
+│   └── PreferenciasUsuario.java      — entidade JPA, tabela `preferencias_usuario` (1:1 com `users`)
 ├── entity/enums
 │   ├── TipoPagamento.java            — MENSAL, TRIMESTRAL, ANUAL
 │   ├── TipoContrato.java             — CLT, PJ, AUTONOMO
@@ -115,7 +119,9 @@ com.carlesso.pilatesapi
 │   ├── StatusPagamento.java          — PENDENTE, PAGO, VENCIDO
 │   ├── TipoSessao.java               — PILATES, FISIOTERAPIA
 │   ├── StatusSessao.java             — AGENDADA, REALIZADA, CANCELADA
-│   └── Role.java                     — USER, ADMIN
+│   ├── Role.java                     — USER, ADMIN
+│   ├── IdiomaPreferencia.java        — PT_BR, EN_US, ES_ES (preferência de idioma do usuário)
+│   └── TemaPreferencia.java          — CLARO, ESCURO (preferência de tema do usuário)
 ├── security
 │   └── JwtAuthenticationFilter.java  — autentica requisições com Authorization Bearer
 ├── dto
@@ -160,7 +166,9 @@ com.carlesso.pilatesapi
 │   ├── AuthResponseDTO.java
 │   ├── UserRequestDTO.java
 │   ├── UserUpdateDTO.java
-│   └── UserResponseDTO.java
+│   ├── UserResponseDTO.java
+│   ├── PreferenciasUsuarioRequestDTO.java  — payload de atualização das preferências (idioma, tema, notificações)
+│   └── PreferenciasUsuarioResponseDTO.java — resposta das preferências (record com factory method `from`)
 └── scheduler
     └── CobrancaScheduler.java        — atualiza vencidos e gera cobranças futuras
 ```
@@ -390,6 +398,21 @@ Relacionamento `@OneToOne` com `SessaoPilates`. Cada sessão possui no máximo u
 
 Relacionamento `@ManyToOne` obrigatório com `Paciente` e relacionamentos opcionais com `AvaliacaoFisioterapeutica` e `PlanoTratamento`. Um paciente pode possuir múltiplas reavaliações periódicas para comparação longitudinal da evolução clínica.
 
+### Tabela `preferencias_usuario`
+
+| Campo | Tipo | Restrição |
+|---|---|---|
+| `id` | BIGINT | PK, auto-increment |
+| `user_id` | BIGINT | NOT NULL, UNIQUE, FK → users `ON DELETE CASCADE` |
+| `idioma` | VARCHAR(20) | NOT NULL (`PT_BR`, `EN_US`, `ES_ES`) |
+| `tema` | VARCHAR(20) | NOT NULL (`CLARO`, `ESCURO`) |
+| `notificacoes_email` | BOOLEAN | NOT NULL |
+| `notificacoes_push` | BOOLEAN | NOT NULL |
+| `data_criacao` | TIMESTAMP | NOT NULL |
+| `data_atualizacao` | TIMESTAMP | — |
+
+Relacionamento `@OneToOne` com `User` (1:1, owning side em `preferencias_usuario`). Cada usuário possui no máximo um registro de preferências — quando não existe, o GET retorna os valores padrão definidos no service.
+
 ### Índices
 
 | Índice | Tabela / Coluna | Motivação |
@@ -417,6 +440,8 @@ Relacionamento `@ManyToOne` obrigatório com `Paciente` e relacionamentos opcion
 | POST | `/auth/login` | Autenticar e retornar JWT | 200 / 400 / 401 |
 | GET | `/users/me` | Consultar usuário autenticado sem expor senha | 200 / 401 |
 | PUT | `/users/me/senha` | Trocar a própria senha (autenticado) informando senha atual, nova senha e confirmação | 204 / 400 / 401 / 422 |
+| GET | `/users/me/preferencias` | Consultar preferências do usuário autenticado; sem registro retorna defaults (`PT_BR`/`CLARO`/email=true/push=false) | 200 / 401 |
+| PUT | `/users/me/preferencias` | Atualizar preferências do usuário autenticado (idioma, tema, notificações); idioma/tema fora dos valores aceitos retornam 400 | 200 / 400 / 401 / 404 |
 | POST | `/users` | Criar usuário com role `USER` ou `ADMIN` | 201 / 400 / 401 / 403 / 409 |
 | GET | `/users` | Listar usuários paginados sem expor senha | 200 / 401 / 403 |
 | GET | `/users/roles` | Listar roles disponíveis (`value` e `label`) para formulários administrativos | 200 / 401 / 403 |
@@ -616,6 +641,16 @@ CPF não pode ser alterado após o cadastro.
 - Atualização parcial: apenas campos não-nulos do DTO de update são aplicados
 - `dataCriacao` é registrada na criação e `dataAtualizacao` em cada atualização
 
+### Preferências do usuário
+- Cada usuário possui no máximo um registro de preferências (constraint `UNIQUE user_id`)
+- Defaults centralizados no `PreferenciasUsuarioService`: `idioma=PT_BR`, `tema=CLARO`, `notificacoesEmail=true`, `notificacoesPush=false`
+- `GET /users/me/preferencias` retorna os defaults quando o usuário ainda não tem registro salvo, sem persistir nada (1 query única via `findByUserEmail`)
+- `PUT /users/me/preferencias` cria o registro na primeira chamada e atualiza nas seguintes; protegido contra criação concorrente para o mesmo usuário por lock pessimista em `users` (`UserRepository.findByEmailForUpdate`)
+- Campos obrigatórios no PUT: `idioma`, `tema`, `notificacoesEmail`, `notificacoesPush` (Bean Validation `@NotNull`); idioma/tema fora dos enums retornam `400`
+- Identificação do dono é feita exclusivamente por `Authentication.getName()`; e-mail é normalizado para lowercase antes da consulta
+- A FK `preferencias_usuario.user_id` usa `ON DELETE CASCADE` para que a remoção física de um usuário (cenário de teste e cleanup) leve junto suas preferências
+- `dataCriacao` é registrada na criação e `dataAtualizacao` em cada atualização
+
 ### Scheduler (processos automáticos)
 | Cron (default) | Ação | Propriedade |
 |---|---|---|
@@ -775,7 +810,10 @@ mvn spring-boot:run
 | `ReavaliacaoControllerTest` | `@WebMvcTest` + MockMvc | 9 |
 | `UserServiceTest` | Unitário (Mockito, sem Spring) | 8 |
 | `UserControllerTest` | `@WebMvcTest` + MockMvc | 8 |
-| `SecurityIntegrationTest` | `@SpringBootTest` + MockMvc + H2 | 32 |
+| `PreferenciasUsuarioServiceTest` | Unitário (Mockito, sem Spring) | 7 |
+| `PreferenciasUsuarioControllerTest` | `@WebMvcTest` + MockMvc | 6 |
+| `PreferenciasUsuarioRepositoryTest` | `@DataJpaTest` + H2 | 5 |
+| `SecurityIntegrationTest` | `@SpringBootTest` + MockMvc + H2 | 42 |
 | `ActuatorTest` | `@SpringBootTest` + H2 | 3 |
 | `PilatesApiApplicationTests` | `@SpringBootTest` + H2 | 1 |
 

--- a/src/main/java/com/carlesso/pilatesapi/config/SecurityConfig.java
+++ b/src/main/java/com/carlesso/pilatesapi/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                         .requestMatchers("/error").permitAll()
                         .requestMatchers("/actuator/health", "/actuator/info").permitAll()
                         .requestMatchers("/api-docs/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-                        .requestMatchers("/users/me", "/users/me/senha").authenticated()
+                        .requestMatchers("/users/me", "/users/me/senha", "/users/me/preferencias").authenticated()
                         .requestMatchers("/users/**").hasRole("ADMIN")
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated())

--- a/src/main/java/com/carlesso/pilatesapi/controller/PreferenciasUsuarioController.java
+++ b/src/main/java/com/carlesso/pilatesapi/controller/PreferenciasUsuarioController.java
@@ -50,7 +50,8 @@ public class PreferenciasUsuarioController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Preferências atualizadas com sucesso"),
             @ApiResponse(responseCode = "400", description = "Payload inválido (idioma/tema fora dos valores aceitos ou campos obrigatórios ausentes)"),
-            @ApiResponse(responseCode = "401", description = "Token ausente ou inválido")
+            @ApiResponse(responseCode = "401", description = "Token ausente ou inválido"),
+            @ApiResponse(responseCode = "404", description = "Usuário do token não encontrado")
     })
     @PutMapping
     public ResponseEntity<PreferenciasUsuarioResponseDTO> atualizar(

--- a/src/main/java/com/carlesso/pilatesapi/controller/PreferenciasUsuarioController.java
+++ b/src/main/java/com/carlesso/pilatesapi/controller/PreferenciasUsuarioController.java
@@ -1,0 +1,61 @@
+package com.carlesso.pilatesapi.controller;
+
+import com.carlesso.pilatesapi.dto.PreferenciasUsuarioRequestDTO;
+import com.carlesso.pilatesapi.dto.PreferenciasUsuarioResponseDTO;
+import com.carlesso.pilatesapi.service.PreferenciasUsuarioService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(
+        name = "Preferências do usuário",
+        description = "Consulta e atualização das preferências pessoais do usuário autenticado (idioma, tema e notificações)."
+)
+@RestController
+@RequestMapping("/users/me/preferencias")
+public class PreferenciasUsuarioController {
+
+    private final PreferenciasUsuarioService service;
+
+    public PreferenciasUsuarioController(PreferenciasUsuarioService service) {
+        this.service = service;
+    }
+
+    @Operation(
+            summary = "Consultar preferências do usuário autenticado",
+            description = "Requer autenticação JWT. Retorna as preferências configuradas; usuário sem preferências salvas recebe os valores padrão."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Preferências retornadas com sucesso"),
+            @ApiResponse(responseCode = "401", description = "Token ausente ou inválido")
+    })
+    @GetMapping
+    public ResponseEntity<PreferenciasUsuarioResponseDTO> consultar(Authentication authentication) {
+        return ResponseEntity.ok(service.buscarPorEmail(authentication.getName()));
+    }
+
+    @Operation(
+            summary = "Atualizar preferências do usuário autenticado",
+            description = "Requer autenticação JWT. Atualiza idioma, tema e preferências de notificação do usuário logado."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Preferências atualizadas com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Payload inválido (idioma/tema fora dos valores aceitos ou campos obrigatórios ausentes)"),
+            @ApiResponse(responseCode = "401", description = "Token ausente ou inválido")
+    })
+    @PutMapping
+    public ResponseEntity<PreferenciasUsuarioResponseDTO> atualizar(
+            @RequestBody @Valid PreferenciasUsuarioRequestDTO dto,
+            Authentication authentication) {
+        return ResponseEntity.ok(service.atualizarPorEmail(authentication.getName(), dto));
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/dto/PreferenciasUsuarioRequestDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/PreferenciasUsuarioRequestDTO.java
@@ -1,0 +1,13 @@
+package com.carlesso.pilatesapi.dto;
+
+import com.carlesso.pilatesapi.entity.enums.IdiomaPreferencia;
+import com.carlesso.pilatesapi.entity.enums.TemaPreferencia;
+import jakarta.validation.constraints.NotNull;
+
+public record PreferenciasUsuarioRequestDTO(
+        @NotNull IdiomaPreferencia idioma,
+        @NotNull TemaPreferencia tema,
+        @NotNull Boolean notificacoesEmail,
+        @NotNull Boolean notificacoesPush
+) {
+}

--- a/src/main/java/com/carlesso/pilatesapi/dto/PreferenciasUsuarioResponseDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/PreferenciasUsuarioResponseDTO.java
@@ -1,0 +1,21 @@
+package com.carlesso.pilatesapi.dto;
+
+import com.carlesso.pilatesapi.entity.PreferenciasUsuario;
+import com.carlesso.pilatesapi.entity.enums.IdiomaPreferencia;
+import com.carlesso.pilatesapi.entity.enums.TemaPreferencia;
+
+public record PreferenciasUsuarioResponseDTO(
+        IdiomaPreferencia idioma,
+        TemaPreferencia tema,
+        boolean notificacoesEmail,
+        boolean notificacoesPush
+) {
+    public static PreferenciasUsuarioResponseDTO from(PreferenciasUsuario preferencias) {
+        return new PreferenciasUsuarioResponseDTO(
+                preferencias.getIdioma(),
+                preferencias.getTema(),
+                preferencias.isNotificacoesEmail(),
+                preferencias.isNotificacoesPush()
+        );
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/entity/PreferenciasUsuario.java
+++ b/src/main/java/com/carlesso/pilatesapi/entity/PreferenciasUsuario.java
@@ -1,0 +1,88 @@
+package com.carlesso.pilatesapi.entity;
+
+import com.carlesso.pilatesapi.entity.enums.IdiomaPreferencia;
+import com.carlesso.pilatesapi.entity.enums.TemaPreferencia;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "preferencias_usuario")
+public class PreferenciasUsuario {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private IdiomaPreferencia idioma;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private TemaPreferencia tema;
+
+    @Column(name = "notificacoes_email", nullable = false)
+    private boolean notificacoesEmail;
+
+    @Column(name = "notificacoes_push", nullable = false)
+    private boolean notificacoesPush;
+
+    public PreferenciasUsuario() {}
+
+    public Long getId() {
+        return id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public IdiomaPreferencia getIdioma() {
+        return idioma;
+    }
+
+    public void setIdioma(IdiomaPreferencia idioma) {
+        this.idioma = idioma;
+    }
+
+    public TemaPreferencia getTema() {
+        return tema;
+    }
+
+    public void setTema(TemaPreferencia tema) {
+        this.tema = tema;
+    }
+
+    public boolean isNotificacoesEmail() {
+        return notificacoesEmail;
+    }
+
+    public void setNotificacoesEmail(boolean notificacoesEmail) {
+        this.notificacoesEmail = notificacoesEmail;
+    }
+
+    public boolean isNotificacoesPush() {
+        return notificacoesPush;
+    }
+
+    public void setNotificacoesPush(boolean notificacoesPush) {
+        this.notificacoesPush = notificacoesPush;
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/entity/PreferenciasUsuario.java
+++ b/src/main/java/com/carlesso/pilatesapi/entity/PreferenciasUsuario.java
@@ -12,7 +12,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "preferencias_usuario")
@@ -24,6 +30,7 @@ public class PreferenciasUsuario {
 
     @OneToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false, unique = true)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @Enumerated(EnumType.STRING)
@@ -40,7 +47,23 @@ public class PreferenciasUsuario {
     @Column(name = "notificacoes_push", nullable = false)
     private boolean notificacoesPush;
 
+    @Column(name = "data_criacao", nullable = false)
+    private LocalDateTime dataCriacao;
+
+    @Column(name = "data_atualizacao")
+    private LocalDateTime dataAtualizacao;
+
     public PreferenciasUsuario() {}
+
+    @PrePersist
+    void prePersist() {
+        this.dataCriacao = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    void preUpdate() {
+        this.dataAtualizacao = LocalDateTime.now();
+    }
 
     public Long getId() {
         return id;
@@ -84,5 +107,21 @@ public class PreferenciasUsuario {
 
     public void setNotificacoesPush(boolean notificacoesPush) {
         this.notificacoesPush = notificacoesPush;
+    }
+
+    public LocalDateTime getDataCriacao() {
+        return dataCriacao;
+    }
+
+    public void setDataCriacao(LocalDateTime dataCriacao) {
+        this.dataCriacao = dataCriacao;
+    }
+
+    public LocalDateTime getDataAtualizacao() {
+        return dataAtualizacao;
+    }
+
+    public void setDataAtualizacao(LocalDateTime dataAtualizacao) {
+        this.dataAtualizacao = dataAtualizacao;
     }
 }

--- a/src/main/java/com/carlesso/pilatesapi/entity/enums/IdiomaPreferencia.java
+++ b/src/main/java/com/carlesso/pilatesapi/entity/enums/IdiomaPreferencia.java
@@ -1,0 +1,17 @@
+package com.carlesso.pilatesapi.entity.enums;
+
+public enum IdiomaPreferencia {
+    PT_BR("Português (Brasil)"),
+    EN_US("English (US)"),
+    ES_ES("Español (España)");
+
+    private final String label;
+
+    IdiomaPreferencia(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/entity/enums/TemaPreferencia.java
+++ b/src/main/java/com/carlesso/pilatesapi/entity/enums/TemaPreferencia.java
@@ -1,0 +1,16 @@
+package com.carlesso.pilatesapi.entity.enums;
+
+public enum TemaPreferencia {
+    CLARO("Claro"),
+    ESCURO("Escuro");
+
+    private final String label;
+
+    TemaPreferencia(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/repository/PreferenciasUsuarioRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/PreferenciasUsuarioRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface PreferenciasUsuarioRepository extends JpaRepository<PreferenciasUsuario, Long> {
 
     Optional<PreferenciasUsuario> findByUserId(Long userId);
+
+    Optional<PreferenciasUsuario> findByUserEmail(String email);
 }

--- a/src/main/java/com/carlesso/pilatesapi/repository/PreferenciasUsuarioRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/PreferenciasUsuarioRepository.java
@@ -1,0 +1,11 @@
+package com.carlesso.pilatesapi.repository;
+
+import com.carlesso.pilatesapi.entity.PreferenciasUsuario;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PreferenciasUsuarioRepository extends JpaRepository<PreferenciasUsuario, Long> {
+
+    Optional<PreferenciasUsuario> findByUserId(Long userId);
+}

--- a/src/main/java/com/carlesso/pilatesapi/repository/UserRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/UserRepository.java
@@ -15,6 +15,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select u from User u where u.email = :email")
+    Optional<User> findByEmailForUpdate(@Param("email") String email);
+
     boolean existsByEmail(String email);
 
     boolean existsByEmailAndIdNot(String email, Long id);

--- a/src/main/java/com/carlesso/pilatesapi/service/PreferenciasUsuarioService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/PreferenciasUsuarioService.java
@@ -1,0 +1,78 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.PreferenciasUsuarioRequestDTO;
+import com.carlesso.pilatesapi.dto.PreferenciasUsuarioResponseDTO;
+import com.carlesso.pilatesapi.entity.PreferenciasUsuario;
+import com.carlesso.pilatesapi.entity.User;
+import com.carlesso.pilatesapi.entity.enums.IdiomaPreferencia;
+import com.carlesso.pilatesapi.entity.enums.TemaPreferencia;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
+import com.carlesso.pilatesapi.repository.PreferenciasUsuarioRepository;
+import com.carlesso.pilatesapi.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Locale;
+
+@Service
+public class PreferenciasUsuarioService {
+
+    public static final IdiomaPreferencia IDIOMA_PADRAO = IdiomaPreferencia.PT_BR;
+    public static final TemaPreferencia TEMA_PADRAO = TemaPreferencia.CLARO;
+    public static final boolean NOTIFICACOES_EMAIL_PADRAO = true;
+    public static final boolean NOTIFICACOES_PUSH_PADRAO = false;
+
+    private final PreferenciasUsuarioRepository repository;
+    private final UserRepository userRepository;
+
+    public PreferenciasUsuarioService(PreferenciasUsuarioRepository repository, UserRepository userRepository) {
+        this.repository = repository;
+        this.userRepository = userRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public PreferenciasUsuarioResponseDTO buscarPorEmail(String email) {
+        User user = encontrarUsuario(email);
+        return repository.findByUserId(user.getId())
+                .map(PreferenciasUsuarioResponseDTO::from)
+                .orElseGet(() -> padraoResponse());
+    }
+
+    @Transactional
+    public PreferenciasUsuarioResponseDTO atualizarPorEmail(String email, PreferenciasUsuarioRequestDTO dto) {
+        User user = encontrarUsuario(email);
+        PreferenciasUsuario preferencias = repository.findByUserId(user.getId())
+                .orElseGet(() -> novaComPadroes(user));
+
+        preferencias.setIdioma(dto.idioma());
+        preferencias.setTema(dto.tema());
+        preferencias.setNotificacoesEmail(Boolean.TRUE.equals(dto.notificacoesEmail()));
+        preferencias.setNotificacoesPush(Boolean.TRUE.equals(dto.notificacoesPush()));
+
+        return PreferenciasUsuarioResponseDTO.from(repository.save(preferencias));
+    }
+
+    private User encontrarUsuario(String email) {
+        return userRepository.findByEmail(email.toLowerCase(Locale.ROOT))
+                .orElseThrow(() -> new ResourceNotFoundException("Usuário não encontrado"));
+    }
+
+    private PreferenciasUsuario novaComPadroes(User user) {
+        PreferenciasUsuario preferencias = new PreferenciasUsuario();
+        preferencias.setUser(user);
+        preferencias.setIdioma(IDIOMA_PADRAO);
+        preferencias.setTema(TEMA_PADRAO);
+        preferencias.setNotificacoesEmail(NOTIFICACOES_EMAIL_PADRAO);
+        preferencias.setNotificacoesPush(NOTIFICACOES_PUSH_PADRAO);
+        return preferencias;
+    }
+
+    private PreferenciasUsuarioResponseDTO padraoResponse() {
+        return new PreferenciasUsuarioResponseDTO(
+                IDIOMA_PADRAO,
+                TEMA_PADRAO,
+                NOTIFICACOES_EMAIL_PADRAO,
+                NOTIFICACOES_PUSH_PADRAO
+        );
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/service/PreferenciasUsuarioService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/PreferenciasUsuarioService.java
@@ -32,29 +32,25 @@ public class PreferenciasUsuarioService {
 
     @Transactional(readOnly = true)
     public PreferenciasUsuarioResponseDTO buscarPorEmail(String email) {
-        User user = encontrarUsuario(email);
-        return repository.findByUserId(user.getId())
+        return repository.findByUserEmail(email.toLowerCase(Locale.ROOT))
                 .map(PreferenciasUsuarioResponseDTO::from)
-                .orElseGet(() -> padraoResponse());
+                .orElseGet(this::padraoResponse);
     }
 
     @Transactional
     public PreferenciasUsuarioResponseDTO atualizarPorEmail(String email, PreferenciasUsuarioRequestDTO dto) {
-        User user = encontrarUsuario(email);
+        User user = userRepository.findByEmailForUpdate(email.toLowerCase(Locale.ROOT))
+                .orElseThrow(() -> new ResourceNotFoundException("Usuário não encontrado"));
+
         PreferenciasUsuario preferencias = repository.findByUserId(user.getId())
                 .orElseGet(() -> novaComPadroes(user));
 
         preferencias.setIdioma(dto.idioma());
         preferencias.setTema(dto.tema());
-        preferencias.setNotificacoesEmail(Boolean.TRUE.equals(dto.notificacoesEmail()));
-        preferencias.setNotificacoesPush(Boolean.TRUE.equals(dto.notificacoesPush()));
+        preferencias.setNotificacoesEmail(dto.notificacoesEmail());
+        preferencias.setNotificacoesPush(dto.notificacoesPush());
 
         return PreferenciasUsuarioResponseDTO.from(repository.save(preferencias));
-    }
-
-    private User encontrarUsuario(String email) {
-        return userRepository.findByEmail(email.toLowerCase(Locale.ROOT))
-                .orElseThrow(() -> new ResourceNotFoundException("Usuário não encontrado"));
     }
 
     private PreferenciasUsuario novaComPadroes(User user) {

--- a/src/main/resources/db/migration/V25__create_preferencias_usuario_table.sql
+++ b/src/main/resources/db/migration/V25__create_preferencias_usuario_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE preferencias_usuario (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL UNIQUE REFERENCES users(id),
+    idioma VARCHAR(20) NOT NULL,
+    tema VARCHAR(20) NOT NULL,
+    notificacoes_email BOOLEAN NOT NULL,
+    notificacoes_push BOOLEAN NOT NULL
+);

--- a/src/main/resources/db/migration/V25__create_preferencias_usuario_table.sql
+++ b/src/main/resources/db/migration/V25__create_preferencias_usuario_table.sql
@@ -1,8 +1,10 @@
 CREATE TABLE preferencias_usuario (
     id BIGSERIAL PRIMARY KEY,
-    user_id BIGINT NOT NULL UNIQUE REFERENCES users(id),
+    user_id BIGINT NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
     idioma VARCHAR(20) NOT NULL,
     tema VARCHAR(20) NOT NULL,
     notificacoes_email BOOLEAN NOT NULL,
-    notificacoes_push BOOLEAN NOT NULL
+    notificacoes_push BOOLEAN NOT NULL,
+    data_criacao TIMESTAMP NOT NULL,
+    data_atualizacao TIMESTAMP
 );

--- a/src/test/java/com/carlesso/pilatesapi/controller/PreferenciasUsuarioControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/PreferenciasUsuarioControllerTest.java
@@ -148,4 +148,24 @@ class PreferenciasUsuarioControllerTest {
 
         verify(service, never()).atualizarPorEmail(any(), any());
     }
+
+    @Test
+    void atualizar_comCamposExplicitamenteNull_deveRetornar400() throws Exception {
+        String payload = """
+                {
+                  "idioma": null,
+                  "tema": null,
+                  "notificacoesEmail": null,
+                  "notificacoesPush": null
+                }
+                """;
+
+        mvc.perform(put("/users/me/preferencias")
+                        .principal(userAuth("user@email.com"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isBadRequest());
+
+        verify(service, never()).atualizarPorEmail(any(), any());
+    }
 }

--- a/src/test/java/com/carlesso/pilatesapi/controller/PreferenciasUsuarioControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/PreferenciasUsuarioControllerTest.java
@@ -1,0 +1,151 @@
+package com.carlesso.pilatesapi.controller;
+
+import com.carlesso.pilatesapi.dto.PreferenciasUsuarioRequestDTO;
+import com.carlesso.pilatesapi.dto.PreferenciasUsuarioResponseDTO;
+import com.carlesso.pilatesapi.entity.enums.IdiomaPreferencia;
+import com.carlesso.pilatesapi.entity.enums.TemaPreferencia;
+import com.carlesso.pilatesapi.service.CustomUserDetailsService;
+import com.carlesso.pilatesapi.service.JwtService;
+import com.carlesso.pilatesapi.service.PreferenciasUsuarioService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PreferenciasUsuarioController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class PreferenciasUsuarioControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockitoBean
+    private PreferenciasUsuarioService service;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    private Authentication userAuth(String email) {
+        return new UsernamePasswordAuthenticationToken(
+                email, null, List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    }
+
+    @Test
+    void consultar_deveRetornar200ComPreferencias() throws Exception {
+        var response = new PreferenciasUsuarioResponseDTO(
+                IdiomaPreferencia.PT_BR, TemaPreferencia.CLARO, true, false);
+        when(service.buscarPorEmail("user@email.com")).thenReturn(response);
+
+        mvc.perform(get("/users/me/preferencias")
+                        .principal(userAuth("user@email.com")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.idioma").value("PT_BR"))
+                .andExpect(jsonPath("$.tema").value("CLARO"))
+                .andExpect(jsonPath("$.notificacoesEmail").value(true))
+                .andExpect(jsonPath("$.notificacoesPush").value(false));
+    }
+
+    @Test
+    void atualizar_comDadosValidos_deveRetornar200() throws Exception {
+        var dto = new PreferenciasUsuarioRequestDTO(
+                IdiomaPreferencia.EN_US, TemaPreferencia.ESCURO, false, true);
+        var response = new PreferenciasUsuarioResponseDTO(
+                IdiomaPreferencia.EN_US, TemaPreferencia.ESCURO, false, true);
+        when(service.atualizarPorEmail(eq("user@email.com"), any())).thenReturn(response);
+
+        mvc.perform(put("/users/me/preferencias")
+                        .principal(userAuth("user@email.com"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.idioma").value("EN_US"))
+                .andExpect(jsonPath("$.tema").value("ESCURO"))
+                .andExpect(jsonPath("$.notificacoesEmail").value(false))
+                .andExpect(jsonPath("$.notificacoesPush").value(true));
+
+        verify(service).atualizarPorEmail(eq("user@email.com"), any());
+    }
+
+    @Test
+    void atualizar_comIdiomaInvalido_deveRetornar400() throws Exception {
+        String payload = """
+                {
+                  "idioma": "INVALIDO",
+                  "tema": "CLARO",
+                  "notificacoesEmail": true,
+                  "notificacoesPush": true
+                }
+                """;
+
+        mvc.perform(put("/users/me/preferencias")
+                        .principal(userAuth("user@email.com"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isBadRequest());
+
+        verify(service, never()).atualizarPorEmail(any(), any());
+    }
+
+    @Test
+    void atualizar_comTemaInvalido_deveRetornar400() throws Exception {
+        String payload = """
+                {
+                  "idioma": "PT_BR",
+                  "tema": "NEON",
+                  "notificacoesEmail": true,
+                  "notificacoesPush": true
+                }
+                """;
+
+        mvc.perform(put("/users/me/preferencias")
+                        .principal(userAuth("user@email.com"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isBadRequest());
+
+        verify(service, never()).atualizarPorEmail(any(), any());
+    }
+
+    @Test
+    void atualizar_comCampoObrigatorioFaltando_deveRetornar400() throws Exception {
+        String payload = """
+                {
+                  "idioma": "PT_BR",
+                  "tema": "CLARO"
+                }
+                """;
+
+        mvc.perform(put("/users/me/preferencias")
+                        .principal(userAuth("user@email.com"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isBadRequest());
+
+        verify(service, never()).atualizarPorEmail(any(), any());
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/repository/PreferenciasUsuarioRepositoryTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/repository/PreferenciasUsuarioRepositoryTest.java
@@ -1,0 +1,119 @@
+package com.carlesso.pilatesapi.repository;
+
+import com.carlesso.pilatesapi.entity.PreferenciasUsuario;
+import com.carlesso.pilatesapi.entity.User;
+import com.carlesso.pilatesapi.entity.enums.IdiomaPreferencia;
+import com.carlesso.pilatesapi.entity.enums.Role;
+import com.carlesso.pilatesapi.entity.enums.TemaPreferencia;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest(showSql = false)
+class PreferenciasUsuarioRepositoryTest {
+
+    @Autowired
+    private PreferenciasUsuarioRepository repository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Test
+    void persistirEBuscarPorUserId_devePreservarEnumsEFlags() {
+        User user = persistirUsuario("persist@email.com");
+        PreferenciasUsuario salvas = entityManager.persistAndFlush(
+                preferencias(user, IdiomaPreferencia.EN_US, TemaPreferencia.ESCURO, false, true));
+        entityManager.clear();
+
+        Optional<PreferenciasUsuario> encontradas = repository.findByUserId(user.getId());
+
+        assertThat(encontradas).isPresent();
+        assertThat(encontradas.get().getId()).isEqualTo(salvas.getId());
+        assertThat(encontradas.get().getIdioma()).isEqualTo(IdiomaPreferencia.EN_US);
+        assertThat(encontradas.get().getTema()).isEqualTo(TemaPreferencia.ESCURO);
+        assertThat(encontradas.get().isNotificacoesEmail()).isFalse();
+        assertThat(encontradas.get().isNotificacoesPush()).isTrue();
+        assertThat(encontradas.get().getDataCriacao()).isNotNull();
+    }
+
+    @Test
+    void findByUserEmail_deveRetornarPreferenciasDoUsuario() {
+        User user = persistirUsuario("byemail@email.com");
+        entityManager.persistAndFlush(
+                preferencias(user, IdiomaPreferencia.ES_ES, TemaPreferencia.CLARO, true, true));
+        entityManager.clear();
+
+        Optional<PreferenciasUsuario> encontradas = repository.findByUserEmail("byemail@email.com");
+
+        assertThat(encontradas).isPresent();
+        assertThat(encontradas.get().getIdioma()).isEqualTo(IdiomaPreferencia.ES_ES);
+        assertThat(encontradas.get().getTema()).isEqualTo(TemaPreferencia.CLARO);
+    }
+
+    @Test
+    void findByUserEmail_quandoSemPreferencias_deveRetornarVazio() {
+        persistirUsuario("sem-prefs@email.com");
+
+        assertThat(repository.findByUserEmail("sem-prefs@email.com")).isEmpty();
+    }
+
+    @Test
+    void persistir_dois_registros_paraMesmoUsuario_deveFalharPorUniqueConstraint() {
+        User user = persistirUsuario("unique@email.com");
+        entityManager.persistAndFlush(
+                preferencias(user, IdiomaPreferencia.PT_BR, TemaPreferencia.CLARO, true, false));
+
+        PreferenciasUsuario duplicada = preferencias(user, IdiomaPreferencia.EN_US, TemaPreferencia.ESCURO, false, true);
+
+        assertThatThrownBy(() -> entityManager.persistAndFlush(duplicada))
+                .isInstanceOfAny(DataIntegrityViolationException.class, jakarta.persistence.PersistenceException.class);
+    }
+
+    @Test
+    void atualizar_devePreencherDataAtualizacao() {
+        User user = persistirUsuario("update@email.com");
+        PreferenciasUsuario salvas = entityManager.persistAndFlush(
+                preferencias(user, IdiomaPreferencia.PT_BR, TemaPreferencia.CLARO, true, false));
+        assertThat(salvas.getDataAtualizacao()).isNull();
+
+        salvas.setTema(TemaPreferencia.ESCURO);
+        entityManager.persistAndFlush(salvas);
+        entityManager.clear();
+
+        PreferenciasUsuario recarregadas = repository.findById(salvas.getId()).orElseThrow();
+        assertThat(recarregadas.getDataAtualizacao()).isNotNull();
+        assertThat(recarregadas.getTema()).isEqualTo(TemaPreferencia.ESCURO);
+    }
+
+    private User persistirUsuario(String email) {
+        User user = new User();
+        user.setName("Usuário " + email);
+        user.setEmail(email);
+        user.setPassword("hash");
+        user.setRole(Role.USER);
+        user.setAtivo(true);
+        return entityManager.persist(user);
+    }
+
+    private PreferenciasUsuario preferencias(
+            User user,
+            IdiomaPreferencia idioma,
+            TemaPreferencia tema,
+            boolean notificacoesEmail,
+            boolean notificacoesPush) {
+        PreferenciasUsuario p = new PreferenciasUsuario();
+        p.setUser(user);
+        p.setIdioma(idioma);
+        p.setTema(tema);
+        p.setNotificacoesEmail(notificacoesEmail);
+        p.setNotificacoesPush(notificacoesPush);
+        return p;
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/security/SecurityIntegrationTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/security/SecurityIntegrationTest.java
@@ -491,6 +491,63 @@ class SecurityIntegrationTest {
     }
 
     @Test
+    void preferencias_get_semToken_deveRetornar401() throws Exception {
+        mvc.perform(get("/users/me/preferencias"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void preferencias_get_comUsuarioComum_deveRetornarPadroes() throws Exception {
+        User user = criarUsuario("prefs-get@email.com", Role.USER);
+
+        mvc.perform(get("/users/me/preferencias")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(user)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.idioma").value("PT_BR"))
+                .andExpect(jsonPath("$.tema").value("CLARO"))
+                .andExpect(jsonPath("$.notificacoesEmail").value(true))
+                .andExpect(jsonPath("$.notificacoesPush").value(false));
+    }
+
+    @Test
+    void preferencias_get_comAdmin_deveRetornar200() throws Exception {
+        User admin = criarUsuario("prefs-admin@email.com", Role.ADMIN);
+
+        mvc.perform(get("/users/me/preferencias")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(admin)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void preferencias_put_comUsuarioComum_devePersistirEReturnarValoresAtualizados() throws Exception {
+        User user = criarUsuario("prefs-put@email.com", Role.USER);
+        String payload = """
+                {
+                  "idioma": "EN_US",
+                  "tema": "ESCURO",
+                  "notificacoesEmail": false,
+                  "notificacoesPush": true
+                }
+                """;
+
+        mvc.perform(put("/users/me/preferencias")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(user))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.idioma").value("EN_US"))
+                .andExpect(jsonPath("$.tema").value("ESCURO"))
+                .andExpect(jsonPath("$.notificacoesEmail").value(false))
+                .andExpect(jsonPath("$.notificacoesPush").value(true));
+
+        mvc.perform(get("/users/me/preferencias")
+                        .header(HttpHeaders.AUTHORIZATION, bearer(user)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.idioma").value("EN_US"))
+                .andExpect(jsonPath("$.tema").value("ESCURO"));
+    }
+
+    @Test
     void dashboardResumo_semToken_deveRetornar401() throws Exception {
         mvc.perform(get("/dashboard/resumo"))
                 .andExpect(status().isUnauthorized());

--- a/src/test/java/com/carlesso/pilatesapi/service/PreferenciasUsuarioServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/PreferenciasUsuarioServiceTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -56,9 +57,7 @@ class PreferenciasUsuarioServiceTest {
 
     @Test
     void buscarPorEmail_semPreferenciasSalvas_deveRetornarPadroes() {
-        User user = usuario(1L, "novo@email.com");
-        when(userRepository.findByEmail("novo@email.com")).thenReturn(Optional.of(user));
-        when(repository.findByUserId(1L)).thenReturn(Optional.empty());
+        when(repository.findByUserEmail("novo@email.com")).thenReturn(Optional.empty());
 
         PreferenciasUsuarioResponseDTO response = service.buscarPorEmail("novo@email.com");
 
@@ -67,6 +66,7 @@ class PreferenciasUsuarioServiceTest {
         assertThat(response.notificacoesEmail()).isEqualTo(PreferenciasUsuarioService.NOTIFICACOES_EMAIL_PADRAO);
         assertThat(response.notificacoesPush()).isEqualTo(PreferenciasUsuarioService.NOTIFICACOES_PUSH_PADRAO);
         verify(repository, never()).save(any());
+        verifyNoInteractions(userRepository);
     }
 
     @Test
@@ -78,8 +78,7 @@ class PreferenciasUsuarioServiceTest {
         salvas.setTema(TemaPreferencia.ESCURO);
         salvas.setNotificacoesEmail(false);
         salvas.setNotificacoesPush(true);
-        when(userRepository.findByEmail("salvo@email.com")).thenReturn(Optional.of(user));
-        when(repository.findByUserId(1L)).thenReturn(Optional.of(salvas));
+        when(repository.findByUserEmail("salvo@email.com")).thenReturn(Optional.of(salvas));
 
         PreferenciasUsuarioResponseDTO response = service.buscarPorEmail("salvo@email.com");
 
@@ -91,28 +90,17 @@ class PreferenciasUsuarioServiceTest {
 
     @Test
     void buscarPorEmail_emailNormalizadoParaLowercase() {
-        User user = usuario(1L, "minusculo@email.com");
-        when(userRepository.findByEmail("minusculo@email.com")).thenReturn(Optional.of(user));
-        when(repository.findByUserId(1L)).thenReturn(Optional.empty());
+        when(repository.findByUserEmail("minusculo@email.com")).thenReturn(Optional.empty());
 
         service.buscarPorEmail("MINUSCULO@EMAIL.COM");
 
-        verify(userRepository).findByEmail("minusculo@email.com");
-    }
-
-    @Test
-    void buscarPorEmail_usuarioInexistente_deveLancar404() {
-        when(userRepository.findByEmail("naoexiste@email.com")).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() -> service.buscarPorEmail("naoexiste@email.com"))
-                .isInstanceOf(ResourceNotFoundException.class)
-                .hasMessage("Usuário não encontrado");
+        verify(repository).findByUserEmail("minusculo@email.com");
     }
 
     @Test
     void atualizarPorEmail_semPreferenciasSalvas_deveCriarComValoresDoDTO() {
         User user = usuario(1L, "novo@email.com");
-        when(userRepository.findByEmail("novo@email.com")).thenReturn(Optional.of(user));
+        when(userRepository.findByEmailForUpdate("novo@email.com")).thenReturn(Optional.of(user));
         when(repository.findByUserId(1L)).thenReturn(Optional.empty());
         when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
         var dto = new PreferenciasUsuarioRequestDTO(IdiomaPreferencia.ES_ES, TemaPreferencia.ESCURO, false, true);
@@ -139,7 +127,7 @@ class PreferenciasUsuarioServiceTest {
         existente.setTema(TemaPreferencia.CLARO);
         existente.setNotificacoesEmail(true);
         existente.setNotificacoesPush(false);
-        when(userRepository.findByEmail("existente@email.com")).thenReturn(Optional.of(user));
+        when(userRepository.findByEmailForUpdate("existente@email.com")).thenReturn(Optional.of(user));
         when(repository.findByUserId(1L)).thenReturn(Optional.of(existente));
         when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
         var dto = new PreferenciasUsuarioRequestDTO(IdiomaPreferencia.EN_US, TemaPreferencia.ESCURO, false, true);
@@ -157,12 +145,26 @@ class PreferenciasUsuarioServiceTest {
     }
 
     @Test
+    void atualizarPorEmail_emailNormalizadoParaLowercase() {
+        User user = usuario(1L, "minusculo@email.com");
+        when(userRepository.findByEmailForUpdate("minusculo@email.com")).thenReturn(Optional.of(user));
+        when(repository.findByUserId(1L)).thenReturn(Optional.empty());
+        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        var dto = new PreferenciasUsuarioRequestDTO(IdiomaPreferencia.PT_BR, TemaPreferencia.CLARO, true, false);
+
+        service.atualizarPorEmail("MINUSCULO@EMAIL.COM", dto);
+
+        verify(userRepository).findByEmailForUpdate("minusculo@email.com");
+    }
+
+    @Test
     void atualizarPorEmail_usuarioInexistente_deveLancar404() {
-        when(userRepository.findByEmail("naoexiste@email.com")).thenReturn(Optional.empty());
+        when(userRepository.findByEmailForUpdate("naoexiste@email.com")).thenReturn(Optional.empty());
         var dto = new PreferenciasUsuarioRequestDTO(IdiomaPreferencia.PT_BR, TemaPreferencia.CLARO, true, true);
 
         assertThatThrownBy(() -> service.atualizarPorEmail("naoexiste@email.com", dto))
-                .isInstanceOf(ResourceNotFoundException.class);
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Usuário não encontrado");
         verify(repository, never()).save(any());
     }
 }

--- a/src/test/java/com/carlesso/pilatesapi/service/PreferenciasUsuarioServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/PreferenciasUsuarioServiceTest.java
@@ -1,0 +1,168 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.PreferenciasUsuarioRequestDTO;
+import com.carlesso.pilatesapi.dto.PreferenciasUsuarioResponseDTO;
+import com.carlesso.pilatesapi.entity.PreferenciasUsuario;
+import com.carlesso.pilatesapi.entity.User;
+import com.carlesso.pilatesapi.entity.enums.IdiomaPreferencia;
+import com.carlesso.pilatesapi.entity.enums.Role;
+import com.carlesso.pilatesapi.entity.enums.TemaPreferencia;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
+import com.carlesso.pilatesapi.repository.PreferenciasUsuarioRepository;
+import com.carlesso.pilatesapi.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PreferenciasUsuarioServiceTest {
+
+    @Mock
+    private PreferenciasUsuarioRepository repository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private PreferenciasUsuarioService service;
+
+    private User usuario(Long id, String email) {
+        User u = new User();
+        u.setName("Teste");
+        u.setEmail(email);
+        u.setPassword("hash");
+        u.setRole(Role.USER);
+        try {
+            var field = User.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(u, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return u;
+    }
+
+    @Test
+    void buscarPorEmail_semPreferenciasSalvas_deveRetornarPadroes() {
+        User user = usuario(1L, "novo@email.com");
+        when(userRepository.findByEmail("novo@email.com")).thenReturn(Optional.of(user));
+        when(repository.findByUserId(1L)).thenReturn(Optional.empty());
+
+        PreferenciasUsuarioResponseDTO response = service.buscarPorEmail("novo@email.com");
+
+        assertThat(response.idioma()).isEqualTo(PreferenciasUsuarioService.IDIOMA_PADRAO);
+        assertThat(response.tema()).isEqualTo(PreferenciasUsuarioService.TEMA_PADRAO);
+        assertThat(response.notificacoesEmail()).isEqualTo(PreferenciasUsuarioService.NOTIFICACOES_EMAIL_PADRAO);
+        assertThat(response.notificacoesPush()).isEqualTo(PreferenciasUsuarioService.NOTIFICACOES_PUSH_PADRAO);
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void buscarPorEmail_comPreferenciasSalvas_deveRetornarValoresPersistidos() {
+        User user = usuario(1L, "salvo@email.com");
+        PreferenciasUsuario salvas = new PreferenciasUsuario();
+        salvas.setUser(user);
+        salvas.setIdioma(IdiomaPreferencia.EN_US);
+        salvas.setTema(TemaPreferencia.ESCURO);
+        salvas.setNotificacoesEmail(false);
+        salvas.setNotificacoesPush(true);
+        when(userRepository.findByEmail("salvo@email.com")).thenReturn(Optional.of(user));
+        when(repository.findByUserId(1L)).thenReturn(Optional.of(salvas));
+
+        PreferenciasUsuarioResponseDTO response = service.buscarPorEmail("salvo@email.com");
+
+        assertThat(response.idioma()).isEqualTo(IdiomaPreferencia.EN_US);
+        assertThat(response.tema()).isEqualTo(TemaPreferencia.ESCURO);
+        assertThat(response.notificacoesEmail()).isFalse();
+        assertThat(response.notificacoesPush()).isTrue();
+    }
+
+    @Test
+    void buscarPorEmail_emailNormalizadoParaLowercase() {
+        User user = usuario(1L, "minusculo@email.com");
+        when(userRepository.findByEmail("minusculo@email.com")).thenReturn(Optional.of(user));
+        when(repository.findByUserId(1L)).thenReturn(Optional.empty());
+
+        service.buscarPorEmail("MINUSCULO@EMAIL.COM");
+
+        verify(userRepository).findByEmail("minusculo@email.com");
+    }
+
+    @Test
+    void buscarPorEmail_usuarioInexistente_deveLancar404() {
+        when(userRepository.findByEmail("naoexiste@email.com")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.buscarPorEmail("naoexiste@email.com"))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("Usuário não encontrado");
+    }
+
+    @Test
+    void atualizarPorEmail_semPreferenciasSalvas_deveCriarComValoresDoDTO() {
+        User user = usuario(1L, "novo@email.com");
+        when(userRepository.findByEmail("novo@email.com")).thenReturn(Optional.of(user));
+        when(repository.findByUserId(1L)).thenReturn(Optional.empty());
+        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        var dto = new PreferenciasUsuarioRequestDTO(IdiomaPreferencia.ES_ES, TemaPreferencia.ESCURO, false, true);
+
+        PreferenciasUsuarioResponseDTO response = service.atualizarPorEmail("novo@email.com", dto);
+
+        ArgumentCaptor<PreferenciasUsuario> captor = ArgumentCaptor.forClass(PreferenciasUsuario.class);
+        verify(repository).save(captor.capture());
+        PreferenciasUsuario salvas = captor.getValue();
+        assertThat(salvas.getUser()).isEqualTo(user);
+        assertThat(salvas.getIdioma()).isEqualTo(IdiomaPreferencia.ES_ES);
+        assertThat(salvas.getTema()).isEqualTo(TemaPreferencia.ESCURO);
+        assertThat(salvas.isNotificacoesEmail()).isFalse();
+        assertThat(salvas.isNotificacoesPush()).isTrue();
+        assertThat(response.idioma()).isEqualTo(IdiomaPreferencia.ES_ES);
+    }
+
+    @Test
+    void atualizarPorEmail_comPreferenciasExistentes_deveAtualizarMesmoRegistro() {
+        User user = usuario(1L, "existente@email.com");
+        PreferenciasUsuario existente = new PreferenciasUsuario();
+        existente.setUser(user);
+        existente.setIdioma(IdiomaPreferencia.PT_BR);
+        existente.setTema(TemaPreferencia.CLARO);
+        existente.setNotificacoesEmail(true);
+        existente.setNotificacoesPush(false);
+        when(userRepository.findByEmail("existente@email.com")).thenReturn(Optional.of(user));
+        when(repository.findByUserId(1L)).thenReturn(Optional.of(existente));
+        when(repository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        var dto = new PreferenciasUsuarioRequestDTO(IdiomaPreferencia.EN_US, TemaPreferencia.ESCURO, false, true);
+
+        PreferenciasUsuarioResponseDTO response = service.atualizarPorEmail("existente@email.com", dto);
+
+        ArgumentCaptor<PreferenciasUsuario> captor = ArgumentCaptor.forClass(PreferenciasUsuario.class);
+        verify(repository).save(captor.capture());
+        assertThat(captor.getValue()).isSameAs(existente);
+        assertThat(existente.getIdioma()).isEqualTo(IdiomaPreferencia.EN_US);
+        assertThat(existente.getTema()).isEqualTo(TemaPreferencia.ESCURO);
+        assertThat(existente.isNotificacoesEmail()).isFalse();
+        assertThat(existente.isNotificacoesPush()).isTrue();
+        assertThat(response.notificacoesPush()).isTrue();
+    }
+
+    @Test
+    void atualizarPorEmail_usuarioInexistente_deveLancar404() {
+        when(userRepository.findByEmail("naoexiste@email.com")).thenReturn(Optional.empty());
+        var dto = new PreferenciasUsuarioRequestDTO(IdiomaPreferencia.PT_BR, TemaPreferencia.CLARO, true, true);
+
+        assertThatThrownBy(() -> service.atualizarPorEmail("naoexiste@email.com", dto))
+                .isInstanceOf(ResourceNotFoundException.class);
+        verify(repository, never()).save(any());
+    }
+}


### PR DESCRIPTION
## Resumo

- Cria a entidade `PreferenciasUsuario` com relacionamento 1:1 com `users` (migration `V25`) para armazenar idioma, tema e preferências de notificação por usuário.
- Adiciona os endpoints `GET /users/me/preferencias` e `PUT /users/me/preferencias` para o usuário autenticado consultar e atualizar suas próprias preferências.
- Centraliza os valores padrão em `PreferenciasUsuarioService` (`PT_BR`, `CLARO`, `notificacoesEmail=true`, `notificacoesPush=false`); usuários sem preferências salvas recebem esses valores no GET.
- Idioma e tema validados via enums (`IdiomaPreferencia`: `PT_BR`/`EN_US`/`ES_ES`; `TemaPreferencia`: `CLARO`/`ESCURO`) — valores fora da lista retornam `400`.

## Motivo

Atende a issue #79: hoje a aplicação tem comportamento fixo para todos os usuários, limitando a adaptação ao fluxo de cada um. Esta entrega permite parametrização persistente por usuário, com isolamento natural (cada registro vinculado ao `user_id`) e valores padrão para quem ainda não configurou.

## Arquivos principais alterados

- `entity/PreferenciasUsuario.java`, `entity/enums/IdiomaPreferencia.java`, `entity/enums/TemaPreferencia.java`
- `repository/PreferenciasUsuarioRepository.java`
- `service/PreferenciasUsuarioService.java`
- `controller/PreferenciasUsuarioController.java`
- `dto/PreferenciasUsuarioRequestDTO.java`, `dto/PreferenciasUsuarioResponseDTO.java`
- `resources/db/migration/V25__create_preferencias_usuario_table.sql`
- `config/SecurityConfig.java` — libera `/users/me/preferencias` para usuários autenticados (USER/ADMIN), mantendo `/users/**` restrito a ADMIN
- `README.md` — endpoints, payload e migration documentados

## Testes executados

- `JAVA_HOME=~/jdk mvn test` → **468 testes, 0 falhas, 0 erros**
- Novos testes:
  - `PreferenciasUsuarioServiceTest` (7) — padrões para usuário novo, persistência, isolamento por usuário, atualização de registro existente, normalização de e-mail, 404 para usuário inexistente
  - `PreferenciasUsuarioControllerTest` (5) — GET, PUT válido, validação de idioma/tema inválido e campos obrigatórios

## Test plan

- [x] GET para usuário sem preferências → retorna padrões
- [x] PUT cria preferências quando não existem; atualiza o mesmo registro quando já existem
- [x] Idioma/tema inválido → 400 (Bean Validation pelo enum)
- [x] Campos obrigatórios ausentes → 400
- [x] Suíte completa de testes verde

Refs #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)