### PR TITLE
feat(nfse): persiste última NFSE emitida por paciente/competência

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,13 @@ As demais rotas de negócio exigem `Authorization: Bearer <accessToken>`. Tokens
 |---|---|---|
 | `GET` | `/api/relatorios/nfse` | Gerar relatório de emissão de NFSEs por competência (JSON, CSV ou XLSX) |
 
+### NFSE emitidas
+
+| Método | Endpoint | Descrição |
+|---|---|---|
+| `POST` | `/api/nfse-emitidas` | Registrar ou atualizar a NFSE emitida de um paciente em uma competência |
+| `GET` | `/api/nfse-emitidas/paciente/{pacienteId}` | Listar as NFSEs emitidas registradas para um paciente |
+
 ### Dashboard
 
 | Método | Endpoint | Descrição |
@@ -449,7 +456,47 @@ Contrato JSON:
 ]
 ```
 
-Para o modelo atual, `notaAnteriorEmitida` é inferido pela existência de pagamento confirmado anterior para o mesmo paciente. CSV e XLSX são retornados como anexo com nome `relatorio-nfse-{MM-AAAA}.{ext}`.
+O campo `notaAnteriorEmitida` é preenchido com base nas NFSEs efetivamente registradas: é `true` quando existe uma NFSE emitida para o paciente em uma competência anterior à consultada (ver seção abaixo). CSV e XLSX são retornados como anexo com nome `relatorio-nfse-{MM-AAAA}.{ext}`.
+
+### NFSE emitidas — registro fiscal
+
+Para que o relatório use dados reais em `notaAnteriorEmitida`, a última NFSE emitida de cada paciente é persistida por competência através de `POST /api/nfse-emitidas`. O registro é idempotente por `(paciente, competência)`: se já existir uma nota para o paciente na competência informada, ela é atualizada; caso contrário, é criada.
+
+Corpo da requisição:
+
+```json
+{
+  "pacienteId": 1,
+  "competencia": "04/2026",
+  "numeroNota": "NF-2026-000123",
+  "dataEmissao": "2026-04-30",
+  "valor": 250.00,
+  "observacoes": "Emitida pelo portal municipal"
+}
+```
+
+- `pacienteId` e `dataEmissao` são obrigatórios; o paciente precisa estar ativo (404 caso contrário).
+- `competencia` é obrigatória no formato `MM/AAAA` (400 quando fora do formato).
+- `numeroNota`, `valor` e `observacoes` são opcionais; quando informado, `valor` deve ser maior que zero (422 caso contrário).
+
+Resposta (`200 OK`):
+
+```json
+{
+  "id": 10,
+  "pacienteId": 1,
+  "nomePaciente": "Ana Souza",
+  "competencia": "04/2026",
+  "numeroNota": "NF-2026-000123",
+  "dataEmissao": "2026-04-30",
+  "valor": 250.00,
+  "observacoes": "Emitida pelo portal municipal",
+  "dataCriacao": "2026-05-01T10:00:00",
+  "dataAtualizacao": null
+}
+```
+
+`GET /api/nfse-emitidas/paciente/{pacienteId}` retorna as notas registradas do paciente, da competência mais recente para a mais antiga.
 
 ---
 
@@ -955,6 +1002,15 @@ curl -s -OJ "http://localhost:8080/api/relatorios/nfse?competencia=04/2026&forma
   -H "Authorization: Bearer $TOKEN"
 ```
 
+### Registrar NFSE emitida
+```bash
+curl -s -X POST "http://localhost:8080/api/nfse-emitidas" \
+  -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"pacienteId":1,"competencia":"04/2026","numeroNota":"NF-2026-000123","dataEmissao":"2026-04-30","valor":250.00}' | jq
+curl -s "http://localhost:8080/api/nfse-emitidas/paciente/1" \
+  -H "Authorization: Bearer $TOKEN" | jq
+```
+
 ---
 
 ## Regras de Negócio
@@ -997,8 +1053,9 @@ curl -s -OJ "http://localhost:8080/api/relatorios/nfse?competencia=04/2026&forma
 - Pacientes inativos são ignorados
 - `Nome`, `CPF/CNPJ`, `ValorPago` e `DataPagamento` vêm do paciente e do pagamento confirmado
 - `DescricaoServico` é gerada automaticamente como `Aulas de Pilates - Competência MM/AAAA`
-- `NotaAnteriorEmitida` é inferida por pagamento confirmado anterior do mesmo paciente
+- `NotaAnteriorEmitida` é baseada nas NFSEs emitidas persistidas: `true` quando há nota registrada para o paciente em competência anterior à consultada
 - Registros sem nome, CPF/CNPJ, valor positivo ou data de pagamento retornam erro de regra de negócio (`422`)
+- As NFSEs emitidas são persistidas por `(paciente, competência)` via `POST /api/nfse-emitidas`; o registro é idempotente (atualiza a nota existente da competência) e exige paciente ativo
 
 ### Geração de Aulas
 - Aulas geradas com base nos dias da semana do plano e no período do pagamento
@@ -1090,6 +1147,7 @@ O projeto possui testes unitários, de controller e de integração organizados 
 | `RelatorioPagamentoExporterServiceTest` | Unitário | 3 |
 | `RelatorioNfseServiceTest` | Unitário (Mockito) | 5 |
 | `RelatorioNfseExporterServiceTest` | Unitário | 3 |
+| `NotaFiscalEmitidaServiceTest` | Unitário (Mockito) | 6 |
 | `AppPropertiesTest` | Unitário (ApplicationContextRunner) | 3 |
 | `GlobalExceptionHandlerTest` | Unitário | 7 |
 | `PacienteServiceIntegrationTest` | JPA (`@DataJpaTest`) | 4 |
@@ -1097,7 +1155,8 @@ O projeto possui testes unitários, de controller e de integração organizados 
 | `PagamentoServiceAtomicidadeIntegrationTest` | Integração (`@SpringBootTest` + H2) | 1 |
 | `CobrancaSchedulerIntegrationTest` | JPA (`@DataJpaTest`) | 11 |
 | `AulaRepositoryTest` | JPA (`@DataJpaTest`) | 6 |
-| `PagamentoRepositoryTest` | JPA (`@DataJpaTest`) | 2 |
+| `PagamentoRepositoryTest` | JPA (`@DataJpaTest`) | 1 |
+| `NotaFiscalEmitidaRepositoryTest` | JPA (`@DataJpaTest`) | 3 |
 | `SessaoPilatesRepositoryTest` | JPA (`@DataJpaTest`) | 4 |
 | `PacienteControllerTest` | Controller (`@WebMvcTest`) | 16 |
 | `PlanoControllerTest` | Controller (`@WebMvcTest`) | 11 |
@@ -1109,6 +1168,7 @@ O projeto possui testes unitários, de controller e de integração organizados 
 | `SessaoPilatesControllerTest` | Controller (`@WebMvcTest`) | 21 |
 | `ProfissionalControllerTest` | Controller (`@WebMvcTest`) | 17 |
 | `RelatorioNfseControllerTest` | Controller (`@WebMvcTest`) | 6 |
+| `NotaFiscalEmitidaControllerTest` | Controller (`@WebMvcTest`) | 4 |
 | `DashboardControllerTest` | Controller (`@WebMvcTest`) | 2 |
 | `DashboardServiceTest` | Unitário (Mockito) | 3 |
 | `SessaoPilatesServiceTest` | Unitário (Mockito) | 25 |

--- a/README.md
+++ b/README.md
@@ -475,9 +475,10 @@ Corpo da requisição:
 }
 ```
 
-- `pacienteId` e `dataEmissao` são obrigatórios; o paciente precisa estar ativo (404 caso contrário).
+- `pacienteId` e `dataEmissao` são obrigatórios; o paciente precisa estar ativo (404 caso contrário). `dataEmissao` não pode ser futura (422 caso contrário).
 - `competencia` é obrigatória no formato `MM/AAAA` (400 quando fora do formato).
-- `numeroNota`, `valor` e `observacoes` são opcionais; quando informado, `valor` deve ser maior que zero (422 caso contrário).
+- `numeroNota` é opcional e limitado a 60 caracteres (400 quando excedido); `valor` e `observacoes` são opcionais; quando informado, `valor` deve ser maior que zero (422 caso contrário).
+- O registro é idempotente por `(paciente, competência)` inclusive sob concorrência: requisições simultâneas para o mesmo par resolvem para uma única nota (a colisão da constraint única é repetida automaticamente como atualização).
 
 Resposta (`200 OK`):
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -596,7 +596,8 @@ CPF não pode ser alterado após o cadastro.
 - O filtro opcional `notaAnteriorEmitida` permite retornar apenas registros com ou sem nota anterior emitida
 - `formato` aceita `JSON`, `CSV` e `XLSX`; CSV e XLSX retornam `Content-Disposition: attachment` com nome `relatorio-nfse-{MM-AAAA}.{ext}`
 - Registros sem nome do paciente, CPF/CNPJ, valor positivo ou data de pagamento retornam `422 Unprocessable Entity`
-- As NFSEs emitidas são registradas via `POST /api/nfse-emitidas` (upsert por `(paciente, competência)`): paciente precisa estar ativo (`404`), `competencia` no formato `MM/AAAA` (`400`) e `valor`, quando informado, maior que zero (`422`)
+- As NFSEs emitidas são registradas via `POST /api/nfse-emitidas` (upsert por `(paciente, competência)`): paciente precisa estar ativo (`404`), `competencia` no formato `MM/AAAA` (`400`), `numeroNota` no máximo 60 caracteres (`400`), `dataEmissao` não futura (`422`) e `valor`, quando informado, maior que zero (`422`). O upsert é idempotente mesmo sob concorrência: a colisão da constraint única `(paciente, competência)` é repetida automaticamente como atualização
+- Timestamps de auditoria (`dataCriacao`/`dataAtualizacao`) das NFSEs emitidas são preenchidos pelos callbacks `@PrePersist`/`@PreUpdate` da entidade, conforme a convenção do projeto
 
 ### Aulas
 - Geradas percorrendo dia a dia entre `periodoInicio` e `periodoFim`

--- a/docs/context.md
+++ b/docs/context.md
@@ -59,6 +59,7 @@ com.carlesso.pilatesapi
 │   ├── UserController.java           — endpoint do usuário autenticado e CRUD administrativo
 │   ├── AdminController.java          — endpoints administrativos
 │   ├── RelatorioNfseController.java  — endpoint de relatório de emissão de NFSEs
+│   ├── NotaFiscalEmitidaController.java — registro/consulta de NFSEs emitidas por paciente/competência
 │   ├── DashboardController.java      — endpoint de resumo para o painel inicial
 │   └── PreferenciasUsuarioController.java — endpoints REST das preferências do usuário autenticado
 ├── service
@@ -74,8 +75,9 @@ com.carlesso.pilatesapi
 │   ├── PagamentoService.java                   — cobranças, confirmação, vencimentos
 │   ├── AulaService.java                        — geração e controle de aulas
 │   ├── RelatorioPagamentoExporterService.java  — exporta o relatório em PDF (OpenPDF) e XLSX (Apache POI)
-│   ├── RelatorioNfseService.java               — monta relatório de NFSEs por competência
+│   ├── RelatorioNfseService.java               — monta relatório de NFSEs por competência (usa NFSEs emitidas persistidas em `notaAnteriorEmitida`)
 │   ├── RelatorioNfseExporterService.java       — exporta relatório de NFSEs em CSV e XLSX
+│   ├── NotaFiscalEmitidaService.java           — registro idempotente (upsert por paciente/competência) e consulta de NFSEs emitidas
 │   ├── DashboardService.java                   — consolida contadores e totais para o painel inicial
 │   ├── AuthService.java                        — registro/login, emissão de token e rate limiting
 │   ├── UserService.java                        — CRUD de usuários e definição de perfis de acesso
@@ -96,7 +98,8 @@ com.carlesso.pilatesapi
 │   ├── EvolucaoSessaoRepository.java
 │   ├── ReavaliacaoRepository.java
 │   ├── UserRepository.java
-│   └── PreferenciasUsuarioRepository.java
+│   ├── PreferenciasUsuarioRepository.java
+│   └── NotaFiscalEmitidaRepository.java
 ├── entity
 │   ├── Paciente.java                 — entidade JPA, tabela `pacientes`
 │   ├── Endereco.java                 — @Embeddable, colunas embutidas em `pacientes`
@@ -111,7 +114,8 @@ com.carlesso.pilatesapi
 │   ├── EvolucaoSessao.java           — entidade JPA, tabela `evolucoes_sessao`
 │   ├── Reavaliacao.java              — entidade JPA, tabela `reavaliacoes`
 │   ├── User.java                     — entidade JPA, tabela `users`
-│   └── PreferenciasUsuario.java      — entidade JPA, tabela `preferencias_usuario` (1:1 com `users`)
+│   ├── PreferenciasUsuario.java      — entidade JPA, tabela `preferencias_usuario` (1:1 com `users`)
+│   └── NotaFiscalEmitida.java        — entidade JPA, tabela `notas_fiscais_emitidas` (NFSE emitida por paciente/competência)
 ├── entity/enums
 │   ├── TipoPagamento.java            — MENSAL, TRIMESTRAL, ANUAL
 │   ├── TipoContrato.java             — CLT, PJ, AUTONOMO
@@ -139,6 +143,8 @@ com.carlesso.pilatesapi
 │   ├── ProfissionalPagamentoRelatorioDTO.java — relatório de pagamento do profissional (contrato Angular-friendly)
 │   ├── ProfissionalPagamentoAulaDTO.java      — detalhe de aula no relatório
 │   ├── RelatorioNfseResponseDTO.java          — item do relatório de emissão de NFSE
+│   ├── NotaFiscalEmitidaRequestDTO.java       — payload de registro de NFSE emitida (record)
+│   ├── NotaFiscalEmitidaResponseDTO.java      — resposta da API de NFSE emitida (record com factory `from`)
 │   ├── DashboardResumoDTO.java                — resposta do endpoint de resumo do dashboard (record com sub-records)
 │   ├── PlanoRequestDTO.java
 │   ├── PlanoResponseDTO.java
@@ -169,8 +175,10 @@ com.carlesso.pilatesapi
 │   ├── UserResponseDTO.java
 │   ├── PreferenciasUsuarioRequestDTO.java  — payload de atualização das preferências (idioma, tema, notificações)
 │   └── PreferenciasUsuarioResponseDTO.java — resposta das preferências (record com factory method `from`)
-└── scheduler
-    └── CobrancaScheduler.java        — atualiza vencidos e gera cobranças futuras
+├── scheduler
+│   └── CobrancaScheduler.java        — atualiza vencidos e gera cobranças futuras
+└── util
+    └── CompetenciaUtils.java         — validação/parsing/formatação de competências `MM/AAAA` (compartilhado pelo relatório e registro de NFSE)
 ```
 
 ---
@@ -413,6 +421,22 @@ Relacionamento `@ManyToOne` obrigatório com `Paciente` e relacionamentos opcion
 
 Relacionamento `@OneToOne` com `User` (1:1, owning side em `preferencias_usuario`). Cada usuário possui no máximo um registro de preferências — quando não existe, o GET retorna os valores padrão definidos no service.
 
+### Tabela `notas_fiscais_emitidas`
+
+| Campo | Tipo | Restrição |
+|---|---|---|
+| `id` | BIGINT | PK, auto-increment |
+| `paciente_id` | BIGINT | NOT NULL, FK → pacientes |
+| `competencia` | DATE | NOT NULL (primeiro dia do mês; `MM/AAAA` na API) |
+| `numero_nota` | VARCHAR(60) | — |
+| `data_emissao` | DATE | NOT NULL |
+| `valor` | DECIMAL(10,2) | — (quando informado, deve ser > 0) |
+| `observacoes` | TEXT | — |
+| `data_criacao` | TIMESTAMP | NOT NULL |
+| `data_atualizacao` | TIMESTAMP | — |
+
+Restrição `UNIQUE (paciente_id, competencia)` garante uma única NFSE emitida por paciente em cada competência (registro idempotente via `POST /api/nfse-emitidas`). É a fonte de verdade do campo `notaAnteriorEmitida` do relatório de NFSE.
+
 ### Índices
 
 | Índice | Tabela / Coluna | Motivação |
@@ -428,6 +452,7 @@ Relacionamento `@OneToOne` com `User` (1:1, owning side em `preferencias_usuario
 | `idx_planos_tratamento_paciente_id` | `planos_tratamento(paciente_id)` | Listagem de planos de tratamento por paciente |
 | `idx_sessoes_pilates_paciente_id` | `sessoes_pilates(paciente_id)` | Listagem de sessões por paciente |
 | `idx_sessoes_pilates_data` | `sessoes_pilates(data)` | Busca e ordenação de sessões por data |
+| `idx_notas_fiscais_emitidas_paciente` | `notas_fiscais_emitidas(paciente_id)` | Listagem de NFSEs por paciente e lookup do relatório de NFSE |
 > **Nota:** colunas `plano_dias_semana(plano_id)`, `pagamentos(plano_id)`, `aulas(paciente_id)` e `anamneses(paciente_id)` **não** possuem índice dedicado porque já são o prefixo esquerdo de índices compostos existentes ou possuem índice automático de constraint `UNIQUE`, que o PostgreSQL pode usar para buscas na coluna isolada.
 
 ---
@@ -478,6 +503,8 @@ Relacionamento `@OneToOne` com `User` (1:1, owning side em `preferencias_usuario
 | GET | `/aulas/pagamento/{id}` | Listar aulas do pagamento | 200 |
 | PATCH | `/aulas/{id}/realizar?profissionalId={id}` | Marcar como realizada e opcionalmente vincular profissional | 200 / 404 / 409 / 422 |
 | GET | `/api/relatorios/nfse?competencia=MM/AAAA&notaAnteriorEmitida={true|false}&formato={JSON|CSV|XLSX}` | Gerar relatório de emissão de NFSEs por competência | 200 / 400 / 422 |
+| POST | `/api/nfse-emitidas` | Registrar/atualizar NFSE emitida do paciente na competência (upsert) | 200 / 400 / 404 / 422 |
+| GET | `/api/nfse-emitidas/paciente/{pacienteId}` | Listar NFSEs emitidas do paciente (competência desc) | 200 / 404 |
 | POST | `/anamneses` | Criar anamnese para um paciente | 201 / 400 / 404 / 409 |
 | GET | `/anamneses/{id}` | Buscar anamnese por ID | 200 / 404 |
 | GET | `/anamneses/paciente/{pacienteId}` | Buscar anamnese por paciente | 200 / 404 |
@@ -565,10 +592,11 @@ CPF não pode ser alterado após o cadastro.
 - `competencia` é obrigatória no formato `MM/AAAA`; mês deve estar entre `01` e `12`
 - O relatório retorna `Nome`, `CPF/CNPJ`, `ValorPago`, `Competencia`, `DescricaoServico`, `NotaAnteriorEmitida`, `DataPagamento` e `Observacoes`
 - `DescricaoServico` é gerada automaticamente como `Aulas de Pilates - Competência MM/AAAA`
-- Como o modelo atual não possui entidade de nota fiscal, `NotaAnteriorEmitida` é inferida pela existência de pagamento confirmado anterior para o mesmo paciente
-- O filtro opcional `notaAnteriorEmitida` permite retornar apenas registros com ou sem nota anterior inferida
+- `NotaAnteriorEmitida` é baseada nas NFSEs emitidas persistidas (`notas_fiscais_emitidas`): `true` quando existe nota registrada para o paciente em competência anterior à consultada
+- O filtro opcional `notaAnteriorEmitida` permite retornar apenas registros com ou sem nota anterior emitida
 - `formato` aceita `JSON`, `CSV` e `XLSX`; CSV e XLSX retornam `Content-Disposition: attachment` com nome `relatorio-nfse-{MM-AAAA}.{ext}`
 - Registros sem nome do paciente, CPF/CNPJ, valor positivo ou data de pagamento retornam `422 Unprocessable Entity`
+- As NFSEs emitidas são registradas via `POST /api/nfse-emitidas` (upsert por `(paciente, competência)`): paciente precisa estar ativo (`404`), `competencia` no formato `MM/AAAA` (`400`) e `valor`, quando informado, maior que zero (`422`)
 
 ### Aulas
 - Geradas percorrendo dia a dia entre `periodoInicio` e `periodoFim`
@@ -784,13 +812,16 @@ mvn spring-boot:run
 | `ProfissionalServiceIntegrationTest` | `@DataJpaTest` + H2 | 5 |
 | `CobrancaSchedulerIntegrationTest` | `@DataJpaTest` + H2 | 11 |
 | `AulaRepositoryTest` | `@DataJpaTest` + H2 | 6 |
-| `PagamentoRepositoryTest` | `@DataJpaTest` + H2 | 2 |
+| `PagamentoRepositoryTest` | `@DataJpaTest` + H2 | 1 |
 | `PacienteControllerTest` | `@WebMvcTest` + MockMvc | 16 |
 | `ProfissionalControllerTest` | `@WebMvcTest` + MockMvc | 17 |
 | `PlanoControllerTest` | `@WebMvcTest` + MockMvc | 11 |
 | `PagamentoControllerTest` | `@WebMvcTest` + MockMvc | 11 |
 | `AulaControllerTest` | `@WebMvcTest` + MockMvc | 10 |
 | `RelatorioNfseControllerTest` | `@WebMvcTest` + MockMvc | 6 |
+| `NotaFiscalEmitidaServiceTest` | Unitário (Mockito, sem Spring) | 6 |
+| `NotaFiscalEmitidaControllerTest` | `@WebMvcTest` + MockMvc | 4 |
+| `NotaFiscalEmitidaRepositoryTest` | `@DataJpaTest` + H2 | 3 |
 | `AnamneseServiceTest` | Unitário (Mockito, sem Spring) | 17 |
 | `AnamneseControllerTest` | `@WebMvcTest` + MockMvc | 14 |
 | `AvaliacaoFisioterapeuticaServiceTest` | Unitário (Mockito, sem Spring) | 8 |

--- a/src/main/java/com/carlesso/pilatesapi/controller/NotaFiscalEmitidaController.java
+++ b/src/main/java/com/carlesso/pilatesapi/controller/NotaFiscalEmitidaController.java
@@ -1,0 +1,59 @@
+package com.carlesso.pilatesapi.controller;
+
+import com.carlesso.pilatesapi.dto.NotaFiscalEmitidaRequestDTO;
+import com.carlesso.pilatesapi.dto.NotaFiscalEmitidaResponseDTO;
+import com.carlesso.pilatesapi.service.NotaFiscalEmitidaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "NFSE", description = "Registro de notas fiscais de serviço emitidas por paciente/competência")
+@RestController
+@RequestMapping("/api/nfse-emitidas")
+public class NotaFiscalEmitidaController {
+
+    private final NotaFiscalEmitidaService service;
+
+    public NotaFiscalEmitidaController(NotaFiscalEmitidaService service) {
+        this.service = service;
+    }
+
+    @Operation(summary = "Registrar ou atualizar NFSE emitida",
+            description = "Registra a última NFSE emitida para um paciente em uma competência. "
+                    + "Se já existir nota para o paciente na competência informada, ela é atualizada.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "NFSE registrada ou atualizada com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Dados inválidos ou competência fora do formato"),
+            @ApiResponse(responseCode = "404", description = "Paciente não encontrado"),
+            @ApiResponse(responseCode = "422", description = "Valor informado inválido")
+    })
+    @PostMapping
+    public ResponseEntity<NotaFiscalEmitidaResponseDTO> registrar(
+            @RequestBody @Valid NotaFiscalEmitidaRequestDTO dto) {
+        return ResponseEntity.ok(service.registrar(dto));
+    }
+
+    @Operation(summary = "Listar NFSEs emitidas de um paciente",
+            description = "Retorna as notas fiscais emitidas registradas para o paciente, da competência mais recente para a mais antiga.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Lista retornada com sucesso"),
+            @ApiResponse(responseCode = "404", description = "Paciente não encontrado")
+    })
+    @GetMapping("/paciente/{pacienteId}")
+    public ResponseEntity<List<NotaFiscalEmitidaResponseDTO>> listarPorPaciente(
+            @Parameter(description = "ID do paciente", required = true) @PathVariable Long pacienteId) {
+        return ResponseEntity.ok(service.listarPorPaciente(pacienteId));
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/dto/NotaFiscalEmitidaRequestDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/NotaFiscalEmitidaRequestDTO.java
@@ -1,16 +1,18 @@
 package com.carlesso.pilatesapi.dto;
 
+import com.carlesso.pilatesapi.util.CompetenciaUtils;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record NotaFiscalEmitidaRequestDTO(
         @NotNull Long pacienteId,
-        @NotNull @Pattern(regexp = "^(0[1-9]|1[0-2])/\\d{4}$", message = "competencia deve estar no formato MM/AAAA")
+        @NotNull @Pattern(regexp = CompetenciaUtils.COMPETENCIA_REGEX, message = "competencia deve estar no formato MM/AAAA")
         String competencia,
-        String numeroNota,
+        @Size(max = 60, message = "numeroNota deve ter no máximo 60 caracteres") String numeroNota,
         @NotNull LocalDate dataEmissao,
         BigDecimal valor,
         String observacoes

--- a/src/main/java/com/carlesso/pilatesapi/dto/NotaFiscalEmitidaRequestDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/NotaFiscalEmitidaRequestDTO.java
@@ -1,0 +1,17 @@
+package com.carlesso.pilatesapi.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record NotaFiscalEmitidaRequestDTO(
+        @NotNull Long pacienteId,
+        @NotNull @Pattern(regexp = "^(0[1-9]|1[0-2])/\\d{4}$", message = "competencia deve estar no formato MM/AAAA")
+        String competencia,
+        String numeroNota,
+        @NotNull LocalDate dataEmissao,
+        BigDecimal valor,
+        String observacoes
+) {}

--- a/src/main/java/com/carlesso/pilatesapi/dto/NotaFiscalEmitidaResponseDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/NotaFiscalEmitidaResponseDTO.java
@@ -1,0 +1,37 @@
+package com.carlesso.pilatesapi.dto;
+
+import com.carlesso.pilatesapi.entity.NotaFiscalEmitida;
+import com.carlesso.pilatesapi.util.CompetenciaUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+
+public record NotaFiscalEmitidaResponseDTO(
+        Long id,
+        Long pacienteId,
+        String nomePaciente,
+        String competencia,
+        String numeroNota,
+        LocalDate dataEmissao,
+        BigDecimal valor,
+        String observacoes,
+        LocalDateTime dataCriacao,
+        LocalDateTime dataAtualizacao
+) {
+    public static NotaFiscalEmitidaResponseDTO from(NotaFiscalEmitida n) {
+        return new NotaFiscalEmitidaResponseDTO(
+                n.getId(),
+                n.getPaciente().getId(),
+                n.getPaciente().getNome(),
+                CompetenciaUtils.format(YearMonth.from(n.getCompetencia())),
+                n.getNumeroNota(),
+                n.getDataEmissao(),
+                n.getValor(),
+                n.getObservacoes(),
+                n.getDataCriacao(),
+                n.getDataAtualizacao()
+        );
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/entity/NotaFiscalEmitida.java
+++ b/src/main/java/com/carlesso/pilatesapi/entity/NotaFiscalEmitida.java
@@ -46,6 +46,16 @@ public class NotaFiscalEmitida {
 
     public NotaFiscalEmitida() {}
 
+    @PrePersist
+    void prePersist() {
+        this.dataCriacao = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    void preUpdate() {
+        this.dataAtualizacao = LocalDateTime.now();
+    }
+
     public Long getId() { return id; }
 
     public Paciente getPaciente() { return paciente; }

--- a/src/main/java/com/carlesso/pilatesapi/entity/NotaFiscalEmitida.java
+++ b/src/main/java/com/carlesso/pilatesapi/entity/NotaFiscalEmitida.java
@@ -1,0 +1,74 @@
+package com.carlesso.pilatesapi.entity;
+
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notas_fiscais_emitidas",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"paciente_id", "competencia"}))
+public class NotaFiscalEmitida {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "paciente_id", nullable = false)
+    private Paciente paciente;
+
+    /**
+     * Competência fiscal da nota, armazenada como o primeiro dia do mês para
+     * permitir ordenação e comparação ({@code MM/AAAA} na API).
+     */
+    @Column(nullable = false)
+    private LocalDate competencia;
+
+    @Column(name = "numero_nota", length = 60)
+    private String numeroNota;
+
+    @Column(name = "data_emissao", nullable = false)
+    private LocalDate dataEmissao;
+
+    @Column(precision = 10, scale = 2)
+    private BigDecimal valor;
+
+    @Column(columnDefinition = "TEXT")
+    private String observacoes;
+
+    @Column(name = "data_criacao", nullable = false)
+    private LocalDateTime dataCriacao;
+
+    @Column(name = "data_atualizacao")
+    private LocalDateTime dataAtualizacao;
+
+    public NotaFiscalEmitida() {}
+
+    public Long getId() { return id; }
+
+    public Paciente getPaciente() { return paciente; }
+    public void setPaciente(Paciente paciente) { this.paciente = paciente; }
+
+    public LocalDate getCompetencia() { return competencia; }
+    public void setCompetencia(LocalDate competencia) { this.competencia = competencia; }
+
+    public String getNumeroNota() { return numeroNota; }
+    public void setNumeroNota(String numeroNota) { this.numeroNota = numeroNota; }
+
+    public LocalDate getDataEmissao() { return dataEmissao; }
+    public void setDataEmissao(LocalDate dataEmissao) { this.dataEmissao = dataEmissao; }
+
+    public BigDecimal getValor() { return valor; }
+    public void setValor(BigDecimal valor) { this.valor = valor; }
+
+    public String getObservacoes() { return observacoes; }
+    public void setObservacoes(String observacoes) { this.observacoes = observacoes; }
+
+    public LocalDateTime getDataCriacao() { return dataCriacao; }
+    public void setDataCriacao(LocalDateTime dataCriacao) { this.dataCriacao = dataCriacao; }
+
+    public LocalDateTime getDataAtualizacao() { return dataAtualizacao; }
+    public void setDataAtualizacao(LocalDateTime dataAtualizacao) { this.dataAtualizacao = dataAtualizacao; }
+}

--- a/src/main/java/com/carlesso/pilatesapi/repository/NotaFiscalEmitidaRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/NotaFiscalEmitidaRepository.java
@@ -1,0 +1,34 @@
+package com.carlesso.pilatesapi.repository;
+
+import com.carlesso.pilatesapi.entity.NotaFiscalEmitida;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface NotaFiscalEmitidaRepository extends JpaRepository<NotaFiscalEmitida, Long> {
+
+    Optional<NotaFiscalEmitida> findByPacienteIdAndCompetencia(Long pacienteId, LocalDate competencia);
+
+    @Query("""
+            select n
+            from NotaFiscalEmitida n
+            join fetch n.paciente
+            where n.paciente.id = :pacienteId
+            order by n.competencia desc
+            """)
+    List<NotaFiscalEmitida> findByPacienteIdOrderByCompetenciaDesc(@Param("pacienteId") Long pacienteId);
+
+    @Query("""
+            select distinct n.paciente.id
+            from NotaFiscalEmitida n
+            where n.paciente.id in :pacienteIds
+              and n.competencia < :competencia
+            """)
+    List<Long> findPacienteIdsComNotaEmitidaAntes(
+            @Param("pacienteIds") List<Long> pacienteIds,
+            @Param("competencia") LocalDate competencia);
+}

--- a/src/main/java/com/carlesso/pilatesapi/repository/PagamentoRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/PagamentoRepository.java
@@ -35,18 +35,6 @@ public interface PagamentoRepository extends JpaRepository<Pagamento, Long> {
             @Param("inicio") LocalDate inicio,
             @Param("fim") LocalDate fim);
 
-    @Query("""
-            select distinct p.paciente.id
-            from Pagamento p
-            where p.status = :status
-              and p.dataPagamento < :dataPagamento
-              and p.paciente.id in :pacienteIds
-            """)
-    List<Long> findPacienteIdsComPagamentoConfirmadoAntes(
-            @Param("pacienteIds") List<Long> pacienteIds,
-            @Param("status") StatusPagamento status,
-            @Param("dataPagamento") LocalDate dataPagamento);
-
     long countByStatus(StatusPagamento status);
 
     @Query("""

--- a/src/main/java/com/carlesso/pilatesapi/service/NotaFiscalEmitidaService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/NotaFiscalEmitidaService.java
@@ -1,0 +1,77 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.NotaFiscalEmitidaRequestDTO;
+import com.carlesso.pilatesapi.dto.NotaFiscalEmitidaResponseDTO;
+import com.carlesso.pilatesapi.entity.NotaFiscalEmitida;
+import com.carlesso.pilatesapi.entity.Paciente;
+import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
+import com.carlesso.pilatesapi.repository.NotaFiscalEmitidaRepository;
+import com.carlesso.pilatesapi.repository.PacienteRepository;
+import com.carlesso.pilatesapi.util.CompetenciaUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+
+@Service
+public class NotaFiscalEmitidaService {
+
+    private final NotaFiscalEmitidaRepository repository;
+    private final PacienteRepository pacienteRepository;
+
+    public NotaFiscalEmitidaService(NotaFiscalEmitidaRepository repository,
+                                    PacienteRepository pacienteRepository) {
+        this.repository = repository;
+        this.pacienteRepository = pacienteRepository;
+    }
+
+    @Transactional
+    public NotaFiscalEmitidaResponseDTO registrar(NotaFiscalEmitidaRequestDTO dto) {
+        Paciente paciente = pacienteRepository.findByIdAndAtivoTrue(dto.pacienteId())
+                .orElseThrow(() -> new ResourceNotFoundException("Paciente não encontrado: " + dto.pacienteId()));
+
+        YearMonth periodo = CompetenciaUtils.parse(dto.competencia());
+        LocalDate competencia = periodo.atDay(1);
+        validar(dto);
+
+        NotaFiscalEmitida nota = repository.findByPacienteIdAndCompetencia(paciente.getId(), competencia)
+                .orElseGet(() -> {
+                    NotaFiscalEmitida nova = new NotaFiscalEmitida();
+                    nova.setPaciente(paciente);
+                    nova.setCompetencia(competencia);
+                    nova.setDataCriacao(LocalDateTime.now());
+                    return nova;
+                });
+
+        if (nota.getId() != null) {
+            nota.setDataAtualizacao(LocalDateTime.now());
+        }
+        nota.setNumeroNota(dto.numeroNota());
+        nota.setDataEmissao(dto.dataEmissao());
+        nota.setValor(dto.valor());
+        nota.setObservacoes(dto.observacoes());
+
+        return NotaFiscalEmitidaResponseDTO.from(repository.save(nota));
+    }
+
+    @Transactional(readOnly = true)
+    public List<NotaFiscalEmitidaResponseDTO> listarPorPaciente(Long pacienteId) {
+        if (!pacienteRepository.existsByIdAndAtivoTrue(pacienteId)) {
+            throw new ResourceNotFoundException("Paciente não encontrado: " + pacienteId);
+        }
+        return repository.findByPacienteIdOrderByCompetenciaDesc(pacienteId).stream()
+                .map(NotaFiscalEmitidaResponseDTO::from)
+                .toList();
+    }
+
+    private void validar(NotaFiscalEmitidaRequestDTO dto) {
+        if (dto.valor() != null && dto.valor().compareTo(BigDecimal.ZERO) <= 0) {
+            throw new BusinessException("valor da NFSE deve ser maior que zero quando informado");
+        }
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/service/NotaFiscalEmitidaService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/NotaFiscalEmitidaService.java
@@ -9,12 +9,14 @@ import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.repository.NotaFiscalEmitidaRepository;
 import com.carlesso.pilatesapi.repository.PacienteRepository;
 import com.carlesso.pilatesapi.util.CompetenciaUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
 
@@ -24,14 +26,41 @@ public class NotaFiscalEmitidaService {
     private final NotaFiscalEmitidaRepository repository;
     private final PacienteRepository pacienteRepository;
 
+    /**
+     * Referência ao próprio bean (proxy transacional) para que {@link #upsert}
+     * execute em uma nova transação a cada tentativa, permitindo o retry após
+     * colisão da constraint única.
+     */
+    private NotaFiscalEmitidaService self;
+
     public NotaFiscalEmitidaService(NotaFiscalEmitidaRepository repository,
                                     PacienteRepository pacienteRepository) {
         this.repository = repository;
         this.pacienteRepository = pacienteRepository;
     }
 
-    @Transactional
+    @Autowired
+    void setSelf(@Lazy NotaFiscalEmitidaService self) {
+        this.self = self;
+    }
+
+    /**
+     * Registra (cria ou atualiza) a NFSE emitida de forma idempotente por
+     * {@code (paciente, competência)}. Sob concorrência, dois inserts podem
+     * colidir na constraint única; nesse caso a operação é repetida uma vez,
+     * quando a busca passa a encontrar o registro já gravado e segue pelo
+     * caminho de atualização — preservando a semântica idempotente (200).
+     */
     public NotaFiscalEmitidaResponseDTO registrar(NotaFiscalEmitidaRequestDTO dto) {
+        try {
+            return self.upsert(dto);
+        } catch (DataIntegrityViolationException e) {
+            return self.upsert(dto);
+        }
+    }
+
+    @Transactional
+    public NotaFiscalEmitidaResponseDTO upsert(NotaFiscalEmitidaRequestDTO dto) {
         Paciente paciente = pacienteRepository.findByIdAndAtivoTrue(dto.pacienteId())
                 .orElseThrow(() -> new ResourceNotFoundException("Paciente não encontrado: " + dto.pacienteId()));
 
@@ -44,13 +73,9 @@ public class NotaFiscalEmitidaService {
                     NotaFiscalEmitida nova = new NotaFiscalEmitida();
                     nova.setPaciente(paciente);
                     nova.setCompetencia(competencia);
-                    nova.setDataCriacao(LocalDateTime.now());
                     return nova;
                 });
 
-        if (nota.getId() != null) {
-            nota.setDataAtualizacao(LocalDateTime.now());
-        }
         nota.setNumeroNota(dto.numeroNota());
         nota.setDataEmissao(dto.dataEmissao());
         nota.setValor(dto.valor());
@@ -72,6 +97,9 @@ public class NotaFiscalEmitidaService {
     private void validar(NotaFiscalEmitidaRequestDTO dto) {
         if (dto.valor() != null && dto.valor().compareTo(BigDecimal.ZERO) <= 0) {
             throw new BusinessException("valor da NFSE deve ser maior que zero quando informado");
+        }
+        if (dto.dataEmissao() != null && dto.dataEmissao().isAfter(LocalDate.now())) {
+            throw new BusinessException("dataEmissao não pode ser futura");
         }
     }
 }

--- a/src/main/java/com/carlesso/pilatesapi/service/RelatorioNfseService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/RelatorioNfseService.java
@@ -5,7 +5,9 @@ import com.carlesso.pilatesapi.entity.Paciente;
 import com.carlesso.pilatesapi.entity.Pagamento;
 import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
 import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.repository.NotaFiscalEmitidaRepository;
 import com.carlesso.pilatesapi.repository.PagamentoRepository;
+import com.carlesso.pilatesapi.util.CompetenciaUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,52 +17,39 @@ import java.time.YearMonth;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Service
 public class RelatorioNfseService {
 
-    private static final Pattern COMPETENCIA_PATTERN = Pattern.compile("^(0[1-9]|1[0-2])/\\d{4}$");
-
     private final PagamentoRepository pagamentoRepository;
+    private final NotaFiscalEmitidaRepository notaFiscalEmitidaRepository;
 
-    public RelatorioNfseService(PagamentoRepository pagamentoRepository) {
+    public RelatorioNfseService(PagamentoRepository pagamentoRepository,
+                                NotaFiscalEmitidaRepository notaFiscalEmitidaRepository) {
         this.pagamentoRepository = pagamentoRepository;
+        this.notaFiscalEmitidaRepository = notaFiscalEmitidaRepository;
     }
 
     @Transactional(readOnly = true)
     public List<RelatorioNfseResponseDTO> gerar(String competencia, Boolean notaAnteriorEmitida) {
-        YearMonth periodo = parseCompetencia(competencia);
+        YearMonth periodo = CompetenciaUtils.parse(competencia);
         LocalDate inicio = periodo.atDay(1);
         LocalDate fim = periodo.atEndOfMonth();
         List<Pagamento> pagamentos = pagamentoRepository.findPagamentosConfirmadosParaRelatorioNfse(
                 StatusPagamento.PAGO,
                 inicio,
                 fim);
-        Set<Long> pacientesComPagamentoAnterior = buscarPacientesComPagamentoAnterior(pagamentos, inicio);
+        Set<Long> pacientesComNotaAnterior = buscarPacientesComNotaEmitidaAntes(pagamentos, inicio);
 
         return pagamentos.stream()
-                .map(pagamento -> montarItem(pagamento, competencia, pacientesComPagamentoAnterior))
+                .map(pagamento -> montarItem(pagamento, competencia, pacientesComNotaAnterior))
                 .filter(item -> notaAnteriorEmitida == null
                         || Objects.equals(item.notaAnteriorEmitida(), notaAnteriorEmitida))
                 .toList();
     }
 
-    private YearMonth parseCompetencia(String competencia) {
-        if (competencia == null || competencia.isBlank()) {
-            throw new IllegalArgumentException("competencia é obrigatória");
-        }
-        if (!COMPETENCIA_PATTERN.matcher(competencia).matches()) {
-            throw new IllegalArgumentException("competencia deve estar no formato MM/AAAA");
-        }
-
-        int mes = Integer.parseInt(competencia.substring(0, 2));
-        int ano = Integer.parseInt(competencia.substring(3));
-        return YearMonth.of(ano, mes);
-    }
-
-    private Set<Long> buscarPacientesComPagamentoAnterior(List<Pagamento> pagamentos, LocalDate inicioCompetencia) {
+    private Set<Long> buscarPacientesComNotaEmitidaAntes(List<Pagamento> pagamentos, LocalDate inicioCompetencia) {
         List<Long> pacienteIds = pagamentos.stream()
                 .map(pagamento -> pagamento.getPaciente().getId())
                 .distinct()
@@ -70,9 +59,8 @@ public class RelatorioNfseService {
             return Set.of();
         }
 
-        return pagamentoRepository.findPacienteIdsComPagamentoConfirmadoAntes(
+        return notaFiscalEmitidaRepository.findPacienteIdsComNotaEmitidaAntes(
                         pacienteIds,
-                        StatusPagamento.PAGO,
                         inicioCompetencia)
                 .stream()
                 .collect(Collectors.toSet());
@@ -81,7 +69,7 @@ public class RelatorioNfseService {
     private RelatorioNfseResponseDTO montarItem(
             Pagamento pagamento,
             String competencia,
-            Set<Long> pacientesComPagamentoAnterior) {
+            Set<Long> pacientesComNotaAnterior) {
         Paciente paciente = pagamento.getPaciente();
         validarDadosParaEmissao(pagamento, paciente);
 
@@ -91,7 +79,7 @@ public class RelatorioNfseService {
                 pagamento.getValor(),
                 competencia,
                 "Aulas de Pilates - Competência " + competencia,
-                pacientesComPagamentoAnterior.contains(paciente.getId()),
+                pacientesComNotaAnterior.contains(paciente.getId()),
                 pagamento.getDataPagamento(),
                 ""
         );

--- a/src/main/java/com/carlesso/pilatesapi/util/CompetenciaUtils.java
+++ b/src/main/java/com/carlesso/pilatesapi/util/CompetenciaUtils.java
@@ -10,7 +10,13 @@ import java.util.regex.Pattern;
  */
 public final class CompetenciaUtils {
 
-    private static final Pattern COMPETENCIA_PATTERN = Pattern.compile("^(0[1-9]|1[0-2])/\\d{4}$");
+    /**
+     * Expressão regular do formato de competência {@code MM/AAAA}, reutilizada
+     * tanto na validação Bean Validation (DTO) quanto no parsing programático.
+     */
+    public static final String COMPETENCIA_REGEX = "^(0[1-9]|1[0-2])/\\d{4}$";
+
+    private static final Pattern COMPETENCIA_PATTERN = Pattern.compile(COMPETENCIA_REGEX);
 
     private CompetenciaUtils() {
     }

--- a/src/main/java/com/carlesso/pilatesapi/util/CompetenciaUtils.java
+++ b/src/main/java/com/carlesso/pilatesapi/util/CompetenciaUtils.java
@@ -1,0 +1,34 @@
+package com.carlesso.pilatesapi.util;
+
+import java.time.YearMonth;
+import java.util.regex.Pattern;
+
+/**
+ * Utilitários para validação, parsing e formatação de competências fiscais no
+ * formato {@code MM/AAAA}, compartilhados entre o relatório de NFSE e o registro
+ * de notas emitidas.
+ */
+public final class CompetenciaUtils {
+
+    private static final Pattern COMPETENCIA_PATTERN = Pattern.compile("^(0[1-9]|1[0-2])/\\d{4}$");
+
+    private CompetenciaUtils() {
+    }
+
+    public static YearMonth parse(String competencia) {
+        if (competencia == null || competencia.isBlank()) {
+            throw new IllegalArgumentException("competencia é obrigatória");
+        }
+        if (!COMPETENCIA_PATTERN.matcher(competencia).matches()) {
+            throw new IllegalArgumentException("competencia deve estar no formato MM/AAAA");
+        }
+
+        int mes = Integer.parseInt(competencia.substring(0, 2));
+        int ano = Integer.parseInt(competencia.substring(3));
+        return YearMonth.of(ano, mes);
+    }
+
+    public static String format(YearMonth periodo) {
+        return String.format("%02d/%04d", periodo.getMonthValue(), periodo.getYear());
+    }
+}

--- a/src/main/resources/db/migration/V26__create_notas_fiscais_emitidas_table.sql
+++ b/src/main/resources/db/migration/V26__create_notas_fiscais_emitidas_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE notas_fiscais_emitidas (
+    id               BIGSERIAL     PRIMARY KEY,
+    paciente_id      BIGINT        NOT NULL REFERENCES pacientes(id),
+    competencia      DATE          NOT NULL,
+    numero_nota      VARCHAR(60),
+    data_emissao     DATE          NOT NULL,
+    valor            DECIMAL(10,2),
+    observacoes      TEXT,
+    data_criacao     TIMESTAMP     NOT NULL,
+    data_atualizacao TIMESTAMP,
+    UNIQUE (paciente_id, competencia)
+);
+
+CREATE INDEX idx_notas_fiscais_emitidas_paciente ON notas_fiscais_emitidas (paciente_id);

--- a/src/test/java/com/carlesso/pilatesapi/controller/NotaFiscalEmitidaControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/NotaFiscalEmitidaControllerTest.java
@@ -1,0 +1,118 @@
+package com.carlesso.pilatesapi.controller;
+
+import com.carlesso.pilatesapi.dto.NotaFiscalEmitidaResponseDTO;
+import com.carlesso.pilatesapi.service.CustomUserDetailsService;
+import com.carlesso.pilatesapi.service.JwtService;
+import com.carlesso.pilatesapi.service.NotaFiscalEmitidaService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NotaFiscalEmitidaController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class NotaFiscalEmitidaControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockitoBean
+    NotaFiscalEmitidaService service;
+
+    @MockitoBean
+    JwtService jwtService;
+
+    @MockitoBean
+    CustomUserDetailsService customUserDetailsService;
+
+    @Test
+    void registrar_deveRetornarNota() throws Exception {
+        when(service.registrar(any())).thenReturn(item());
+
+        var body = Map.of(
+                "pacienteId", 1,
+                "competencia", "04/2026",
+                "numeroNota", "NF-123",
+                "dataEmissao", "2026-04-15",
+                "valor", 250.00);
+
+        mockMvc.perform(post("/api/nfse-emitidas")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(5))
+                .andExpect(jsonPath("$.pacienteId").value(1))
+                .andExpect(jsonPath("$.competencia").value("04/2026"))
+                .andExpect(jsonPath("$.numeroNota").value("NF-123"));
+    }
+
+    @Test
+    void registrar_competenciaInvalida_deveRetornar400() throws Exception {
+        var body = Map.of(
+                "pacienteId", 1,
+                "competencia", "13/2026",
+                "dataEmissao", "2026-04-15");
+
+        mockMvc.perform(post("/api/nfse-emitidas")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void registrar_semPacienteId_deveRetornar400() throws Exception {
+        var body = Map.of(
+                "competencia", "04/2026",
+                "dataEmissao", "2026-04-15");
+
+        mockMvc.perform(post("/api/nfse-emitidas")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(body)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void listarPorPaciente_deveRetornarLista() throws Exception {
+        when(service.listarPorPaciente(1L)).thenReturn(List.of(item()));
+
+        mockMvc.perform(get("/api/nfse-emitidas/paciente/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(5))
+                .andExpect(jsonPath("$[0].competencia").value("04/2026"));
+    }
+
+    private NotaFiscalEmitidaResponseDTO item() {
+        return new NotaFiscalEmitidaResponseDTO(
+                5L,
+                1L,
+                "Ana Souza",
+                "04/2026",
+                "NF-123",
+                LocalDate.of(2026, 4, 15),
+                new BigDecimal("250.00"),
+                "ok",
+                LocalDateTime.of(2026, 4, 15, 10, 0),
+                null
+        );
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/repository/NotaFiscalEmitidaRepositoryTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/repository/NotaFiscalEmitidaRepositoryTest.java
@@ -1,0 +1,93 @@
+package com.carlesso.pilatesapi.repository;
+
+import com.carlesso.pilatesapi.entity.NotaFiscalEmitida;
+import com.carlesso.pilatesapi.entity.Paciente;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest(showSql = false)
+class NotaFiscalEmitidaRepositoryTest {
+
+    @Autowired
+    NotaFiscalEmitidaRepository repository;
+
+    @Autowired
+    TestEntityManager entityManager;
+
+    @Test
+    void findPacienteIdsComNotaEmitidaAntes_retornaApenasPacientesComNotaEmCompetenciaAnterior() {
+        Paciente comNotaAnterior = entityManager.persist(paciente("Ana", "ana@email.com", "11122233344"));
+        Paciente semNotaAnterior = entityManager.persist(paciente("Bia", "bia@email.com", "55566677788"));
+
+        entityManager.persist(nota(comNotaAnterior, LocalDate.of(2026, 3, 1)));
+        entityManager.persist(nota(semNotaAnterior, LocalDate.of(2026, 4, 1)));
+        entityManager.flush();
+
+        var pacienteIds = repository.findPacienteIdsComNotaEmitidaAntes(
+                List.of(comNotaAnterior.getId(), semNotaAnterior.getId()),
+                LocalDate.of(2026, 4, 1));
+
+        assertThat(pacienteIds).containsExactly(comNotaAnterior.getId());
+    }
+
+    @Test
+    void findByPacienteIdAndCompetencia_retornaNotaDaCompetencia() {
+        Paciente paciente = entityManager.persist(paciente("Ana", "ana@email.com", "11122233344"));
+        entityManager.persist(nota(paciente, LocalDate.of(2026, 4, 1)));
+        entityManager.flush();
+        entityManager.clear();
+
+        var nota = repository.findByPacienteIdAndCompetencia(paciente.getId(), LocalDate.of(2026, 4, 1));
+
+        assertThat(nota).isPresent();
+        assertThat(nota.get().getNumeroNota()).isEqualTo("NF-1");
+    }
+
+    @Test
+    void findByPacienteIdOrderByCompetenciaDesc_retornaDaMaisRecenteParaMaisAntiga() {
+        Paciente paciente = entityManager.persist(paciente("Ana", "ana@email.com", "11122233344"));
+        entityManager.persist(nota(paciente, LocalDate.of(2026, 3, 1)));
+        entityManager.persist(nota(paciente, LocalDate.of(2026, 5, 1)));
+        entityManager.persist(nota(paciente, LocalDate.of(2026, 4, 1)));
+        entityManager.flush();
+        entityManager.clear();
+
+        var notas = repository.findByPacienteIdOrderByCompetenciaDesc(paciente.getId());
+
+        assertThat(notas)
+                .extracting(NotaFiscalEmitida::getCompetencia)
+                .containsExactly(
+                        LocalDate.of(2026, 5, 1),
+                        LocalDate.of(2026, 4, 1),
+                        LocalDate.of(2026, 3, 1));
+    }
+
+    private Paciente paciente(String nome, String email, String cpf) {
+        Paciente paciente = new Paciente();
+        paciente.setNome(nome);
+        paciente.setEmail(email);
+        paciente.setCpf(cpf);
+        paciente.setAtivo(true);
+        return paciente;
+    }
+
+    private NotaFiscalEmitida nota(Paciente paciente, LocalDate competencia) {
+        NotaFiscalEmitida nota = new NotaFiscalEmitida();
+        nota.setPaciente(paciente);
+        nota.setCompetencia(competencia);
+        nota.setNumeroNota("NF-1");
+        nota.setDataEmissao(competencia.plusDays(10));
+        nota.setValor(new BigDecimal("250.00"));
+        nota.setDataCriacao(LocalDateTime.now());
+        return nota;
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/repository/NotaFiscalEmitidaRepositoryTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/repository/NotaFiscalEmitidaRepositoryTest.java
@@ -9,7 +9,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,6 +49,8 @@ class NotaFiscalEmitidaRepositoryTest {
 
         assertThat(nota).isPresent();
         assertThat(nota.get().getNumeroNota()).isEqualTo("NF-1");
+        // dataCriacao é preenchida automaticamente pelo callback @PrePersist (helper não a define).
+        assertThat(nota.get().getDataCriacao()).isNotNull();
     }
 
     @Test
@@ -87,7 +88,6 @@ class NotaFiscalEmitidaRepositoryTest {
         nota.setNumeroNota("NF-1");
         nota.setDataEmissao(competencia.plusDays(10));
         nota.setValor(new BigDecimal("250.00"));
-        nota.setDataCriacao(LocalDateTime.now());
         return nota;
     }
 }

--- a/src/test/java/com/carlesso/pilatesapi/repository/PagamentoRepositoryTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/repository/PagamentoRepositoryTest.java
@@ -55,25 +55,6 @@ class PagamentoRepositoryTest {
                 .containsExactly(pagoNaCompetencia.getId());
     }
 
-    @Test
-    void findPacienteIdsComPagamentoConfirmadoAntes_retornaPacientesComPagamentoAnterior() {
-        Paciente paciente = entityManager.persist(paciente("Ana Ativa", "ana@email.com", "11122233344", true));
-        Paciente pacienteSemAnterior = entityManager.persist(paciente("Bia Ativa", "bia@email.com", "55566677788", true));
-        Plano plano = entityManager.persist(plano(paciente));
-        Plano planoSemAnterior = entityManager.persist(plano(pacienteSemAnterior));
-        entityManager.persist(pagamento(paciente, plano, StatusPagamento.PAGO, LocalDate.of(2026, 3, 10)));
-        entityManager.persist(pagamento(pacienteSemAnterior, planoSemAnterior, StatusPagamento.PAGO,
-                LocalDate.of(2026, 4, 10)));
-        entityManager.flush();
-
-        var pacienteIds = repository.findPacienteIdsComPagamentoConfirmadoAntes(
-                List.of(paciente.getId(), pacienteSemAnterior.getId()),
-                StatusPagamento.PAGO,
-                LocalDate.of(2026, 4, 1));
-
-        assertThat(pacienteIds).containsExactly(paciente.getId());
-    }
-
     private Paciente paciente(String nome, String email, String cpf, boolean ativo) {
         Paciente paciente = new Paciente();
         paciente.setNome(nome);

--- a/src/test/java/com/carlesso/pilatesapi/service/NotaFiscalEmitidaServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/NotaFiscalEmitidaServiceTest.java
@@ -7,6 +7,7 @@ import com.carlesso.pilatesapi.exception.BusinessException;
 import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.repository.NotaFiscalEmitidaRepository;
 import com.carlesso.pilatesapi.repository.PacienteRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -37,6 +38,13 @@ class NotaFiscalEmitidaServiceTest {
     @InjectMocks
     NotaFiscalEmitidaService service;
 
+    @BeforeEach
+    void setUp() {
+        // Em produção o proxy transacional é injetado via @Lazy; no teste unitário
+        // apontamos o "self" para a própria instância para que registrar() delegue ao upsert().
+        service.setSelf(service);
+    }
+
     @Test
     void registrar_quandoNaoExiste_deveCriarNota() {
         Paciente paciente = paciente();
@@ -66,7 +74,7 @@ class NotaFiscalEmitidaServiceTest {
         ArgumentCaptor<NotaFiscalEmitida> captor = ArgumentCaptor.forClass(NotaFiscalEmitida.class);
         org.mockito.Mockito.verify(repository).save(captor.capture());
         assertThat(captor.getValue().getCompetencia()).isEqualTo(LocalDate.of(2026, 4, 1));
-        assertThat(captor.getValue().getDataCriacao()).isNotNull();
+        // dataCriacao agora é preenchida pelo callback @PrePersist da entidade (coberto no teste de repositório).
     }
 
     @Test
@@ -93,7 +101,7 @@ class NotaFiscalEmitidaServiceTest {
         assertThat(response.id()).isEqualTo(9L);
         assertThat(response.numeroNota()).isEqualTo("NF-NOVA");
         assertThat(response.dataEmissao()).isEqualTo(LocalDate.of(2026, 4, 20));
-        assertThat(response.dataAtualizacao()).isNotNull();
+        // dataAtualizacao agora é preenchida pelo callback @PreUpdate da entidade.
     }
 
     @Test
@@ -118,6 +126,18 @@ class NotaFiscalEmitidaServiceTest {
         assertThatThrownBy(() -> service.registrar(dto))
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("maior que zero");
+    }
+
+    @Test
+    void registrar_dataEmissaoFutura_deveLancarErroDeNegocio() {
+        when(pacienteRepository.findByIdAndAtivoTrue(1L)).thenReturn(Optional.of(paciente()));
+
+        var dto = new NotaFiscalEmitidaRequestDTO(1L, "04/2026", "NF-1",
+                LocalDate.now().plusDays(1), new BigDecimal("250.00"), null);
+
+        assertThatThrownBy(() -> service.registrar(dto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("futura");
     }
 
     @Test

--- a/src/test/java/com/carlesso/pilatesapi/service/NotaFiscalEmitidaServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/NotaFiscalEmitidaServiceTest.java
@@ -1,0 +1,150 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.NotaFiscalEmitidaRequestDTO;
+import com.carlesso.pilatesapi.entity.NotaFiscalEmitida;
+import com.carlesso.pilatesapi.entity.Paciente;
+import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
+import com.carlesso.pilatesapi.repository.NotaFiscalEmitidaRepository;
+import com.carlesso.pilatesapi.repository.PacienteRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotaFiscalEmitidaServiceTest {
+
+    @Mock
+    NotaFiscalEmitidaRepository repository;
+
+    @Mock
+    PacienteRepository pacienteRepository;
+
+    @InjectMocks
+    NotaFiscalEmitidaService service;
+
+    @Test
+    void registrar_quandoNaoExiste_deveCriarNota() {
+        Paciente paciente = paciente();
+        when(pacienteRepository.findByIdAndAtivoTrue(1L)).thenReturn(Optional.of(paciente));
+        when(repository.findByPacienteIdAndCompetencia(1L, LocalDate.of(2026, 4, 1)))
+                .thenReturn(Optional.empty());
+        when(repository.save(any(NotaFiscalEmitida.class))).thenAnswer(inv -> {
+            NotaFiscalEmitida n = inv.getArgument(0);
+            ReflectionTestUtils.setField(n, "id", 5L);
+            return n;
+        });
+
+        var dto = new NotaFiscalEmitidaRequestDTO(1L, "04/2026", "NF-123",
+                LocalDate.of(2026, 4, 15), new BigDecimal("250.00"), "ok");
+
+        var response = service.registrar(dto);
+
+        assertThat(response.id()).isEqualTo(5L);
+        assertThat(response.pacienteId()).isEqualTo(1L);
+        assertThat(response.nomePaciente()).isEqualTo("Ana Souza");
+        assertThat(response.competencia()).isEqualTo("04/2026");
+        assertThat(response.numeroNota()).isEqualTo("NF-123");
+        assertThat(response.dataEmissao()).isEqualTo(LocalDate.of(2026, 4, 15));
+        assertThat(response.valor()).isEqualByComparingTo("250.00");
+        assertThat(response.dataAtualizacao()).isNull();
+
+        ArgumentCaptor<NotaFiscalEmitida> captor = ArgumentCaptor.forClass(NotaFiscalEmitida.class);
+        org.mockito.Mockito.verify(repository).save(captor.capture());
+        assertThat(captor.getValue().getCompetencia()).isEqualTo(LocalDate.of(2026, 4, 1));
+        assertThat(captor.getValue().getDataCriacao()).isNotNull();
+    }
+
+    @Test
+    void registrar_quandoJaExiste_deveAtualizarNota() {
+        Paciente paciente = paciente();
+        NotaFiscalEmitida existente = new NotaFiscalEmitida();
+        ReflectionTestUtils.setField(existente, "id", 9L);
+        existente.setPaciente(paciente);
+        existente.setCompetencia(LocalDate.of(2026, 4, 1));
+        existente.setNumeroNota("NF-ANTIGA");
+        existente.setDataEmissao(LocalDate.of(2026, 4, 5));
+        existente.setDataCriacao(LocalDateTime.of(2026, 4, 5, 10, 0));
+
+        when(pacienteRepository.findByIdAndAtivoTrue(1L)).thenReturn(Optional.of(paciente));
+        when(repository.findByPacienteIdAndCompetencia(1L, LocalDate.of(2026, 4, 1)))
+                .thenReturn(Optional.of(existente));
+        when(repository.save(any(NotaFiscalEmitida.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        var dto = new NotaFiscalEmitidaRequestDTO(1L, "04/2026", "NF-NOVA",
+                LocalDate.of(2026, 4, 20), new BigDecimal("300.00"), null);
+
+        var response = service.registrar(dto);
+
+        assertThat(response.id()).isEqualTo(9L);
+        assertThat(response.numeroNota()).isEqualTo("NF-NOVA");
+        assertThat(response.dataEmissao()).isEqualTo(LocalDate.of(2026, 4, 20));
+        assertThat(response.dataAtualizacao()).isNotNull();
+    }
+
+    @Test
+    void registrar_pacienteInexistente_deveLancar404() {
+        when(pacienteRepository.findByIdAndAtivoTrue(1L)).thenReturn(Optional.empty());
+
+        var dto = new NotaFiscalEmitidaRequestDTO(1L, "04/2026", "NF-1",
+                LocalDate.of(2026, 4, 15), null, null);
+
+        assertThatThrownBy(() -> service.registrar(dto))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Paciente não encontrado");
+    }
+
+    @Test
+    void registrar_valorNegativo_deveLancarErroDeNegocio() {
+        when(pacienteRepository.findByIdAndAtivoTrue(1L)).thenReturn(Optional.of(paciente()));
+
+        var dto = new NotaFiscalEmitidaRequestDTO(1L, "04/2026", "NF-1",
+                LocalDate.of(2026, 4, 15), new BigDecimal("-1.00"), null);
+
+        assertThatThrownBy(() -> service.registrar(dto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("maior que zero");
+    }
+
+    @Test
+    void registrar_competenciaInvalida_deveLancarErro() {
+        when(pacienteRepository.findByIdAndAtivoTrue(1L)).thenReturn(Optional.of(paciente()));
+
+        var dto = new NotaFiscalEmitidaRequestDTO(1L, "13/2026", "NF-1",
+                LocalDate.of(2026, 4, 15), null, null);
+
+        assertThatThrownBy(() -> service.registrar(dto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("MM/AAAA");
+    }
+
+    @Test
+    void listarPorPaciente_pacienteInexistente_deveLancar404() {
+        when(pacienteRepository.existsByIdAndAtivoTrue(1L)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.listarPorPaciente(1L))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    private Paciente paciente() {
+        Paciente paciente = new Paciente();
+        ReflectionTestUtils.setField(paciente, "id", 1L);
+        paciente.setNome("Ana Souza");
+        paciente.setCpf("11122233344");
+        return paciente;
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/service/RelatorioNfseServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/RelatorioNfseServiceTest.java
@@ -5,6 +5,7 @@ import com.carlesso.pilatesapi.entity.Pagamento;
 import com.carlesso.pilatesapi.entity.Plano;
 import com.carlesso.pilatesapi.entity.enums.StatusPagamento;
 import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.repository.NotaFiscalEmitidaRepository;
 import com.carlesso.pilatesapi.repository.PagamentoRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,6 +29,9 @@ class RelatorioNfseServiceTest {
     @Mock
     PagamentoRepository pagamentoRepository;
 
+    @Mock
+    NotaFiscalEmitidaRepository notaFiscalEmitidaRepository;
+
     @InjectMocks
     RelatorioNfseService service;
 
@@ -41,9 +45,8 @@ class RelatorioNfseServiceTest {
                 LocalDate.of(2026, 4, 1),
                 LocalDate.of(2026, 4, 30)))
                 .thenReturn(List.of(pagamento));
-        when(pagamentoRepository.findPacienteIdsComPagamentoConfirmadoAntes(
+        when(notaFiscalEmitidaRepository.findPacienteIdsComNotaEmitidaAntes(
                 List.of(1L),
-                StatusPagamento.PAGO,
                 LocalDate.of(2026, 4, 1)))
                 .thenReturn(List.of(1L));
 
@@ -59,9 +62,8 @@ class RelatorioNfseServiceTest {
             assertThat(item.dataPagamento()).isEqualTo(LocalDate.of(2026, 4, 10));
             assertThat(item.observacoes()).isEmpty();
         });
-        verify(pagamentoRepository).findPacienteIdsComPagamentoConfirmadoAntes(
+        verify(notaFiscalEmitidaRepository).findPacienteIdsComNotaEmitidaAntes(
                 List.of(1L),
-                StatusPagamento.PAGO,
                 LocalDate.of(2026, 4, 1));
     }
 
@@ -78,9 +80,8 @@ class RelatorioNfseServiceTest {
                 LocalDate.of(2026, 4, 1),
                 LocalDate.of(2026, 4, 30)))
                 .thenReturn(List.of(comNotaAnterior, semNotaAnterior));
-        when(pagamentoRepository.findPacienteIdsComPagamentoConfirmadoAntes(
+        when(notaFiscalEmitidaRepository.findPacienteIdsComNotaEmitidaAntes(
                 List.of(1L, 2L),
-                StatusPagamento.PAGO,
                 LocalDate.of(2026, 4, 1)))
                 .thenReturn(List.of(1L));
 
@@ -90,9 +91,8 @@ class RelatorioNfseServiceTest {
                 .singleElement()
                 .extracting("nome")
                 .isEqualTo("Bia Lima");
-        verify(pagamentoRepository).findPacienteIdsComPagamentoConfirmadoAntes(
+        verify(notaFiscalEmitidaRepository).findPacienteIdsComNotaEmitidaAntes(
                 List.of(1L, 2L),
-                StatusPagamento.PAGO,
                 LocalDate.of(2026, 4, 1));
     }
 
@@ -120,9 +120,8 @@ class RelatorioNfseServiceTest {
                 LocalDate.of(2026, 4, 1),
                 LocalDate.of(2026, 4, 30)))
                 .thenReturn(List.of(pagamento));
-        when(pagamentoRepository.findPacienteIdsComPagamentoConfirmadoAntes(
+        when(notaFiscalEmitidaRepository.findPacienteIdsComNotaEmitidaAntes(
                 List.of(1L),
-                StatusPagamento.PAGO,
                 LocalDate.of(2026, 4, 1)))
                 .thenReturn(List.of());
 


### PR DESCRIPTION
## Resumo

Adiciona persistência da última NFSE emitida por paciente/competência e passa a usar esse dado real no relatório fiscal, eliminando a inferência por pagamento confirmado anterior.

- Nova entidade `NotaFiscalEmitida` (tabela `notas_fiscais_emitidas`) com restrição única `(paciente, competência)`.
- Novos endpoints REST para registrar/atualizar e consultar NFSEs emitidas:
  - `POST /api/nfse-emitidas` — upsert idempotente por `(paciente, competência)`.
  - `GET /api/nfse-emitidas/paciente/{pacienteId}` — lista (competência desc).
- `GET /api/relatorios/nfse` agora preenche `notaAnteriorEmitida` com base nas notas persistidas (existe NFSE para o paciente em competência anterior à consultada).
- `CompetenciaUtils` centraliza validação/parsing/formatação de competências `MM/AAAA` (reaproveitado pelo relatório e pelo registro).
- Migração `V26__create_notas_fiscais_emitidas_table.sql`.

## Motivo

A issue #8 introduziu o relatório de NFSEs, mas `notaAnteriorEmitida` era apenas inferido por pagamento confirmado anterior, pois não havia persistência de NFSE no modelo. Esta mudança registra a NFSE efetivamente emitida e usa o dado real no relatório.

## Testes executados

- `mvn test` — **490 testes, 0 falhas**.
- `mvn package -DskipTests` — build do JAR concluído com sucesso.
- Novos testes: `NotaFiscalEmitidaServiceTest` (6), `NotaFiscalEmitidaControllerTest` (4), `NotaFiscalEmitidaRepositoryTest` (3).
- Testes ajustados pela nova fonte de dados: `RelatorioNfseServiceTest`, `PagamentoRepositoryTest` (remoção da consulta de inferência agora não utilizada).

## Arquivos principais alterados

**Novos**
- `entity/NotaFiscalEmitida.java`
- `repository/NotaFiscalEmitidaRepository.java`
- `dto/NotaFiscalEmitidaRequestDTO.java`, `dto/NotaFiscalEmitidaResponseDTO.java`
- `service/NotaFiscalEmitidaService.java`
- `controller/NotaFiscalEmitidaController.java`
- `util/CompetenciaUtils.java`
- `db/migration/V26__create_notas_fiscais_emitidas_table.sql`

**Modificados**
- `service/RelatorioNfseService.java` — usa NFSEs persistidas em `notaAnteriorEmitida`.
- `repository/PagamentoRepository.java` — remove consulta de inferência não mais utilizada.
- `README.md`, `docs/context.md` — documentação dos endpoints, tabela e regras.

## Referência

Closes #38

---
_Generated by [Claude Code](https://claude.ai/code/session_01L22eU9JhRnUbKBHFqR8Ycf)_