### PR TITLE
feat(auth): recuperação de senha via e-mail

### DIFF
--- a/README.md
+++ b/README.md
@@ -859,6 +859,7 @@ cd scripts && python3 -m unittest test_import_seufisio -v
 | `APP_EMAIL_PROVIDER` | `smtp` | Provedor de e-mail ativo (seleciona o bean `EmailSender` via `EmailConfig`) |
 | `APP_EMAIL_FROM` | `no-reply@carlessopilates.com.br` | Remetente usado no envio de e-mails transacionais |
 | `APP_EMAIL_RESET_PASSWORD_URL` | `https://app.carlessopilates.com.br/resetar-senha` | URL do frontend para onde o link de redefinição de senha aponta (`?token=...`) |
+| `APP_EMAIL_RESET_PASSWORD_TOKEN_TTL_MINUTOS` | `30` | Validade do token de redefinição de senha; a mesma propriedade define o prazo real e o texto exibido no e-mail |
 | `SMTP_HOST` | - | Host do servidor SMTP usado pelo `SmtpEmailSender` |
 | `SMTP_PORT` | `587` | Porta do servidor SMTP |
 | `SMTP_USERNAME` | - | Usuário de autenticação SMTP |
@@ -1124,11 +1125,12 @@ curl -s "http://localhost:8080/api/nfse-emitidas/paciente/1" \
 
 ### Recuperação de senha (esqueci minha senha)
 - `POST /auth/forgot-password` recebe `email` e sempre retorna `200` com resposta genérica, mesmo se o e-mail não existir ou pertencer a um usuário inativo, para evitar enumeração de usuários
-- Rate limiting reaproveita o `LoginAttemptService` (5 solicitações por e-mail em 15 minutos); acima do limite retorna `429`
-- Token de redefinição: gerado aleatoriamente (32 bytes, Base64 URL-safe), salvo em `password_reset_tokens` **apenas como hash SHA-256** (nunca em texto puro), com expiração de 30 minutos e uso único
+- Rate limiting reaproveita o `LoginAttemptService` (5 solicitações por e-mail em 15 minutos); acima do limite retorna `429`. Chaves cujas tentativas já saíram da janela são removidas do mapa em memória tanto ao consultar o limite quanto periodicamente por `LoginAttemptCleanupScheduler` (a cada 15 min), evitando crescimento ilimitado via solicitações não autenticadas
+- Ao gerar um novo token, qualquer token anterior ainda válido do mesmo usuário é invalidado — apenas o token da solicitação mais recente funciona
+- Token de redefinição: gerado aleatoriamente (32 bytes, Base64 URL-safe), salvo em `password_reset_tokens` **apenas como hash SHA-256** (nunca em texto puro), com expiração configurável (`app.email.reset-password-token-ttl-minutos`, default 30 min — a mesma propriedade usada no texto do e-mail) e uso único
 - O e-mail de redefinição é montado a partir do template Thymeleaf `password-reset.html` e enviado de forma assíncrona (`@Async`) via `EmailSender`, sem bloquear a resposta do `forgot-password`
-- `POST /auth/reset-password` recebe `token`, `novaSenha` (mín. 8 caracteres) e `confirmacaoNovaSenha`; token inexistente, expirado ou já utilizado, assim como confirmação divergente, retornam `422` com mensagem genérica
-- Ao redefinir com sucesso: a senha é armazenada com `BCryptPasswordEncoder`, o `token_version` do usuário é incrementado (invalidando JWTs emitidos antes da redefinição) e o token é marcado como usado
+- `POST /auth/reset-password` recebe `token`, `novaSenha` (mín. 8 caracteres) e `confirmacaoNovaSenha`; token inexistente, expirado ou já utilizado, assim como confirmação divergente, retornam `422` com mensagem genérica. A busca do token usa lock pessimista (`@Lock(PESSIMISTIC_WRITE)`) para impedir que duas requisições concorrentes redimam o mesmo token de uso único
+- Ao redefinir com sucesso: a senha é armazenada com `BCryptPasswordEncoder` e o `token_version` do usuário é incrementado (invalidando JWTs emitidos antes da redefinição) via `UserService.aplicarNovaSenha`, reaproveitado também por `PUT /users/me/senha` e pelo CRUD administrativo; o token é marcado como usado
 - Troca de provedor de e-mail (SMTP → SES, por exemplo) exige apenas uma nova implementação de `EmailSender` e ajuste em `EmailConfig`/`app.email.provider`, sem alterar `PasswordResetService`
 
 ### Scheduler (processos automáticos)
@@ -1209,9 +1211,10 @@ O projeto possui testes unitários, de controller e de integração organizados 
 | `PreferenciasUsuarioServiceTest` | Unitário (Mockito) | 7 |
 | `PreferenciasUsuarioControllerTest` | Controller (`@WebMvcTest`) | 6 |
 | `PreferenciasUsuarioRepositoryTest` | Repositório (`@DataJpaTest` + H2) | 5 |
-| `PasswordResetServiceTest` | Unitário (Mockito) | 10 |
+| `PasswordResetServiceTest` | Unitário (Mockito) | 12 |
+| `LoginAttemptServiceTest` | Unitário (sem mocks) | 6 |
 | `AuthControllerTest` | Controller (`@WebMvcTest`) | 9 |
-| `PasswordResetIntegrationTest` | Integração (`@SpringBootTest` + MockMvc + H2, `EmailSender` mockado) | 5 |
+| `PasswordResetIntegrationTest` | Integração (`@SpringBootTest` + MockMvc + H2, `EmailSender` mockado) | 6 |
 | `SecurityIntegrationTest` | Integração (`@SpringBootTest` + MockMvc + H2) | 42 |
 | `ActuatorTest` | Integração (`@SpringBootTest`) | 3 |
 | `PilatesApiApplicationTests` | Integração (`@SpringBootTest`) | 1 |

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ Base URL: `http://localhost:8080`
 |---|---|---|---|
 | `POST` | `/auth/register` | Público | Registra usuário com role `USER`, salva senha com BCrypt e retorna JWT |
 | `POST` | `/auth/login` | Público | Valida e-mail/senha e retorna JWT. Retorna `429` após 5 tentativas falhas em 15 min |
+| `POST` | `/auth/forgot-password` | Público | Solicita redefinição de senha por e-mail. Sempre retorna `200` com mensagem genérica, mesmo se o e-mail não existir (evita enumeração de usuários). Retorna `429` após 5 solicitações em 15 min para o mesmo e-mail |
+| `POST` | `/auth/reset-password` | Público | Redefine a senha a partir de `token`, `novaSenha` (mín. 8 caracteres) e `confirmacaoNovaSenha`. Retorna `422` para token inválido, expirado, já utilizado ou confirmação divergente |
 | `GET` | `/users/me` | Autenticado | Retorna dados seguros do usuário autenticado |
 | `PUT` | `/users/me/senha` | Autenticado | Troca a própria senha informando `senhaAtual`, `novaSenha` (mín. 8 caracteres) e `confirmacaoNovaSenha`. Retorna `422` para senha atual incorreta, confirmação divergente ou reuso da senha atual. Tokens emitidos antes da troca deixam de autorizar rotas protegidas |
 | `GET` | `/users/me/preferencias` | Autenticado | Retorna as preferências do usuário autenticado (idioma, tema e notificações). Usuário sem preferências salvas recebe os valores padrão |
@@ -770,6 +772,7 @@ O projeto utiliza **Flyway** para versionamento e execução automática das mig
 | `V23__add_pacientes_email_cpf_partial_unique.sql` | Recria a unicidade como índice **parcial** (`WHERE col IS NOT NULL`) — múltiplos pacientes podem ter `email`/`cpf` nulos, mas valores preenchidos seguem únicos. `PacienteService.cadastrar` também valida e retorna 409 antes de chegar no banco |
 | `V24__add_token_version_to_users.sql` | Adiciona coluna `token_version` em `users` para invalidar JWTs anteriores após troca/redefinição de senha |
 | `V25__create_preferencias_usuario_table.sql` | Cria tabela `preferencias_usuario` (1:1 com `users`) para idioma, tema e preferências de notificação |
+| `V26__create_password_reset_tokens_table.sql` | Cria tabela `password_reset_tokens` para o fluxo de recuperação de senha; token salvo apenas como hash SHA-256 |
 
 ### Migrations de seed (`db/seed/`) — apenas perfil `dev`
 
@@ -853,6 +856,13 @@ cd scripts && python3 -m unittest test_import_seufisio -v
 | `APP_COBRANCA_CRON_COBRANCAS_FUTURAS` | `0 0 7 * * *` | Cron expression do scheduler que gera cobranças futuras |
 | `APP_COBRANCA_VENCIMENTO_DIAS` | `10` | Dias somados ao início do período para definir o vencimento das cobranças geradas |
 | `APP_PAGINACAO_TAMANHO_PADRAO` | `10` | Tamanho padrão de página nas listagens paginadas |
+| `APP_EMAIL_PROVIDER` | `smtp` | Provedor de e-mail ativo (seleciona o bean `EmailSender` via `EmailConfig`) |
+| `APP_EMAIL_FROM` | `no-reply@carlessopilates.com.br` | Remetente usado no envio de e-mails transacionais |
+| `APP_EMAIL_RESET_PASSWORD_URL` | `https://app.carlessopilates.com.br/resetar-senha` | URL do frontend para onde o link de redefinição de senha aponta (`?token=...`) |
+| `SMTP_HOST` | - | Host do servidor SMTP usado pelo `SmtpEmailSender` |
+| `SMTP_PORT` | `587` | Porta do servidor SMTP |
+| `SMTP_USERNAME` | - | Usuário de autenticação SMTP |
+| `SMTP_PASSWORD` | - | Senha de autenticação SMTP |
 
 ---
 
@@ -881,6 +891,18 @@ Usuários iniciais criados pela migration de seed `V12` no perfil `dev` usam a s
 | `recepcao@carlessopilates.com` | `USER` |
 | `financeiro@carlessopilates.com` | `USER` |
 | `consulta@carlessopilates.com` | `USER` |
+
+### Recuperar senha esquecida
+```bash
+curl -s -X POST http://localhost:8080/auth/forgot-password \
+  -H "Content-Type: application/json" \
+  -d '{"email":"maria@email.com"}' -w "%{http_code}"
+
+# Token chega por e-mail (link com ?token=...); com o token em mãos:
+curl -s -X POST http://localhost:8080/auth/reset-password \
+  -H "Content-Type: application/json" \
+  -d '{"token":"<token-recebido-por-email>","novaSenha":"novaSenha123","confirmacaoNovaSenha":"novaSenha123"}' | jq
+```
 
 ### Gerenciar usuários como ADMIN
 ```bash
@@ -1100,6 +1122,15 @@ curl -s "http://localhost:8080/api/nfse-emitidas/paciente/1" \
 - Consultas e atualizações filtram sessões de pacientes ativos
 - Atualização parcial: apenas campos não-nulos do DTO de update são aplicados
 
+### Recuperação de senha (esqueci minha senha)
+- `POST /auth/forgot-password` recebe `email` e sempre retorna `200` com resposta genérica, mesmo se o e-mail não existir ou pertencer a um usuário inativo, para evitar enumeração de usuários
+- Rate limiting reaproveita o `LoginAttemptService` (5 solicitações por e-mail em 15 minutos); acima do limite retorna `429`
+- Token de redefinição: gerado aleatoriamente (32 bytes, Base64 URL-safe), salvo em `password_reset_tokens` **apenas como hash SHA-256** (nunca em texto puro), com expiração de 30 minutos e uso único
+- O e-mail de redefinição é montado a partir do template Thymeleaf `password-reset.html` e enviado de forma assíncrona (`@Async`) via `EmailSender`, sem bloquear a resposta do `forgot-password`
+- `POST /auth/reset-password` recebe `token`, `novaSenha` (mín. 8 caracteres) e `confirmacaoNovaSenha`; token inexistente, expirado ou já utilizado, assim como confirmação divergente, retornam `422` com mensagem genérica
+- Ao redefinir com sucesso: a senha é armazenada com `BCryptPasswordEncoder`, o `token_version` do usuário é incrementado (invalidando JWTs emitidos antes da redefinição) e o token é marcado como usado
+- Troca de provedor de e-mail (SMTP → SES, por exemplo) exige apenas uma nova implementação de `EmailSender` e ajuste em `EmailConfig`/`app.email.provider`, sem alterar `PasswordResetService`
+
 ### Scheduler (processos automáticos)
 | Horário | Ação | Configuração |
 |---|---|---|
@@ -1178,6 +1209,9 @@ O projeto possui testes unitários, de controller e de integração organizados 
 | `PreferenciasUsuarioServiceTest` | Unitário (Mockito) | 7 |
 | `PreferenciasUsuarioControllerTest` | Controller (`@WebMvcTest`) | 6 |
 | `PreferenciasUsuarioRepositoryTest` | Repositório (`@DataJpaTest` + H2) | 5 |
+| `PasswordResetServiceTest` | Unitário (Mockito) | 10 |
+| `AuthControllerTest` | Controller (`@WebMvcTest`) | 9 |
+| `PasswordResetIntegrationTest` | Integração (`@SpringBootTest` + MockMvc + H2, `EmailSender` mockado) | 5 |
 | `SecurityIntegrationTest` | Integração (`@SpringBootTest` + MockMvc + H2) | 42 |
 | `ActuatorTest` | Integração (`@SpringBootTest`) | 3 |
 | `PilatesApiApplicationTests` | Integração (`@SpringBootTest`) | 1 |

--- a/docs/context.md
+++ b/docs/context.md
@@ -188,9 +188,11 @@ com.carlesso.pilatesapi
 │   ├── ForgotPasswordRequestDTO.java  — payload de "esqueci minha senha" (record: email)
 │   └── ResetPasswordRequestDTO.java   — payload de redefinição de senha (record: token, novaSenha, confirmacaoNovaSenha)
 ├── scheduler
-│   └── CobrancaScheduler.java        — atualiza vencidos e gera cobranças futuras
+│   ├── CobrancaScheduler.java        — atualiza vencidos e gera cobranças futuras
+│   └── LoginAttemptCleanupScheduler.java — remove periodicamente do LoginAttemptService chaves cujas tentativas já saíram da janela, evitando crescimento ilimitado do mapa em memória
 └── util
-    └── CompetenciaUtils.java         — validação/parsing/formatação de competências `MM/AAAA` (compartilhado pelo relatório e registro de NFSE)
+    ├── CompetenciaUtils.java         — validação/parsing/formatação de competências `MM/AAAA` (compartilhado pelo relatório e registro de NFSE)
+    └── EmailNormalizer.java          — normalização de e-mail (lowercase, locale-independente) compartilhada entre os services que identificam usuários por e-mail
 ```
 
 ---
@@ -589,11 +591,11 @@ CPF não pode ser alterado após o cadastro.
 
 ### Recuperação de senha (esqueci minha senha)
 - `POST /auth/forgot-password` recebe `email` e sempre retorna `200` com resposta genérica, independentemente de o e-mail existir ou pertencer a um usuário ativo, para evitar enumeração de usuários
-- Rate limiting reaproveitando `LoginAttemptService` (mesmo limite de login: 5 solicitações por e-mail em 15 minutos); acima do limite retorna `429 Too Many Requests`
-- Quando o e-mail pertence a um usuário ativo, é gerado um token aleatório (32 bytes, Base64 URL-safe) e salvo em `password_reset_tokens` **apenas como hash SHA-256**, com expiração de 30 minutos; o token em texto puro nunca é persistido, apenas enviado por e-mail
+- Rate limiting reaproveitando `LoginAttemptService` (mesmo limite de login: 5 solicitações por e-mail em 15 minutos); acima do limite retorna `429 Too Many Requests`. Chaves cujas tentativas já saíram da janela são removidas do mapa em memória tanto ao consultar o limite quanto periodicamente por `LoginAttemptCleanupScheduler` (a cada 15 min), evitando crescimento ilimitado de memória via solicitações não autenticadas
+- Quando o e-mail pertence a um usuário ativo, qualquer token de redefinição anterior ainda válido é invalidado e um novo token aleatório (32 bytes, Base64 URL-safe) é gerado e salvo em `password_reset_tokens` **apenas como hash SHA-256**, com expiração configurável (`app.email.reset-password-token-ttl-minutos`, default 30 min — a mesma propriedade usada no texto do e-mail, evitando divergência entre o prazo real e o exibido ao usuário); o token em texto puro nunca é persistido, apenas enviado por e-mail. Apenas o token da solicitação mais recente é válido
 - O e-mail é montado a partir do template Thymeleaf `password-reset.html` e enviado de forma assíncrona (`@Async`) via `EmailSender`, sem bloquear a resposta do `forgot-password`
-- `POST /auth/reset-password` recebe `token`, `novaSenha` (mínimo 8 caracteres) e `confirmacaoNovaSenha`; token inexistente, expirado ou já utilizado retorna `422 Unprocessable Entity` com mensagem genérica ("Token inválido ou expirado"), assim como confirmação de senha divergente
-- Ao redefinir com sucesso, a senha é armazenada com `BCryptPasswordEncoder`, o `token_version` do usuário é incrementado (invalidando JWTs emitidos antes da redefinição) e o token de redefinição é marcado como usado (`used_at`), não podendo ser reutilizado
+- `POST /auth/reset-password` recebe `token`, `novaSenha` (mínimo 8 caracteres) e `confirmacaoNovaSenha`; token inexistente, expirado ou já utilizado retorna `422 Unprocessable Entity` com mensagem genérica ("Token inválido ou expirado"), assim como confirmação de senha divergente. A busca do token usa lock pessimista (`@Lock(PESSIMISTIC_WRITE)`, mesmo padrão de `UserRepository.findByEmailForUpdate`) para impedir que duas requisições concorrentes redimam o mesmo token de uso único
+- Ao redefinir com sucesso, a senha é armazenada com `BCryptPasswordEncoder` e o `token_version` do usuário é incrementado (invalidando JWTs emitidos antes da redefinição) através do mesmo `UserService.aplicarNovaSenha` reaproveitado por `PUT /users/me/senha` e pelo CRUD administrativo de usuários; o token de redefinição é marcado como usado (`used_at`), não podendo ser reutilizado
 - A troca de provedor de e-mail (SMTP → SES, por exemplo) é feita apenas registrando uma nova implementação de `EmailSender` e ajustando `EmailConfig`/`app.email.provider`, sem alterar `PasswordResetService`
 
 ### Pacientes
@@ -763,6 +765,7 @@ A quantidade de dias até o vencimento das cobranças geradas é controlada por 
 | `APP_EMAIL_PROVIDER` | `smtp` |
 | `APP_EMAIL_FROM` | `no-reply@carlessopilates.com.br` |
 | `APP_EMAIL_RESET_PASSWORD_URL` | `https://app.carlessopilates.com.br/resetar-senha` |
+| `APP_EMAIL_RESET_PASSWORD_TOKEN_TTL_MINUTOS` | `30` |
 | `SMTP_HOST` | — (obrigatório para envio real de e-mail) |
 | `SMTP_PORT` | `587` |
 | `SMTP_USERNAME` | — |
@@ -804,14 +807,14 @@ spring.data.web.pageable.default-page-size=${APP_PAGINACAO_TAMANHO_PADRAO:10}
 app.email.provider=${APP_EMAIL_PROVIDER:smtp}
 app.email.from=${APP_EMAIL_FROM:no-reply@carlessopilates.com.br}
 app.email.reset-password-url=${APP_EMAIL_RESET_PASSWORD_URL:https://app.carlessopilates.com.br/resetar-senha}
+app.email.reset-password-token-ttl-minutos=${APP_EMAIL_RESET_PASSWORD_TOKEN_TTL_MINUTOS:30}
 spring.mail.host=${SMTP_HOST:}
 spring.mail.port=${SMTP_PORT:587}
 spring.mail.username=${SMTP_USERNAME:}
 spring.mail.password=${SMTP_PASSWORD:}
-management.health.mail.enabled=false
 ```
 
-Os valores `app.cobranca.*` são vinculados pela classe `config/AppProperties` (Spring `@ConfigurationProperties`), evitando magic numbers e cron expressions hardcoded em código. A paginação usa a propriedade nativa do Spring Data Web, alimentada pela variável de ambiente `APP_PAGINACAO_TAMANHO_PADRAO`. O indicador de saúde do Actuator para `mail` é desabilitado (`management.health.mail.enabled=false`) para que uma falha de conectividade SMTP não derrube o status geral de `/actuator/health` — o envio de e-mail é assíncrono e não crítico para a disponibilidade da API.
+Os valores `app.cobranca.*` são vinculados pela classe `config/AppProperties` (Spring `@ConfigurationProperties`), evitando magic numbers e cron expressions hardcoded em código. A paginação usa a propriedade nativa do Spring Data Web, alimentada pela variável de ambiente `APP_PAGINACAO_TAMANHO_PADRAO`. A mesma propriedade `app.email.reset-password-token-ttl-minutos` define tanto a expiração real do token de redefinição quanto o texto exibido no e-mail, evitando divergência entre os dois. O indicador de saúde do Actuator para `mail` (`management.health.mail.enabled=false`) é desabilitado apenas nos perfis `dev` e nos testes, onde normalmente não há um servidor SMTP real disponível; em produção ele permanece ativo para refletir o estado real da conectividade SMTP em `/actuator/health`.
 
 ---
 
@@ -892,14 +895,15 @@ mvn spring-boot:run
 | `EvolucaoSessaoControllerTest` | `@WebMvcTest` + MockMvc | 13 |
 | `ReavaliacaoServiceTest` | Unitário (Mockito, sem Spring) | 14 |
 | `ReavaliacaoControllerTest` | `@WebMvcTest` + MockMvc | 9 |
-| `UserServiceTest` | Unitário (Mockito, sem Spring) | 8 |
+| `UserServiceTest` | Unitário (Mockito, sem Spring) | 23 |
 | `UserControllerTest` | `@WebMvcTest` + MockMvc | 8 |
 | `PreferenciasUsuarioServiceTest` | Unitário (Mockito, sem Spring) | 7 |
 | `PreferenciasUsuarioControllerTest` | `@WebMvcTest` + MockMvc | 6 |
 | `PreferenciasUsuarioRepositoryTest` | `@DataJpaTest` + H2 | 5 |
-| `PasswordResetServiceTest` | Unitário (Mockito, sem Spring) | 10 |
+| `PasswordResetServiceTest` | Unitário (Mockito, sem Spring) | 12 |
+| `LoginAttemptServiceTest` | Unitário (sem mocks) | 6 |
 | `AuthControllerTest` | `@WebMvcTest` + MockMvc | 9 |
-| `PasswordResetIntegrationTest` | `@SpringBootTest` + MockMvc + H2 (EmailSender mockado) | 5 |
+| `PasswordResetIntegrationTest` | `@SpringBootTest` + MockMvc + H2 (EmailSender mockado) | 6 |
 | `SecurityIntegrationTest` | `@SpringBootTest` + MockMvc + H2 | 42 |
 | `ActuatorTest` | `@SpringBootTest` + H2 | 3 |
 | `PilatesApiApplicationTests` | `@SpringBootTest` + H2 | 1 |

--- a/docs/context.md
+++ b/docs/context.md
@@ -35,9 +35,16 @@ API REST para gerenciar pacientes e profissionais de um estúdio de pilates. Per
 com.carlesso.pilatesapi
 ├── config
 │   ├── AppProperties.java            — @ConfigurationProperties (cobranca)
+│   ├── EmailConfig.java              — bean do EmailSender ativo, selecionado via @ConditionalOnProperty("app.email.provider") (hoje só `smtp`; troca futura para `ses` não exige mudança no PasswordResetService)
 │   ├── GlobalExceptionHandler.java   — mapeia exceções customizadas para HTTP (404/409/422)
 │   ├── OpenApiConfig.java            — configuração do Swagger/OpenAPI
 │   └── SecurityConfig.java           — regras de acesso, CORS e sessão stateless
+├── email
+│   ├── EmailMessage.java             — record (to, subject, htmlBody, textBody)
+│   ├── EmailSender.java              — interface de envio, implementada por SmtpEmailSender (portável para outros provedores)
+│   ├── EmailTemplateService.java     — interface de geração de EmailMessage a partir de template + variáveis
+│   ├── SmtpEmailSender.java          — implementação via JavaMailSender, envio assíncrono (@Async)
+│   └── ThymeleafEmailTemplateService.java — implementação via Thymeleaf + template `password-reset.html`
 ├── exception
 │   ├── ResourceNotFoundException.java — 404 (recurso não encontrado)
 │   ├── ConflictException.java         — 409 (conflito de estado/duplicidade)
@@ -82,9 +89,10 @@ com.carlesso.pilatesapi
 │   ├── AuthService.java                        — registro/login, emissão de token e rate limiting
 │   ├── UserService.java                        — CRUD de usuários e definição de perfis de acesso
 │   ├── JwtService.java                         — geração (claims role/userId) e validação de JWT
-│   ├── LoginAttemptService.java                — rate limiting in-memory por e-mail (5 tentativas / 15 min)
+│   ├── LoginAttemptService.java                — rate limiting in-memory por chave (e-mail de login ou de recuperação de senha; 5 tentativas / 15 min)
 │   ├── CustomUserDetailsService.java           — carregamento de usuários para Spring Security
-│   └── PreferenciasUsuarioService.java         — leitura/atualização das preferências do usuário com defaults centralizados
+│   ├── PreferenciasUsuarioService.java         — leitura/atualização das preferências do usuário com defaults centralizados
+│   └── PasswordResetService.java               — geração/validação de token de redefinição de senha (hash SHA-256) e redefinição com invalidação de JWTs ativos
 ├── repository
 │   ├── PacienteRepository.java       — acesso ao banco via Spring Data JPA
 │   ├── ProfissionalRepository.java   — acesso ao banco via Spring Data JPA
@@ -99,7 +107,8 @@ com.carlesso.pilatesapi
 │   ├── ReavaliacaoRepository.java
 │   ├── UserRepository.java
 │   ├── PreferenciasUsuarioRepository.java
-│   └── NotaFiscalEmitidaRepository.java
+│   ├── NotaFiscalEmitidaRepository.java
+│   └── PasswordResetTokenRepository.java
 ├── entity
 │   ├── Paciente.java                 — entidade JPA, tabela `pacientes`
 │   ├── Endereco.java                 — @Embeddable, colunas embutidas em `pacientes`
@@ -115,7 +124,8 @@ com.carlesso.pilatesapi
 │   ├── Reavaliacao.java              — entidade JPA, tabela `reavaliacoes`
 │   ├── User.java                     — entidade JPA, tabela `users`
 │   ├── PreferenciasUsuario.java      — entidade JPA, tabela `preferencias_usuario` (1:1 com `users`)
-│   └── NotaFiscalEmitida.java        — entidade JPA, tabela `notas_fiscais_emitidas` (NFSE emitida por paciente/competência)
+│   ├── NotaFiscalEmitida.java        — entidade JPA, tabela `notas_fiscais_emitidas` (NFSE emitida por paciente/competência)
+│   └── PasswordResetToken.java       — entidade JPA, tabela `password_reset_tokens` (token de redefinição de senha, salvo apenas como hash)
 ├── entity/enums
 │   ├── TipoPagamento.java            — MENSAL, TRIMESTRAL, ANUAL
 │   ├── TipoContrato.java             — CLT, PJ, AUTONOMO
@@ -174,7 +184,9 @@ com.carlesso.pilatesapi
 │   ├── UserUpdateDTO.java
 │   ├── UserResponseDTO.java
 │   ├── PreferenciasUsuarioRequestDTO.java  — payload de atualização das preferências (idioma, tema, notificações)
-│   └── PreferenciasUsuarioResponseDTO.java — resposta das preferências (record com factory method `from`)
+│   ├── PreferenciasUsuarioResponseDTO.java — resposta das preferências (record com factory method `from`)
+│   ├── ForgotPasswordRequestDTO.java  — payload de "esqueci minha senha" (record: email)
+│   └── ResetPasswordRequestDTO.java   — payload de redefinição de senha (record: token, novaSenha, confirmacaoNovaSenha)
 ├── scheduler
 │   └── CobrancaScheduler.java        — atualiza vencidos e gera cobranças futuras
 └── util
@@ -437,6 +449,19 @@ Relacionamento `@OneToOne` com `User` (1:1, owning side em `preferencias_usuario
 
 Restrição `UNIQUE (paciente_id, competencia)` garante uma única NFSE emitida por paciente em cada competência (registro idempotente via `POST /api/nfse-emitidas`). É a fonte de verdade do campo `notaAnteriorEmitida` do relatório de NFSE.
 
+### Tabela `password_reset_tokens`
+
+| Campo | Tipo | Restrição |
+|---|---|---|
+| `id` | BIGINT | PK, auto-increment |
+| `user_id` | BIGINT | NOT NULL, FK → users `ON DELETE CASCADE` |
+| `token_hash` | VARCHAR(64) | NOT NULL, UNIQUE (hash SHA-256 do token; o token em texto puro nunca é persistido) |
+| `expires_at` | TIMESTAMP | NOT NULL |
+| `used_at` | TIMESTAMP | nullable (marcado no uso; token de uso único) |
+| `created_at` | TIMESTAMP | NOT NULL |
+
+Relacionamento `@ManyToOne` com `User`. Cada solicitação de "esqueci minha senha" gera um novo registro; tokens não são reutilizados entre solicitações.
+
 ### Índices
 
 | Índice | Tabela / Coluna | Motivação |
@@ -453,6 +478,7 @@ Restrição `UNIQUE (paciente_id, competencia)` garante uma única NFSE emitida 
 | `idx_sessoes_pilates_paciente_id` | `sessoes_pilates(paciente_id)` | Listagem de sessões por paciente |
 | `idx_sessoes_pilates_data` | `sessoes_pilates(data)` | Busca e ordenação de sessões por data |
 | `idx_notas_fiscais_emitidas_paciente` | `notas_fiscais_emitidas(paciente_id)` | Listagem de NFSEs por paciente e lookup do relatório de NFSE |
+| `idx_password_reset_tokens_user_id` | `password_reset_tokens(user_id)` | Suporte a possíveis consultas administrativas/cleanup por usuário |
 > **Nota:** colunas `plano_dias_semana(plano_id)`, `pagamentos(plano_id)`, `aulas(paciente_id)` e `anamneses(paciente_id)` **não** possuem índice dedicado porque já são o prefixo esquerdo de índices compostos existentes ou possuem índice automático de constraint `UNIQUE`, que o PostgreSQL pode usar para buscas na coluna isolada.
 
 ---
@@ -463,6 +489,8 @@ Restrição `UNIQUE (paciente_id, competencia)` garante uma única NFSE emitida 
 |---|---|---|---|
 | POST | `/auth/register` | Registrar usuário `USER` com senha BCrypt e retornar JWT | 200 / 400 / 409 |
 | POST | `/auth/login` | Autenticar e retornar JWT | 200 / 400 / 401 |
+| POST | `/auth/forgot-password` | Solicitar redefinição de senha por e-mail; sempre retorna 200 genérico (evita enumeração de usuários) | 200 / 400 / 429 |
+| POST | `/auth/reset-password` | Redefinir senha a partir de um token de redefinição válido, não expirado e ainda não utilizado | 200 / 400 / 422 |
 | GET | `/users/me` | Consultar usuário autenticado sem expor senha | 200 / 401 |
 | PUT | `/users/me/senha` | Trocar a própria senha (autenticado) informando senha atual, nova senha e confirmação | 204 / 400 / 401 / 422 |
 | GET | `/users/me/preferencias` | Consultar preferências do usuário autenticado; sem registro retorna defaults (`PT_BR`/`CLARO`/email=true/push=false) | 200 / 401 |
@@ -558,6 +586,15 @@ CPF não pode ser alterado após o cadastro.
 - Usuário autenticado pode trocar a própria senha via `PUT /users/me/senha`: precisa informar `senhaAtual`, `novaSenha` (mínimo 8 caracteres) e `confirmacaoNovaSenha`; senha atual incorreta, confirmação divergente ou reuso da senha atual retornam `422 Unprocessable Entity`; a nova senha é armazenada com `BCryptPasswordEncoder` e tokens emitidos antes da troca passam a retornar `401 Unauthorized`
 - CORS permite o frontend Angular configurado em `CORS_ALLOWED_ORIGINS` (padrão `http://localhost:4200`)
 - Token ausente, inválido ou expirado em rota protegida retorna `401`; usuário sem `ADMIN` em `/admin/**` retorna `403`
+
+### Recuperação de senha (esqueci minha senha)
+- `POST /auth/forgot-password` recebe `email` e sempre retorna `200` com resposta genérica, independentemente de o e-mail existir ou pertencer a um usuário ativo, para evitar enumeração de usuários
+- Rate limiting reaproveitando `LoginAttemptService` (mesmo limite de login: 5 solicitações por e-mail em 15 minutos); acima do limite retorna `429 Too Many Requests`
+- Quando o e-mail pertence a um usuário ativo, é gerado um token aleatório (32 bytes, Base64 URL-safe) e salvo em `password_reset_tokens` **apenas como hash SHA-256**, com expiração de 30 minutos; o token em texto puro nunca é persistido, apenas enviado por e-mail
+- O e-mail é montado a partir do template Thymeleaf `password-reset.html` e enviado de forma assíncrona (`@Async`) via `EmailSender`, sem bloquear a resposta do `forgot-password`
+- `POST /auth/reset-password` recebe `token`, `novaSenha` (mínimo 8 caracteres) e `confirmacaoNovaSenha`; token inexistente, expirado ou já utilizado retorna `422 Unprocessable Entity` com mensagem genérica ("Token inválido ou expirado"), assim como confirmação de senha divergente
+- Ao redefinir com sucesso, a senha é armazenada com `BCryptPasswordEncoder`, o `token_version` do usuário é incrementado (invalidando JWTs emitidos antes da redefinição) e o token de redefinição é marcado como usado (`used_at`), não podendo ser reutilizado
+- A troca de provedor de e-mail (SMTP → SES, por exemplo) é feita apenas registrando uma nova implementação de `EmailSender` e ajustando `EmailConfig`/`app.email.provider`, sem alterar `PasswordResetService`
 
 ### Pacientes
 - Apenas um plano ativo por paciente por vez
@@ -723,6 +760,13 @@ A quantidade de dias até o vencimento das cobranças geradas é controlada por 
 | `APP_COBRANCA_CRON_COBRANCAS_FUTURAS` | `0 0 7 * * *` |
 | `APP_COBRANCA_VENCIMENTO_DIAS` | `10` |
 | `APP_PAGINACAO_TAMANHO_PADRAO` | `10` |
+| `APP_EMAIL_PROVIDER` | `smtp` |
+| `APP_EMAIL_FROM` | `no-reply@carlessopilates.com.br` |
+| `APP_EMAIL_RESET_PASSWORD_URL` | `https://app.carlessopilates.com.br/resetar-senha` |
+| `SMTP_HOST` | — (obrigatório para envio real de e-mail) |
+| `SMTP_PORT` | `587` |
+| `SMTP_USERNAME` | — |
+| `SMTP_PASSWORD` | — |
 
 ### URLs de desenvolvimento
 
@@ -757,9 +801,17 @@ app.cobranca.cron-vencidos=${APP_COBRANCA_CRON_VENCIDOS:0 0 6 * * *}
 app.cobranca.cron-cobrancas-futuras=${APP_COBRANCA_CRON_COBRANCAS_FUTURAS:0 0 7 * * *}
 app.cobranca.vencimento-dias=${APP_COBRANCA_VENCIMENTO_DIAS:10}
 spring.data.web.pageable.default-page-size=${APP_PAGINACAO_TAMANHO_PADRAO:10}
+app.email.provider=${APP_EMAIL_PROVIDER:smtp}
+app.email.from=${APP_EMAIL_FROM:no-reply@carlessopilates.com.br}
+app.email.reset-password-url=${APP_EMAIL_RESET_PASSWORD_URL:https://app.carlessopilates.com.br/resetar-senha}
+spring.mail.host=${SMTP_HOST:}
+spring.mail.port=${SMTP_PORT:587}
+spring.mail.username=${SMTP_USERNAME:}
+spring.mail.password=${SMTP_PASSWORD:}
+management.health.mail.enabled=false
 ```
 
-Os valores `app.cobranca.*` são vinculados pela classe `config/AppProperties` (Spring `@ConfigurationProperties`), evitando magic numbers e cron expressions hardcoded em código. A paginação usa a propriedade nativa do Spring Data Web, alimentada pela variável de ambiente `APP_PAGINACAO_TAMANHO_PADRAO`.
+Os valores `app.cobranca.*` são vinculados pela classe `config/AppProperties` (Spring `@ConfigurationProperties`), evitando magic numbers e cron expressions hardcoded em código. A paginação usa a propriedade nativa do Spring Data Web, alimentada pela variável de ambiente `APP_PAGINACAO_TAMANHO_PADRAO`. O indicador de saúde do Actuator para `mail` é desabilitado (`management.health.mail.enabled=false`) para que uma falha de conectividade SMTP não derrube o status geral de `/actuator/health` — o envio de e-mail é assíncrono e não crítico para a disponibilidade da API.
 
 ---
 
@@ -845,6 +897,9 @@ mvn spring-boot:run
 | `PreferenciasUsuarioServiceTest` | Unitário (Mockito, sem Spring) | 7 |
 | `PreferenciasUsuarioControllerTest` | `@WebMvcTest` + MockMvc | 6 |
 | `PreferenciasUsuarioRepositoryTest` | `@DataJpaTest` + H2 | 5 |
+| `PasswordResetServiceTest` | Unitário (Mockito, sem Spring) | 10 |
+| `AuthControllerTest` | `@WebMvcTest` + MockMvc | 9 |
+| `PasswordResetIntegrationTest` | `@SpringBootTest` + MockMvc + H2 (EmailSender mockado) | 5 |
 | `SecurityIntegrationTest` | `@SpringBootTest` + MockMvc + H2 | 42 |
 | `ActuatorTest` | `@SpringBootTest` + H2 | 3 |
 | `PilatesApiApplicationTests` | `@SpringBootTest` + H2 | 1 |

--- a/docs/documentacao.html
+++ b/docs/documentacao.html
@@ -575,6 +575,8 @@
         <tbody>
           <tr><td><span class="method post">POST</span></td><td><code>/auth/register</code></td><td>Público</td><td>Registra usuário com role <code>USER</code> e retorna JWT.</td></tr>
           <tr><td><span class="method post">POST</span></td><td><code>/auth/login</code></td><td>Público</td><td>Valida e-mail/senha e retorna JWT (rate limit 5/15min).</td></tr>
+          <tr><td><span class="method post">POST</span></td><td><code>/auth/forgot-password</code></td><td>Público</td><td>Solicita redefinição de senha por e-mail. Sempre retorna 200 genérico (evita enumeração de usuários); rate limit 5/15min por e-mail.</td></tr>
+          <tr><td><span class="method post">POST</span></td><td><code>/auth/reset-password</code></td><td>Público</td><td>Redefine a senha a partir de um token válido, não expirado e ainda não utilizado.</td></tr>
           <tr><td><span class="method get">GET</span></td><td><code>/users/me</code></td><td>Autenticado</td><td>Dados do usuário autenticado.</td></tr>
           <tr><td><span class="method put">PUT</span></td><td><code>/users/me/senha</code></td><td>Autenticado</td><td>Troca a própria senha e invalida tokens antigos.</td></tr>
           <tr><td><span class="method post">POST</span></td><td><code>/users</code></td><td>ADMIN</td><td>Cria usuário com role <code>USER</code> ou <code>ADMIN</code>.</td></tr>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,16 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 

--- a/src/main/java/com/carlesso/pilatesapi/PilatesApiApplication.java
+++ b/src/main/java/com/carlesso/pilatesapi/PilatesApiApplication.java
@@ -4,12 +4,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableAsync
 @ConfigurationPropertiesScan
 @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 public class PilatesApiApplication {

--- a/src/main/java/com/carlesso/pilatesapi/config/EmailConfig.java
+++ b/src/main/java/com/carlesso/pilatesapi/config/EmailConfig.java
@@ -1,0 +1,20 @@
+package com.carlesso.pilatesapi.config;
+
+import com.carlesso.pilatesapi.email.EmailSender;
+import com.carlesso.pilatesapi.email.SmtpEmailSender;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+
+@Configuration
+public class EmailConfig {
+
+    @Bean
+    @ConditionalOnProperty(name = "app.email.provider", havingValue = "smtp", matchIfMissing = true)
+    public EmailSender smtpEmailSender(JavaMailSender mailSender,
+                                        @Value("${app.email.from}") String from) {
+        return new SmtpEmailSender(mailSender, from);
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/controller/AuthController.java
+++ b/src/main/java/com/carlesso/pilatesapi/controller/AuthController.java
@@ -3,8 +3,13 @@ package com.carlesso.pilatesapi.controller;
 import com.carlesso.pilatesapi.dto.AuthLoginRequestDTO;
 import com.carlesso.pilatesapi.dto.AuthRegisterRequestDTO;
 import com.carlesso.pilatesapi.dto.AuthResponseDTO;
+import com.carlesso.pilatesapi.dto.ForgotPasswordRequestDTO;
+import com.carlesso.pilatesapi.dto.ResetPasswordRequestDTO;
 import com.carlesso.pilatesapi.service.AuthService;
+import com.carlesso.pilatesapi.service.PasswordResetService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -23,9 +28,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final PasswordResetService passwordResetService;
 
-    public AuthController(AuthService authService) {
+    public AuthController(AuthService authService, PasswordResetService passwordResetService) {
         this.authService = authService;
+        this.passwordResetService = passwordResetService;
     }
 
     @Operation(
@@ -44,5 +51,37 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<AuthResponseDTO> login(@RequestBody @Valid AuthLoginRequestDTO dto) {
         return ResponseEntity.ok(authService.login(dto));
+    }
+
+    @Operation(
+            summary = "Esqueci minha senha",
+            description = "Endpoint público. Envia um e-mail com link de redefinição quando o e-mail informado pertencer a um usuário ativo. " +
+                    "Sempre retorna 200 com uma mensagem genérica, independentemente de o e-mail existir, para evitar enumeração de usuários."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Solicitação processada"),
+            @ApiResponse(responseCode = "400", description = "Payload inválido"),
+            @ApiResponse(responseCode = "429", description = "Muitas solicitações para o e-mail informado")
+    })
+    @PostMapping("/forgot-password")
+    public ResponseEntity<Void> forgotPassword(@RequestBody @Valid ForgotPasswordRequestDTO dto) {
+        passwordResetService.solicitarRedefinicao(dto.email());
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(
+            summary = "Redefinir senha",
+            description = "Endpoint público. Redefine a senha a partir de um token de redefinição válido, não expirado e ainda não utilizado. " +
+                    "Tokens emitidos antes da redefinição deixam de autorizar rotas protegidas."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Senha redefinida com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Payload inválido"),
+            @ApiResponse(responseCode = "422", description = "Token inválido, expirado, já utilizado ou confirmação de senha não confere")
+    })
+    @PostMapping("/reset-password")
+    public ResponseEntity<Void> resetPassword(@RequestBody @Valid ResetPasswordRequestDTO dto) {
+        passwordResetService.redefinirSenha(dto);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/carlesso/pilatesapi/dto/ForgotPasswordRequestDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/ForgotPasswordRequestDTO.java
@@ -1,0 +1,9 @@
+package com.carlesso.pilatesapi.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record ForgotPasswordRequestDTO(
+        @NotBlank @Email String email
+) {
+}

--- a/src/main/java/com/carlesso/pilatesapi/dto/ResetPasswordRequestDTO.java
+++ b/src/main/java/com/carlesso/pilatesapi/dto/ResetPasswordRequestDTO.java
@@ -1,0 +1,11 @@
+package com.carlesso.pilatesapi.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ResetPasswordRequestDTO(
+        @NotBlank String token,
+        @NotBlank @Size(min = 8) String novaSenha,
+        @NotBlank String confirmacaoNovaSenha
+) {
+}

--- a/src/main/java/com/carlesso/pilatesapi/email/EmailMessage.java
+++ b/src/main/java/com/carlesso/pilatesapi/email/EmailMessage.java
@@ -1,0 +1,4 @@
+package com.carlesso.pilatesapi.email;
+
+public record EmailMessage(String to, String subject, String htmlBody, String textBody) {
+}

--- a/src/main/java/com/carlesso/pilatesapi/email/EmailSender.java
+++ b/src/main/java/com/carlesso/pilatesapi/email/EmailSender.java
@@ -1,0 +1,6 @@
+package com.carlesso.pilatesapi.email;
+
+public interface EmailSender {
+
+    void send(EmailMessage message);
+}

--- a/src/main/java/com/carlesso/pilatesapi/email/EmailTemplateService.java
+++ b/src/main/java/com/carlesso/pilatesapi/email/EmailTemplateService.java
@@ -1,0 +1,8 @@
+package com.carlesso.pilatesapi.email;
+
+import com.carlesso.pilatesapi.entity.User;
+
+public interface EmailTemplateService {
+
+    EmailMessage criarEmailRedefinicaoSenha(User user, String linkRedefinicao);
+}

--- a/src/main/java/com/carlesso/pilatesapi/email/SmtpEmailSender.java
+++ b/src/main/java/com/carlesso/pilatesapi/email/SmtpEmailSender.java
@@ -1,0 +1,34 @@
+package com.carlesso.pilatesapi.email;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+
+public class SmtpEmailSender implements EmailSender {
+
+    private final JavaMailSender mailSender;
+    private final String from;
+
+    public SmtpEmailSender(JavaMailSender mailSender, String from) {
+        this.mailSender = mailSender;
+        this.from = from;
+    }
+
+    @Override
+    @Async
+    public void send(EmailMessage message) {
+        try {
+            MimeMessage mimeMessage = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+            helper.setFrom(from);
+            helper.setTo(message.to());
+            helper.setSubject(message.subject());
+            helper.setText(message.textBody(), message.htmlBody());
+            mailSender.send(mimeMessage);
+        } catch (MessagingException e) {
+            throw new IllegalStateException("Falha ao enviar e-mail", e);
+        }
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/email/ThymeleafEmailTemplateService.java
+++ b/src/main/java/com/carlesso/pilatesapi/email/ThymeleafEmailTemplateService.java
@@ -1,0 +1,34 @@
+package com.carlesso.pilatesapi.email;
+
+import com.carlesso.pilatesapi.entity.User;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+@Component
+public class ThymeleafEmailTemplateService implements EmailTemplateService {
+
+    private final SpringTemplateEngine templateEngine;
+    private final int expiracaoMinutos;
+
+    public ThymeleafEmailTemplateService(SpringTemplateEngine templateEngine,
+                                          @Value("${app.email.reset-password-token-ttl-minutos:30}") int expiracaoMinutos) {
+        this.templateEngine = templateEngine;
+        this.expiracaoMinutos = expiracaoMinutos;
+    }
+
+    @Override
+    public EmailMessage criarEmailRedefinicaoSenha(User user, String linkRedefinicao) {
+        Context context = new Context();
+        context.setVariable("nome", user.getName());
+        context.setVariable("linkRedefinicao", linkRedefinicao);
+        context.setVariable("expiracaoMinutos", expiracaoMinutos);
+
+        String htmlBody = templateEngine.process("password-reset", context);
+        String textBody = "Olá " + user.getName() + ", acesse o link a seguir para redefinir sua senha: "
+                + linkRedefinicao + ". O link expira em " + expiracaoMinutos + " minutos.";
+
+        return new EmailMessage(user.getEmail(), "Redefinição de senha - Carlesso Pilates", htmlBody, textBody);
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/entity/PasswordResetToken.java
+++ b/src/main/java/com/carlesso/pilatesapi/entity/PasswordResetToken.java
@@ -87,7 +87,7 @@ public class PasswordResetToken {
         return createdAt;
     }
 
-    public boolean isValido(LocalDateTime agora) {
-        return usedAt == null && expiresAt.isAfter(agora);
+    public boolean isValido() {
+        return usedAt == null && expiresAt.isAfter(LocalDateTime.now());
     }
 }

--- a/src/main/java/com/carlesso/pilatesapi/entity/PasswordResetToken.java
+++ b/src/main/java/com/carlesso/pilatesapi/entity/PasswordResetToken.java
@@ -1,0 +1,93 @@
+package com.carlesso.pilatesapi.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "password_reset_tokens")
+public class PasswordResetToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User user;
+
+    @Column(name = "token_hash", nullable = false, unique = true)
+    private String tokenHash;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(name = "used_at")
+    private LocalDateTime usedAt;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    public PasswordResetToken() {
+    }
+
+    @PrePersist
+    void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public String getTokenHash() {
+        return tokenHash;
+    }
+
+    public void setTokenHash(String tokenHash) {
+        this.tokenHash = tokenHash;
+    }
+
+    public LocalDateTime getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(LocalDateTime expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+
+    public LocalDateTime getUsedAt() {
+        return usedAt;
+    }
+
+    public void setUsedAt(LocalDateTime usedAt) {
+        this.usedAt = usedAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public boolean isValido(LocalDateTime agora) {
+        return usedAt == null && expiresAt.isAfter(agora);
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/repository/PasswordResetTokenRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,11 @@
+package com.carlesso.pilatesapi.repository;
+
+import com.carlesso.pilatesapi.entity.PasswordResetToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
+
+    Optional<PasswordResetToken> findByTokenHash(String tokenHash);
+}

--- a/src/main/java/com/carlesso/pilatesapi/repository/PasswordResetTokenRepository.java
+++ b/src/main/java/com/carlesso/pilatesapi/repository/PasswordResetTokenRepository.java
@@ -1,11 +1,24 @@
 package com.carlesso.pilatesapi.repository;
 
 import com.carlesso.pilatesapi.entity.PasswordResetToken;
+import com.carlesso.pilatesapi.entity.User;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
 
-    Optional<PasswordResetToken> findByTokenHash(String tokenHash);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select t from PasswordResetToken t where t.tokenHash = :tokenHash")
+    Optional<PasswordResetToken> findByTokenHash(@Param("tokenHash") String tokenHash);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update PasswordResetToken t set t.usedAt = :agora where t.user = :user and t.usedAt is null")
+    void invalidarTokensAtivos(@Param("user") User user, @Param("agora") LocalDateTime agora);
 }

--- a/src/main/java/com/carlesso/pilatesapi/scheduler/LoginAttemptCleanupScheduler.java
+++ b/src/main/java/com/carlesso/pilatesapi/scheduler/LoginAttemptCleanupScheduler.java
@@ -1,0 +1,20 @@
+package com.carlesso.pilatesapi.scheduler;
+
+import com.carlesso.pilatesapi.service.LoginAttemptService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LoginAttemptCleanupScheduler {
+
+    private final LoginAttemptService loginAttemptService;
+
+    public LoginAttemptCleanupScheduler(LoginAttemptService loginAttemptService) {
+        this.loginAttemptService = loginAttemptService;
+    }
+
+    @Scheduled(fixedRate = 15 * 60 * 1000)
+    public void limparTentativasExpiradas() {
+        loginAttemptService.limparEntradasExpiradas();
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/service/AuthService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/AuthService.java
@@ -9,6 +9,7 @@ import com.carlesso.pilatesapi.entity.enums.Role;
 import com.carlesso.pilatesapi.exception.ConflictException;
 import com.carlesso.pilatesapi.exception.TooManyRequestsException;
 import com.carlesso.pilatesapi.repository.UserRepository;
+import com.carlesso.pilatesapi.util.EmailNormalizer;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -40,7 +41,7 @@ public class AuthService {
 
     @Transactional
     public AuthResponseDTO register(AuthRegisterRequestDTO dto) {
-        String email = dto.email().toLowerCase();
+        String email = EmailNormalizer.normalizar(dto.email());
         if (userRepository.existsByEmail(email)) {
             throw new ConflictException("E-mail já cadastrado");
         }
@@ -58,7 +59,7 @@ public class AuthService {
 
     @Transactional(readOnly = true)
     public AuthResponseDTO login(AuthLoginRequestDTO dto) {
-        String email = dto.email().toLowerCase();
+        String email = EmailNormalizer.normalizar(dto.email());
         if (loginAttemptService.isBlocked(email)) {
             throw new TooManyRequestsException("Muitas tentativas. Tente novamente em 15 minutos.");
         }

--- a/src/main/java/com/carlesso/pilatesapi/service/LoginAttemptService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/LoginAttemptService.java
@@ -29,12 +29,27 @@ public class LoginAttemptService {
     }
 
     public boolean isBlocked(String key) {
-        Deque<Instant> deque = history.get(key);
-        if (deque == null) return false;
+        Deque<Instant> deque = prunirExpirados(key);
+        return deque != null && deque.size() >= MAX_ATTEMPTS;
+    }
+
+    /**
+     * Remove do mapa as chaves cujas tentativas já saíram da janela. Sem isso,
+     * chaves que nunca são revisitadas (ex.: um e-mail de recuperação de senha
+     * usado uma única vez) ficariam retidas para sempre, permitindo crescimento
+     * ilimitado do mapa em memória por um endpoint não autenticado.
+     */
+    public void limparEntradasExpiradas() {
+        history.keySet().forEach(this::prunirExpirados);
+    }
+
+    private Deque<Instant> prunirExpirados(String key) {
         Instant cutoff = Instant.now().minus(WINDOW);
-        while (!deque.isEmpty() && deque.peekFirst().isBefore(cutoff)) {
-            deque.pollFirst();
-        }
-        return deque.size() >= MAX_ATTEMPTS;
+        return history.computeIfPresent(key, (k, deque) -> {
+            while (!deque.isEmpty() && deque.peekFirst().isBefore(cutoff)) {
+                deque.pollFirst();
+            }
+            return deque.isEmpty() ? null : deque;
+        });
     }
 }

--- a/src/main/java/com/carlesso/pilatesapi/service/PasswordResetService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/PasswordResetService.java
@@ -1,0 +1,118 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.ResetPasswordRequestDTO;
+import com.carlesso.pilatesapi.email.EmailSender;
+import com.carlesso.pilatesapi.email.EmailTemplateService;
+import com.carlesso.pilatesapi.entity.PasswordResetToken;
+import com.carlesso.pilatesapi.entity.User;
+import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.exception.TooManyRequestsException;
+import com.carlesso.pilatesapi.repository.PasswordResetTokenRepository;
+import com.carlesso.pilatesapi.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.Locale;
+
+@Service
+public class PasswordResetService {
+
+    private static final String RATE_LIMIT_KEY_PREFIX = "forgot-password:";
+    private static final Duration TOKEN_TTL = Duration.ofMinutes(30);
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private final UserRepository userRepository;
+    private final PasswordResetTokenRepository tokenRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final EmailSender emailSender;
+    private final EmailTemplateService emailTemplateService;
+    private final LoginAttemptService loginAttemptService;
+    private final String resetPasswordUrl;
+
+    public PasswordResetService(UserRepository userRepository,
+                                 PasswordResetTokenRepository tokenRepository,
+                                 PasswordEncoder passwordEncoder,
+                                 EmailSender emailSender,
+                                 EmailTemplateService emailTemplateService,
+                                 LoginAttemptService loginAttemptService,
+                                 @Value("${app.email.reset-password-url}") String resetPasswordUrl) {
+        this.userRepository = userRepository;
+        this.tokenRepository = tokenRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.emailSender = emailSender;
+        this.emailTemplateService = emailTemplateService;
+        this.loginAttemptService = loginAttemptService;
+        this.resetPasswordUrl = resetPasswordUrl;
+    }
+
+    @Transactional
+    public void solicitarRedefinicao(String email) {
+        String normalizedEmail = email.toLowerCase(Locale.ROOT);
+        String rateLimitKey = RATE_LIMIT_KEY_PREFIX + normalizedEmail;
+        if (loginAttemptService.isBlocked(rateLimitKey)) {
+            throw new TooManyRequestsException("Muitas solicitações. Tente novamente em 15 minutos.");
+        }
+        loginAttemptService.registerFailure(rateLimitKey);
+
+        userRepository.findByEmail(normalizedEmail)
+                .filter(User::isAtivo)
+                .ifPresent(this::gerarTokenEEnviarEmail);
+    }
+
+    @Transactional
+    public void redefinirSenha(ResetPasswordRequestDTO dto) {
+        if (!dto.novaSenha().equals(dto.confirmacaoNovaSenha())) {
+            throw new BusinessException("Confirmação de senha não confere");
+        }
+
+        PasswordResetToken resetToken = tokenRepository.findByTokenHash(hash(dto.token()))
+                .filter(t -> t.isValido(LocalDateTime.now()))
+                .orElseThrow(() -> new BusinessException("Token inválido ou expirado"));
+
+        User user = resetToken.getUser();
+        user.setPassword(passwordEncoder.encode(dto.novaSenha()));
+        user.incrementarTokenVersion();
+        userRepository.save(user);
+
+        resetToken.setUsedAt(LocalDateTime.now());
+        tokenRepository.save(resetToken);
+    }
+
+    private void gerarTokenEEnviarEmail(User user) {
+        String rawToken = gerarTokenAleatorio();
+
+        PasswordResetToken token = new PasswordResetToken();
+        token.setUser(user);
+        token.setTokenHash(hash(rawToken));
+        token.setExpiresAt(LocalDateTime.now().plus(TOKEN_TTL));
+        tokenRepository.save(token);
+
+        String link = resetPasswordUrl + "?token=" + rawToken;
+        emailSender.send(emailTemplateService.criarEmailRedefinicaoSenha(user, link));
+    }
+
+    private String gerarTokenAleatorio() {
+        byte[] bytes = new byte[32];
+        SECURE_RANDOM.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private String hash(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(token.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("Algoritmo de hash indisponível", e);
+        }
+    }
+}

--- a/src/main/java/com/carlesso/pilatesapi/service/PasswordResetService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/PasswordResetService.java
@@ -9,8 +9,8 @@ import com.carlesso.pilatesapi.exception.BusinessException;
 import com.carlesso.pilatesapi.exception.TooManyRequestsException;
 import com.carlesso.pilatesapi.repository.PasswordResetTokenRepository;
 import com.carlesso.pilatesapi.repository.UserRepository;
+import com.carlesso.pilatesapi.util.EmailNormalizer;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,46 +18,46 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.HexFormat;
-import java.util.Locale;
 
 @Service
 public class PasswordResetService {
 
     private static final String RATE_LIMIT_KEY_PREFIX = "forgot-password:";
-    private static final Duration TOKEN_TTL = Duration.ofMinutes(30);
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private final UserRepository userRepository;
     private final PasswordResetTokenRepository tokenRepository;
-    private final PasswordEncoder passwordEncoder;
+    private final UserService userService;
     private final EmailSender emailSender;
     private final EmailTemplateService emailTemplateService;
     private final LoginAttemptService loginAttemptService;
     private final String resetPasswordUrl;
+    private final long tokenTtlMinutos;
 
     public PasswordResetService(UserRepository userRepository,
                                  PasswordResetTokenRepository tokenRepository,
-                                 PasswordEncoder passwordEncoder,
+                                 UserService userService,
                                  EmailSender emailSender,
                                  EmailTemplateService emailTemplateService,
                                  LoginAttemptService loginAttemptService,
-                                 @Value("${app.email.reset-password-url}") String resetPasswordUrl) {
+                                 @Value("${app.email.reset-password-url}") String resetPasswordUrl,
+                                 @Value("${app.email.reset-password-token-ttl-minutos:30}") long tokenTtlMinutos) {
         this.userRepository = userRepository;
         this.tokenRepository = tokenRepository;
-        this.passwordEncoder = passwordEncoder;
+        this.userService = userService;
         this.emailSender = emailSender;
         this.emailTemplateService = emailTemplateService;
         this.loginAttemptService = loginAttemptService;
         this.resetPasswordUrl = resetPasswordUrl;
+        this.tokenTtlMinutos = tokenTtlMinutos;
     }
 
     @Transactional
     public void solicitarRedefinicao(String email) {
-        String normalizedEmail = email.toLowerCase(Locale.ROOT);
+        String normalizedEmail = EmailNormalizer.normalizar(email);
         String rateLimitKey = RATE_LIMIT_KEY_PREFIX + normalizedEmail;
         if (loginAttemptService.isBlocked(rateLimitKey)) {
             throw new TooManyRequestsException("Muitas solicitações. Tente novamente em 15 minutos.");
@@ -76,12 +76,11 @@ public class PasswordResetService {
         }
 
         PasswordResetToken resetToken = tokenRepository.findByTokenHash(hash(dto.token()))
-                .filter(t -> t.isValido(LocalDateTime.now()))
+                .filter(PasswordResetToken::isValido)
                 .orElseThrow(() -> new BusinessException("Token inválido ou expirado"));
 
         User user = resetToken.getUser();
-        user.setPassword(passwordEncoder.encode(dto.novaSenha()));
-        user.incrementarTokenVersion();
+        userService.aplicarNovaSenha(user, dto.novaSenha());
         userRepository.save(user);
 
         resetToken.setUsedAt(LocalDateTime.now());
@@ -89,12 +88,14 @@ public class PasswordResetService {
     }
 
     private void gerarTokenEEnviarEmail(User user) {
+        tokenRepository.invalidarTokensAtivos(user, LocalDateTime.now());
+
         String rawToken = gerarTokenAleatorio();
 
         PasswordResetToken token = new PasswordResetToken();
         token.setUser(user);
         token.setTokenHash(hash(rawToken));
-        token.setExpiresAt(LocalDateTime.now().plus(TOKEN_TTL));
+        token.setExpiresAt(LocalDateTime.now().plusMinutes(tokenTtlMinutos));
         tokenRepository.save(token);
 
         String link = resetPasswordUrl + "?token=" + rawToken;

--- a/src/main/java/com/carlesso/pilatesapi/service/PreferenciasUsuarioService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/PreferenciasUsuarioService.java
@@ -9,10 +9,9 @@ import com.carlesso.pilatesapi.entity.enums.TemaPreferencia;
 import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.repository.PreferenciasUsuarioRepository;
 import com.carlesso.pilatesapi.repository.UserRepository;
+import com.carlesso.pilatesapi.util.EmailNormalizer;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Locale;
 
 @Service
 public class PreferenciasUsuarioService {
@@ -32,14 +31,14 @@ public class PreferenciasUsuarioService {
 
     @Transactional(readOnly = true)
     public PreferenciasUsuarioResponseDTO buscarPorEmail(String email) {
-        return repository.findByUserEmail(email.toLowerCase(Locale.ROOT))
+        return repository.findByUserEmail(EmailNormalizer.normalizar(email))
                 .map(PreferenciasUsuarioResponseDTO::from)
                 .orElseGet(this::padraoResponse);
     }
 
     @Transactional
     public PreferenciasUsuarioResponseDTO atualizarPorEmail(String email, PreferenciasUsuarioRequestDTO dto) {
-        User user = userRepository.findByEmailForUpdate(email.toLowerCase(Locale.ROOT))
+        User user = userRepository.findByEmailForUpdate(EmailNormalizer.normalizar(email))
                 .orElseThrow(() -> new ResourceNotFoundException("Usuário não encontrado"));
 
         PreferenciasUsuario preferencias = repository.findByUserId(user.getId())

--- a/src/main/java/com/carlesso/pilatesapi/service/UserService.java
+++ b/src/main/java/com/carlesso/pilatesapi/service/UserService.java
@@ -11,6 +11,7 @@ import com.carlesso.pilatesapi.exception.BusinessException;
 import com.carlesso.pilatesapi.exception.ConflictException;
 import com.carlesso.pilatesapi.exception.ResourceNotFoundException;
 import com.carlesso.pilatesapi.repository.UserRepository;
+import com.carlesso.pilatesapi.util.EmailNormalizer;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -19,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 
 @Service
 public class UserService {
@@ -34,7 +34,7 @@ public class UserService {
 
     @Transactional
     public UserResponseDTO criar(UserRequestDTO dto) {
-        String email = normalizarEmail(dto.email());
+        String email = EmailNormalizer.normalizar(dto.email());
         if (repository.existsByEmail(email)) {
             throw new ConflictException("E-mail já cadastrado");
         }
@@ -68,7 +68,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserResponseDTO buscarPorEmail(String email) {
         return UserResponseDTO.from(
-                repository.findByEmail(email.toLowerCase(Locale.ROOT))
+                repository.findByEmail(EmailNormalizer.normalizar(email))
                         .orElseThrow(() -> new ResourceNotFoundException("Usuário não encontrado"))
         );
     }
@@ -86,7 +86,7 @@ public class UserService {
         }
 
         if (dto.email() != null) {
-            String email = normalizarEmail(dto.email());
+            String email = EmailNormalizer.normalizar(dto.email());
             if (repository.existsByEmailAndIdNot(email, id)) {
                 throw new ConflictException("E-mail já cadastrado");
             }
@@ -94,8 +94,7 @@ public class UserService {
         }
         if (dto.name() != null) user.setName(dto.name());
         if (dto.password() != null) {
-            user.setPassword(passwordEncoder.encode(dto.password()));
-            user.incrementarTokenVersion();
+            aplicarNovaSenha(user, dto.password());
         }
         if (dto.role() != null) user.setRole(dto.role());
 
@@ -104,7 +103,7 @@ public class UserService {
 
     @Transactional
     public void alterarSenha(String currentEmail, UserAlterarSenhaRequestDTO dto) {
-        User user = repository.findByEmail(currentEmail.toLowerCase(Locale.ROOT))
+        User user = repository.findByEmail(EmailNormalizer.normalizar(currentEmail))
                 .orElseThrow(() -> new ResourceNotFoundException("Usuário não encontrado"));
 
         if (!passwordEncoder.matches(dto.senhaAtual(), user.getPassword())) {
@@ -117,9 +116,19 @@ public class UserService {
             throw new BusinessException("A nova senha deve ser diferente da senha atual");
         }
 
-        user.setPassword(passwordEncoder.encode(dto.novaSenha()));
-        user.incrementarTokenVersion();
+        aplicarNovaSenha(user, dto.novaSenha());
         repository.save(user);
+    }
+
+    /**
+     * Aplica uma nova senha ao usuário (encode + invalidação de JWTs emitidos
+     * antes da troca via incremento de token_version), sem persistir; o
+     * chamador decide quando salvar. Reaproveitado por {@code alterarSenha},
+     * {@code atualizar} e pelo fluxo de redefinição de senha.
+     */
+    public void aplicarNovaSenha(User user, String novaSenhaPlana) {
+        user.setPassword(passwordEncoder.encode(novaSenhaPlana));
+        user.incrementarTokenVersion();
     }
 
     @Transactional
@@ -143,9 +152,5 @@ public class UserService {
     private User encontrar(Long id) {
         return repository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Usuário não encontrado: " + id));
-    }
-
-    private String normalizarEmail(String email) {
-        return email.toLowerCase(Locale.ROOT);
     }
 }

--- a/src/main/java/com/carlesso/pilatesapi/util/EmailNormalizer.java
+++ b/src/main/java/com/carlesso/pilatesapi/util/EmailNormalizer.java
@@ -1,0 +1,13 @@
+package com.carlesso.pilatesapi.util;
+
+import java.util.Locale;
+
+public final class EmailNormalizer {
+
+    private EmailNormalizer() {
+    }
+
+    public static String normalizar(String email) {
+        return email.toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -8,3 +8,6 @@ management.endpoint.health.show-details=always
 management.info.env.enabled=true
 info.app.name=${spring.application.name}
 info.app.description=Carlesso Pilates API
+
+# desabilitado só em dev: sem SMTP real local, não deve derrubar o healthcheck (em prod o mail deve refletir o estado real)
+management.health.mail.enabled=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,7 +27,6 @@ springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.swagger-ui.operationsSorter=method
 
 management.endpoints.web.exposure.include=health
-management.health.mail.enabled=false
 
 jwt.secret=${JWT_SECRET}
 jwt.expiration-ms=${JWT_EXPIRATION_MS:86400000}
@@ -43,6 +42,7 @@ spring.data.web.pageable.default-page-size=${APP_PAGINACAO_TAMANHO_PADRAO:10}
 app.email.provider=${APP_EMAIL_PROVIDER:smtp}
 app.email.from=${APP_EMAIL_FROM:no-reply@carlessopilates.com.br}
 app.email.reset-password-url=${APP_EMAIL_RESET_PASSWORD_URL:https://app.carlessopilates.com.br/resetar-senha}
+app.email.reset-password-token-ttl-minutos=${APP_EMAIL_RESET_PASSWORD_TOKEN_TTL_MINUTOS:30}
 spring.mail.host=${SMTP_HOST:}
 spring.mail.port=${SMTP_PORT:587}
 spring.mail.username=${SMTP_USERNAME:}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,6 +27,7 @@ springdoc.swagger-ui.path=/swagger-ui.html
 springdoc.swagger-ui.operationsSorter=method
 
 management.endpoints.web.exposure.include=health
+management.health.mail.enabled=false
 
 jwt.secret=${JWT_SECRET}
 jwt.expiration-ms=${JWT_EXPIRATION_MS:86400000}
@@ -38,3 +39,13 @@ app.cobranca.cron-vencidos=${APP_COBRANCA_CRON_VENCIDOS:0 0 6 * * *}
 app.cobranca.cron-cobrancas-futuras=${APP_COBRANCA_CRON_COBRANCAS_FUTURAS:0 0 7 * * *}
 app.cobranca.vencimento-dias=${APP_COBRANCA_VENCIMENTO_DIAS:10}
 spring.data.web.pageable.default-page-size=${APP_PAGINACAO_TAMANHO_PADRAO:10}
+
+app.email.provider=${APP_EMAIL_PROVIDER:smtp}
+app.email.from=${APP_EMAIL_FROM:no-reply@carlessopilates.com.br}
+app.email.reset-password-url=${APP_EMAIL_RESET_PASSWORD_URL:https://app.carlessopilates.com.br/resetar-senha}
+spring.mail.host=${SMTP_HOST:}
+spring.mail.port=${SMTP_PORT:587}
+spring.mail.username=${SMTP_USERNAME:}
+spring.mail.password=${SMTP_PASSWORD:}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true

--- a/src/main/resources/db/migration/V26__create_password_reset_tokens_table.sql
+++ b/src/main/resources/db/migration/V26__create_password_reset_tokens_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE password_reset_tokens (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash VARCHAR(64) NOT NULL UNIQUE,
+    expires_at TIMESTAMP NOT NULL,
+    used_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL
+);
+
+CREATE INDEX idx_password_reset_tokens_user_id ON password_reset_tokens(user_id);

--- a/src/main/resources/templates/password-reset.html
+++ b/src/main/resources/templates/password-reset.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="pt-br">
+<head>
+    <meta charset="UTF-8"/>
+    <title>Redefinição de senha</title>
+</head>
+<body style="font-family: Arial, sans-serif; background-color: #f4f4f4; padding: 24px;">
+    <div style="max-width: 480px; margin: 0 auto; background-color: #ffffff; border-radius: 8px; padding: 32px;">
+        <h2 style="color: #333333;">Redefinição de senha</h2>
+        <p style="color: #555555;">Olá, <span th:text="${nome}">Usuário</span>.</p>
+        <p style="color: #555555;">
+            Recebemos uma solicitação para redefinir a senha da sua conta na Carlesso Pilates.
+            Clique no botão abaixo para escolher uma nova senha:
+        </p>
+        <p style="text-align: center; margin: 32px 0;">
+            <a th:href="${linkRedefinicao}"
+               style="background-color: #2f7d5f; color: #ffffff; padding: 12px 24px; border-radius: 4px; text-decoration: none;">
+                Redefinir senha
+            </a>
+        </p>
+        <p style="color: #888888; font-size: 14px;">
+            Este link expira em <span th:text="${expiracaoMinutos}">30</span> minutos e só pode ser usado uma vez.
+        </p>
+        <p style="color: #888888; font-size: 14px;">
+            Se você não solicitou essa alteração, ignore este e-mail — sua senha continuará a mesma.
+        </p>
+    </div>
+</body>
+</html>

--- a/src/test/java/com/carlesso/pilatesapi/controller/AuthControllerTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/controller/AuthControllerTest.java
@@ -1,0 +1,158 @@
+package com.carlesso.pilatesapi.controller;
+
+import com.carlesso.pilatesapi.dto.AuthLoginRequestDTO;
+import com.carlesso.pilatesapi.dto.AuthRegisterRequestDTO;
+import com.carlesso.pilatesapi.dto.AuthResponseDTO;
+import com.carlesso.pilatesapi.dto.ForgotPasswordRequestDTO;
+import com.carlesso.pilatesapi.dto.ResetPasswordRequestDTO;
+import com.carlesso.pilatesapi.dto.UserResponseDTO;
+import com.carlesso.pilatesapi.entity.enums.Role;
+import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.exception.TooManyRequestsException;
+import com.carlesso.pilatesapi.service.AuthService;
+import com.carlesso.pilatesapi.service.CustomUserDetailsService;
+import com.carlesso.pilatesapi.service.JwtService;
+import com.carlesso.pilatesapi.service.PasswordResetService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @MockitoBean
+    private AuthService authService;
+
+    @MockitoBean
+    private PasswordResetService passwordResetService;
+
+    @MockitoBean
+    private JwtService jwtService;
+
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    @Test
+    void register_deveRetornar201() throws Exception {
+        var request = new AuthRegisterRequestDTO("Maria", "maria@email.com", "senha1234");
+        when(authService.register(any())).thenReturn(AuthResponseDTO.bearer("token",
+                new UserResponseDTO(1L, "Maria", "maria@email.com", Role.USER, true)));
+
+        mvc.perform(post("/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void login_deveRetornar200() throws Exception {
+        var request = new AuthLoginRequestDTO("maria@email.com", "senha1234");
+        when(authService.login(any())).thenReturn(AuthResponseDTO.bearer("token",
+                new UserResponseDTO(1L, "Maria", "maria@email.com", Role.USER, true)));
+
+        mvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void forgotPassword_deveRetornar200() throws Exception {
+        var request = new ForgotPasswordRequestDTO("maria@email.com");
+
+        mvc.perform(post("/auth/forgot-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        verify(passwordResetService).solicitarRedefinicao("maria@email.com");
+    }
+
+    @Test
+    void forgotPassword_comEmailInexistente_aindaAssimDeveRetornar200() throws Exception {
+        var request = new ForgotPasswordRequestDTO("naoexiste@email.com");
+
+        mvc.perform(post("/auth/forgot-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void forgotPassword_comEmailInvalido_deveRetornar400() throws Exception {
+        var request = new ForgotPasswordRequestDTO("email-invalido");
+
+        mvc.perform(post("/auth/forgot-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void forgotPassword_aposLimiteDeSolicitacoes_deveRetornar429() throws Exception {
+        var request = new ForgotPasswordRequestDTO("maria@email.com");
+        doThrow(new TooManyRequestsException("Muitas solicitações. Tente novamente em 15 minutos."))
+                .when(passwordResetService).solicitarRedefinicao("maria@email.com");
+
+        mvc.perform(post("/auth/forgot-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isTooManyRequests())
+                .andExpect(jsonPath("$.erro").value("Muitas solicitações. Tente novamente em 15 minutos."));
+    }
+
+    @Test
+    void resetPassword_deveRetornar200() throws Exception {
+        var request = new ResetPasswordRequestDTO("token-valido", "novaSenha123", "novaSenha123");
+
+        mvc.perform(post("/auth/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        verify(passwordResetService).redefinirSenha(request);
+    }
+
+    @Test
+    void resetPassword_comPayloadInvalido_deveRetornar400() throws Exception {
+        var request = new ResetPasswordRequestDTO("", "curta", "curta");
+
+        mvc.perform(post("/auth/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void resetPassword_comTokenInvalidoOuExpirado_deveRetornar422() throws Exception {
+        var request = new ResetPasswordRequestDTO("token-invalido", "novaSenha123", "novaSenha123");
+        doThrow(new BusinessException("Token inválido ou expirado"))
+                .when(passwordResetService).redefinirSenha(request);
+
+        mvc.perform(post("/auth/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.erro").value("Token inválido ou expirado"));
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/security/PasswordResetIntegrationTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/security/PasswordResetIntegrationTest.java
@@ -1,0 +1,179 @@
+package com.carlesso.pilatesapi.security;
+
+import com.carlesso.pilatesapi.dto.ForgotPasswordRequestDTO;
+import com.carlesso.pilatesapi.dto.ResetPasswordRequestDTO;
+import com.carlesso.pilatesapi.email.EmailMessage;
+import com.carlesso.pilatesapi.email.EmailSender;
+import com.carlesso.pilatesapi.entity.User;
+import com.carlesso.pilatesapi.entity.enums.Role;
+import com.carlesso.pilatesapi.repository.UserRepository;
+import com.carlesso.pilatesapi.service.JwtService;
+import com.carlesso.pilatesapi.service.LoginAttemptService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.lang.reflect.Field;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PasswordResetIntegrationTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JwtService jwtService;
+
+    @Autowired
+    private LoginAttemptService loginAttemptService;
+
+    @MockitoBean
+    private EmailSender emailSender;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        userRepository.deleteAll();
+        Field historyField = LoginAttemptService.class.getDeclaredField("history");
+        historyField.setAccessible(true);
+        ((java.util.concurrent.ConcurrentHashMap<?, ?>) historyField.get(loginAttemptService)).clear();
+    }
+
+    @Test
+    void fluxoCompleto_solicitarERedefinirSenha_devePermitirLoginComNovaSenha() throws Exception {
+        User user = criarUsuario("recupera@email.com");
+        String tokenAntigo = "Bearer " + jwtService.generateToken(user);
+
+        mvc.perform(post("/auth/forgot-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(new ForgotPasswordRequestDTO("recupera@email.com"))))
+                .andExpect(status().isOk());
+
+        var captor = forClass(EmailMessage.class);
+        verify(emailSender).send(captor.capture());
+        String rawToken = extrairToken(captor.getValue());
+
+        var resetRequest = new ResetPasswordRequestDTO(rawToken, "novaSenha123", "novaSenha123");
+        mvc.perform(post("/auth/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(resetRequest)))
+                .andExpect(status().isOk());
+
+        User atualizado = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(passwordEncoder.matches("novaSenha123", atualizado.getPassword())).isTrue();
+        assertThat(atualizado.getTokenVersion()).isEqualTo(user.getTokenVersion() + 1);
+
+        mvc.perform(get("/dashboard/resumo").header(HttpHeaders.AUTHORIZATION, tokenAntigo))
+                .andExpect(status().isUnauthorized());
+
+        mvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(
+                                new com.carlesso.pilatesapi.dto.AuthLoginRequestDTO("recupera@email.com", "novaSenha123"))))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void resetPassword_comMesmoTokenUsadoDuasVezes_segundaVezDeveRetornar422() throws Exception {
+        User user = criarUsuario("reuso@email.com");
+
+        mvc.perform(post("/auth/forgot-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(new ForgotPasswordRequestDTO("reuso@email.com"))))
+                .andExpect(status().isOk());
+
+        var captor = forClass(EmailMessage.class);
+        verify(emailSender).send(captor.capture());
+        String rawToken = extrairToken(captor.getValue());
+        var resetRequest = new ResetPasswordRequestDTO(rawToken, "novaSenha123", "novaSenha123");
+
+        mvc.perform(post("/auth/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(resetRequest)))
+                .andExpect(status().isOk());
+
+        mvc.perform(post("/auth/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(resetRequest)))
+                .andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    void resetPassword_comTokenInvalido_deveRetornar422() throws Exception {
+        var resetRequest = new ResetPasswordRequestDTO("token-que-nao-existe", "novaSenha123", "novaSenha123");
+
+        mvc.perform(post("/auth/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(resetRequest)))
+                .andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    void forgotPassword_comEmailInexistente_deveRetornar200SemEnviarEmail() throws Exception {
+        mvc.perform(post("/auth/forgot-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(new ForgotPasswordRequestDTO("naoexiste@email.com"))))
+                .andExpect(status().isOk());
+
+        org.mockito.Mockito.verifyNoInteractions(emailSender);
+    }
+
+    @Test
+    void forgotPassword_aposLimiteDeSolicitacoes_deveRetornar429() throws Exception {
+        criarUsuario("bloqueado@email.com");
+        var request = new ForgotPasswordRequestDTO("bloqueado@email.com");
+
+        for (int i = 0; i < LoginAttemptService.MAX_ATTEMPTS; i++) {
+            mvc.perform(post("/auth/forgot-password")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(mapper.writeValueAsString(request)));
+        }
+
+        mvc.perform(post("/auth/forgot-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isTooManyRequests());
+    }
+
+    private String extrairToken(EmailMessage message) {
+        Matcher matcher = Pattern.compile("token=([^\"&\\s]+)").matcher(message.htmlBody());
+        assertThat(matcher.find()).isTrue();
+        return matcher.group(1);
+    }
+
+    private User criarUsuario(String email) {
+        User user = new User();
+        user.setName("Usuário Teste");
+        user.setEmail(email);
+        user.setPassword(passwordEncoder.encode("senha1234"));
+        user.setRole(Role.USER);
+        user.setAtivo(true);
+        return userRepository.save(user);
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/security/PasswordResetIntegrationTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/security/PasswordResetIntegrationTest.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -122,6 +123,38 @@ class PasswordResetIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(mapper.writeValueAsString(resetRequest)))
                 .andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    void forgotPassword_solicitadoDuasVezes_tokenAnteriorNaoDeveMaisFuncionar() throws Exception {
+        criarUsuario("duplasolicitacao@email.com");
+        var request = new ForgotPasswordRequestDTO("duplasolicitacao@email.com");
+
+        mvc.perform(post("/auth/forgot-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+        mvc.perform(post("/auth/forgot-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        var captor = forClass(EmailMessage.class);
+        verify(emailSender, times(2)).send(captor.capture());
+        String tokenAntigo = extrairToken(captor.getAllValues().get(0));
+        String tokenNovo = extrairToken(captor.getAllValues().get(1));
+
+        mvc.perform(post("/auth/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(
+                                new ResetPasswordRequestDTO(tokenAntigo, "novaSenha123", "novaSenha123"))))
+                .andExpect(status().isUnprocessableEntity());
+
+        mvc.perform(post("/auth/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(
+                                new ResetPasswordRequestDTO(tokenNovo, "novaSenha123", "novaSenha123"))))
+                .andExpect(status().isOk());
     }
 
     @Test

--- a/src/test/java/com/carlesso/pilatesapi/service/LoginAttemptServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/LoginAttemptServiceTest.java
@@ -1,0 +1,88 @@
+package com.carlesso.pilatesapi.service;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LoginAttemptServiceTest {
+
+    private final LoginAttemptService service = new LoginAttemptService();
+
+    @Test
+    void isBlocked_semTentativas_retornaFalse() {
+        assertThat(service.isBlocked("novo@email.com")).isFalse();
+    }
+
+    @Test
+    void isBlocked_comMenosQueMaxAttempts_retornaFalse() {
+        for (int i = 0; i < LoginAttemptService.MAX_ATTEMPTS - 1; i++) {
+            service.registerFailure("quase@email.com");
+        }
+
+        assertThat(service.isBlocked("quase@email.com")).isFalse();
+    }
+
+    @Test
+    void isBlocked_comMaxAttempts_retornaTrue() {
+        for (int i = 0; i < LoginAttemptService.MAX_ATTEMPTS; i++) {
+            service.registerFailure("bloqueado@email.com");
+        }
+
+        assertThat(service.isBlocked("bloqueado@email.com")).isTrue();
+    }
+
+    @Test
+    void registerSuccess_limpaHistoricoDaChave() {
+        for (int i = 0; i < LoginAttemptService.MAX_ATTEMPTS; i++) {
+            service.registerFailure("recupera@email.com");
+        }
+
+        service.registerSuccess("recupera@email.com");
+
+        assertThat(service.isBlocked("recupera@email.com")).isFalse();
+        assertThat(history()).doesNotContainKey("recupera@email.com");
+    }
+
+    @Test
+    void isBlocked_removeChaveDoMapaQuandoTentativasJaExpiraram() {
+        history().put("expirado@email.com", dequeComInstanteExpirado());
+
+        boolean bloqueado = service.isBlocked("expirado@email.com");
+
+        assertThat(bloqueado).isFalse();
+        assertThat(history()).doesNotContainKey("expirado@email.com");
+    }
+
+    @Test
+    void limparEntradasExpiradas_removeChavesComTentativasExpiradasEMantemAsRecentes() {
+        history().put("expirado@email.com", dequeComInstanteExpirado());
+        service.registerFailure("recente@email.com");
+
+        service.limparEntradasExpiradas();
+
+        assertThat(history()).doesNotContainKey("expirado@email.com").containsKey("recente@email.com");
+    }
+
+    private Deque<Instant> dequeComInstanteExpirado() {
+        Deque<Instant> deque = new ArrayDeque<>();
+        deque.addLast(Instant.now().minus(LoginAttemptService.WINDOW).minusSeconds(1));
+        return deque;
+    }
+
+    @SuppressWarnings("unchecked")
+    private ConcurrentHashMap<String, Deque<Instant>> history() {
+        try {
+            Field field = LoginAttemptService.class.getDeclaredField("history");
+            field.setAccessible(true);
+            return (ConcurrentHashMap<String, Deque<Instant>>) field.get(service);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/service/PasswordResetServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/PasswordResetServiceTest.java
@@ -1,0 +1,215 @@
+package com.carlesso.pilatesapi.service;
+
+import com.carlesso.pilatesapi.dto.ResetPasswordRequestDTO;
+import com.carlesso.pilatesapi.email.EmailMessage;
+import com.carlesso.pilatesapi.email.EmailSender;
+import com.carlesso.pilatesapi.email.EmailTemplateService;
+import com.carlesso.pilatesapi.entity.PasswordResetToken;
+import com.carlesso.pilatesapi.entity.User;
+import com.carlesso.pilatesapi.entity.enums.Role;
+import com.carlesso.pilatesapi.exception.BusinessException;
+import com.carlesso.pilatesapi.exception.TooManyRequestsException;
+import com.carlesso.pilatesapi.repository.PasswordResetTokenRepository;
+import com.carlesso.pilatesapi.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordResetServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordResetTokenRepository tokenRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private EmailSender emailSender;
+
+    @Mock
+    private EmailTemplateService emailTemplateService;
+
+    private LoginAttemptService loginAttemptService;
+
+    private PasswordResetService service;
+
+    @BeforeEach
+    void setUp() {
+        loginAttemptService = new LoginAttemptService();
+        service = new PasswordResetService(
+                userRepository, tokenRepository, passwordEncoder, emailSender, emailTemplateService,
+                loginAttemptService, "https://app.carlessopilates.com.br/resetar-senha");
+    }
+
+    private User usuario(Long id, String email, boolean ativo) {
+        User u = new User();
+        u.setName("Maria");
+        u.setEmail(email);
+        u.setPassword("hash-atual");
+        u.setRole(Role.USER);
+        u.setAtivo(ativo);
+        try {
+            var field = User.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(u, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return u;
+    }
+
+    @Test
+    void solicitarRedefinicao_comEmailExistenteEAtivo_deveGerarTokenEEnviarEmail() {
+        User user = usuario(1L, "maria@email.com", true);
+        when(userRepository.findByEmail("maria@email.com")).thenReturn(Optional.of(user));
+        when(emailTemplateService.criarEmailRedefinicaoSenha(any(), anyString()))
+                .thenReturn(new EmailMessage("maria@email.com", "assunto", "html", "texto"));
+
+        service.solicitarRedefinicao("maria@email.com");
+
+        ArgumentCaptor<PasswordResetToken> captor = ArgumentCaptor.forClass(PasswordResetToken.class);
+        verify(tokenRepository).save(captor.capture());
+        PasswordResetToken saved = captor.getValue();
+        assertThat(saved.getUser()).isEqualTo(user);
+        assertThat(saved.getTokenHash()).isNotBlank();
+        assertThat(saved.getExpiresAt()).isAfter(LocalDateTime.now());
+        verify(emailSender).send(any(EmailMessage.class));
+    }
+
+    @Test
+    void solicitarRedefinicao_comEmailInexistente_naoDeveEnviarEmailNemLancarErro() {
+        when(userRepository.findByEmail("naoexiste@email.com")).thenReturn(Optional.empty());
+
+        service.solicitarRedefinicao("naoexiste@email.com");
+
+        verify(tokenRepository, never()).save(any());
+        verifyNoInteractions(emailSender, emailTemplateService);
+    }
+
+    @Test
+    void solicitarRedefinicao_comUsuarioInativo_naoDeveEnviarEmail() {
+        User inativo = usuario(1L, "inativo@email.com", false);
+        when(userRepository.findByEmail("inativo@email.com")).thenReturn(Optional.of(inativo));
+
+        service.solicitarRedefinicao("inativo@email.com");
+
+        verify(tokenRepository, never()).save(any());
+        verifyNoInteractions(emailSender, emailTemplateService);
+    }
+
+    @Test
+    void solicitarRedefinicao_emailNormalizadoParaLowercase() {
+        when(userRepository.findByEmail("minusculo@email.com")).thenReturn(Optional.empty());
+
+        service.solicitarRedefinicao("MINUSCULO@EMAIL.COM");
+
+        verify(userRepository).findByEmail("minusculo@email.com");
+    }
+
+    @Test
+    void solicitarRedefinicao_aposLimiteDeSolicitacoes_deveLancarTooManyRequests() {
+        for (int i = 0; i < LoginAttemptService.MAX_ATTEMPTS; i++) {
+            when(userRepository.findByEmail("bloqueado@email.com")).thenReturn(Optional.empty());
+            service.solicitarRedefinicao("bloqueado@email.com");
+        }
+
+        assertThatThrownBy(() -> service.solicitarRedefinicao("bloqueado@email.com"))
+                .isInstanceOf(TooManyRequestsException.class);
+        verify(userRepository, times(LoginAttemptService.MAX_ATTEMPTS)).findByEmail("bloqueado@email.com");
+    }
+
+    @Test
+    void redefinirSenha_comTokenValido_deveAtualizarSenhaEIncrementarTokenVersionEMarcarTokenUsado() {
+        User user = usuario(1L, "maria@email.com", true);
+        PasswordResetToken token = tokenValido(user);
+        when(tokenRepository.findByTokenHash(anyString())).thenReturn(Optional.of(token));
+        when(passwordEncoder.encode("novaSenha123")).thenReturn("hash-nova");
+        var dto = new ResetPasswordRequestDTO("token-bruto", "novaSenha123", "novaSenha123");
+
+        service.redefinirSenha(dto);
+
+        assertThat(user.getPassword()).isEqualTo("hash-nova");
+        assertThat(user.getTokenVersion()).isEqualTo(1);
+        assertThat(token.getUsedAt()).isNotNull();
+        verify(userRepository).save(user);
+        verify(tokenRepository).save(token);
+    }
+
+    @Test
+    void redefinirSenha_comConfirmacaoDivergente_deveLancarBusinessException() {
+        var dto = new ResetPasswordRequestDTO("token-bruto", "novaSenha123", "outraSenha123");
+
+        assertThatThrownBy(() -> service.redefinirSenha(dto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Confirmação de senha não confere");
+        verifyNoInteractions(tokenRepository);
+    }
+
+    @Test
+    void redefinirSenha_comTokenInexistente_deveLancarBusinessException() {
+        when(tokenRepository.findByTokenHash(anyString())).thenReturn(Optional.empty());
+        var dto = new ResetPasswordRequestDTO("token-invalido", "novaSenha123", "novaSenha123");
+
+        assertThatThrownBy(() -> service.redefinirSenha(dto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Token inválido ou expirado");
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void redefinirSenha_comTokenExpirado_deveLancarBusinessException() {
+        PasswordResetToken token = mock(PasswordResetToken.class);
+        when(token.isValido(any())).thenReturn(false);
+        when(tokenRepository.findByTokenHash(anyString())).thenReturn(Optional.of(token));
+        var dto = new ResetPasswordRequestDTO("token-expirado", "novaSenha123", "novaSenha123");
+
+        assertThatThrownBy(() -> service.redefinirSenha(dto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Token inválido ou expirado");
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    void redefinirSenha_comTokenJaUtilizado_deveLancarBusinessException() {
+        User user = usuario(1L, "maria@email.com", true);
+        PasswordResetToken token = tokenValido(user);
+        token.setUsedAt(LocalDateTime.now().minusMinutes(5));
+        when(tokenRepository.findByTokenHash(anyString())).thenReturn(Optional.of(token));
+        var dto = new ResetPasswordRequestDTO("token-usado", "novaSenha123", "novaSenha123");
+
+        assertThatThrownBy(() -> service.redefinirSenha(dto))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("Token inválido ou expirado");
+        verify(userRepository, never()).save(any());
+    }
+
+    private PasswordResetToken tokenValido(User user) {
+        PasswordResetToken token = new PasswordResetToken();
+        token.setUser(user);
+        token.setTokenHash("qualquer-hash");
+        token.setExpiresAt(LocalDateTime.now().plusMinutes(30));
+        return token;
+    }
+}

--- a/src/test/java/com/carlesso/pilatesapi/service/PasswordResetServiceTest.java
+++ b/src/test/java/com/carlesso/pilatesapi/service/PasswordResetServiceTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -26,7 +25,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -36,6 +36,9 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class PasswordResetServiceTest {
 
+    private static final String RESET_PASSWORD_URL = "https://app.carlessopilates.com.br/resetar-senha";
+    private static final long TOKEN_TTL_MINUTOS = 30;
+
     @Mock
     private UserRepository userRepository;
 
@@ -43,7 +46,7 @@ class PasswordResetServiceTest {
     private PasswordResetTokenRepository tokenRepository;
 
     @Mock
-    private PasswordEncoder passwordEncoder;
+    private UserService userService;
 
     @Mock
     private EmailSender emailSender;
@@ -58,9 +61,13 @@ class PasswordResetServiceTest {
     @BeforeEach
     void setUp() {
         loginAttemptService = new LoginAttemptService();
-        service = new PasswordResetService(
-                userRepository, tokenRepository, passwordEncoder, emailSender, emailTemplateService,
-                loginAttemptService, "https://app.carlessopilates.com.br/resetar-senha");
+        service = novoService(TOKEN_TTL_MINUTOS);
+    }
+
+    private PasswordResetService novoService(long tokenTtlMinutos) {
+        return new PasswordResetService(
+                userRepository, tokenRepository, userService, emailSender, emailTemplateService,
+                loginAttemptService, RESET_PASSWORD_URL, tokenTtlMinutos);
     }
 
     private User usuario(Long id, String email, boolean ativo) {
@@ -96,6 +103,35 @@ class PasswordResetServiceTest {
         assertThat(saved.getTokenHash()).isNotBlank();
         assertThat(saved.getExpiresAt()).isAfter(LocalDateTime.now());
         verify(emailSender).send(any(EmailMessage.class));
+    }
+
+    @Test
+    void solicitarRedefinicao_deveInvalidarTokensAnterioresAntesDeGerarNovo() {
+        User user = usuario(1L, "maria@email.com", true);
+        when(userRepository.findByEmail("maria@email.com")).thenReturn(Optional.of(user));
+        when(emailTemplateService.criarEmailRedefinicaoSenha(any(), anyString()))
+                .thenReturn(new EmailMessage("maria@email.com", "assunto", "html", "texto"));
+
+        service.solicitarRedefinicao("maria@email.com");
+
+        verify(tokenRepository).invalidarTokensAtivos(eq(user), any(LocalDateTime.class));
+    }
+
+    @Test
+    void solicitarRedefinicao_deveRespeitarTtlConfiguradoViaProperty() {
+        PasswordResetService customService = novoService(45);
+        User user = usuario(1L, "maria@email.com", true);
+        when(userRepository.findByEmail("maria@email.com")).thenReturn(Optional.of(user));
+        when(emailTemplateService.criarEmailRedefinicaoSenha(any(), anyString()))
+                .thenReturn(new EmailMessage("maria@email.com", "assunto", "html", "texto"));
+
+        customService.solicitarRedefinicao("maria@email.com");
+
+        ArgumentCaptor<PasswordResetToken> captor = ArgumentCaptor.forClass(PasswordResetToken.class);
+        verify(tokenRepository).save(captor.capture());
+        assertThat(captor.getValue().getExpiresAt())
+                .isAfter(LocalDateTime.now().plusMinutes(44))
+                .isBefore(LocalDateTime.now().plusMinutes(46));
     }
 
     @Test
@@ -141,15 +177,21 @@ class PasswordResetServiceTest {
     }
 
     @Test
-    void redefinirSenha_comTokenValido_deveAtualizarSenhaEIncrementarTokenVersionEMarcarTokenUsado() {
+    void redefinirSenha_comTokenValido_deveAtualizarSenhaEMarcarTokenUsado() {
         User user = usuario(1L, "maria@email.com", true);
         PasswordResetToken token = tokenValido(user);
         when(tokenRepository.findByTokenHash(anyString())).thenReturn(Optional.of(token));
-        when(passwordEncoder.encode("novaSenha123")).thenReturn("hash-nova");
+        doAnswer(invocation -> {
+            User alvo = invocation.getArgument(0);
+            alvo.setPassword("hash-nova");
+            alvo.incrementarTokenVersion();
+            return null;
+        }).when(userService).aplicarNovaSenha(eq(user), eq("novaSenha123"));
         var dto = new ResetPasswordRequestDTO("token-bruto", "novaSenha123", "novaSenha123");
 
         service.redefinirSenha(dto);
 
+        verify(userService).aplicarNovaSenha(user, "novaSenha123");
         assertThat(user.getPassword()).isEqualTo("hash-nova");
         assertThat(user.getTokenVersion()).isEqualTo(1);
         assertThat(token.getUsedAt()).isNotNull();
@@ -180,8 +222,9 @@ class PasswordResetServiceTest {
 
     @Test
     void redefinirSenha_comTokenExpirado_deveLancarBusinessException() {
-        PasswordResetToken token = mock(PasswordResetToken.class);
-        when(token.isValido(any())).thenReturn(false);
+        User user = usuario(1L, "maria@email.com", true);
+        PasswordResetToken token = tokenValido(user);
+        token.setExpiresAt(LocalDateTime.now().minusMinutes(1));
         when(tokenRepository.findByTokenHash(anyString())).thenReturn(Optional.of(token));
         var dto = new ResetPasswordRequestDTO("token-expirado", "novaSenha123", "novaSenha123");
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -36,6 +36,7 @@ spring.data.web.pageable.default-page-size=10
 app.email.provider=smtp
 app.email.from=no-reply@carlessopilates.com.br
 app.email.reset-password-url=https://app.carlessopilates.com.br/resetar-senha
+app.email.reset-password-token-ttl-minutos=30
 spring.mail.host=localhost
 spring.mail.port=3025
 spring.mail.username=test

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -18,6 +18,7 @@ server.error.include-exception=false
 
 spring.application.name=CarlessoPilatesApi
 management.endpoints.web.exposure.include=health,info
+management.health.mail.enabled=false
 management.endpoint.health.show-details=always
 management.info.env.enabled=true
 info.app.name=${spring.application.name}
@@ -31,3 +32,11 @@ app.cobranca.cron-vencidos=0 0 6 * * *
 app.cobranca.cron-cobrancas-futuras=0 0 7 * * *
 app.cobranca.vencimento-dias=10
 spring.data.web.pageable.default-page-size=10
+
+app.email.provider=smtp
+app.email.from=no-reply@carlessopilates.com.br
+app.email.reset-password-url=https://app.carlessopilates.com.br/resetar-senha
+spring.mail.host=localhost
+spring.mail.port=3025
+spring.mail.username=test
+spring.mail.password=test


### PR DESCRIPTION
## Resumo

Implementa o fluxo completo de "esqueci minha senha" via token enviado por e-mail:

- `POST /auth/forgot-password` — recebe `email` e sempre retorna `200` com resposta genérica, independentemente de o e-mail existir ou pertencer a um usuário ativo (evita enumeração de usuários). Reaproveita o `LoginAttemptService` já existente para rate limiting (5 solicitações / 15 min por e-mail).
- `POST /auth/reset-password` — recebe `token`, `novaSenha` e `confirmacaoNovaSenha`. Token inválido, expirado, já utilizado ou confirmação divergente retornam `422`.
- Token de redefinição: gerado aleatoriamente (32 bytes, Base64 URL-safe), salvo em `password_reset_tokens` **apenas como hash SHA-256** (nunca em texto puro), expiração de 30 minutos, uso único.
- Ao redefinir a senha com sucesso: senha armazenada com `BCryptPasswordEncoder` e `token_version` do usuário incrementado, invalidando JWTs emitidos antes da redefinição (mesmo padrão já usado em `PUT /users/me/senha`).
- Camada de e-mail abstraída para portabilidade: `EmailSender` / `EmailTemplateService` (interfaces) com implementação SMTP (`SmtpEmailSender` via `JavaMailSender`, envio assíncrono com `@Async`) e template Thymeleaf (`ThymeleafEmailTemplateService` + `password-reset.html`). `EmailConfig` usa `@ConditionalOnProperty("app.email.provider")` para permitir trocar de provedor (ex.: SES) no futuro sem alterar o `PasswordResetService`.
- Nova migration `V26__create_password_reset_tokens_table.sql`.
- Novas propriedades `app.email.*` e `spring.mail.*` em `application.properties`, com `management.health.mail.enabled=false` para que uma falha de SMTP não derrube o healthcheck do Actuator (envio de e-mail é assíncrono e não crítico).

## Motivo

Issue #83: o sistema não possuía fluxo de redefinição de senha — usuários que esqueciam a senha dependiam de intervenção manual.

## Testes executados

- `PasswordResetServiceTest` (10 testes unitários, Mockito) — geração/validação de token, rate limiting, casos de token expirado/usado/inexistente, normalização de e-mail.
- `AuthControllerTest` (9 testes, `@WebMvcTest`) — contrato HTTP dos novos endpoints e dos já existentes (`register`/`login`).
- `PasswordResetIntegrationTest` (5 testes, `@SpringBootTest` + MockMvc + H2, `EmailSender` mockado) — fluxo completo ponta a ponta (solicitar → capturar token do e-mail → redefinir → login com nova senha → JWT antigo invalidado), reuso de token, token inválido, rate limit, e-mail inexistente.
- Suíte completa: `mvn test` — **515 testes, 0 falhas, 0 erros** (491 pré-existentes + 24 novos).
- `mvn package` (sem testes) para confirmar que a aplicação continua compilando e empacotando.

## Arquivos principais alterados

- `service/PasswordResetService.java` (novo)
- `entity/PasswordResetToken.java`, `repository/PasswordResetTokenRepository.java` (novos)
- `email/EmailSender.java`, `EmailMessage.java`, `EmailTemplateService.java`, `SmtpEmailSender.java`, `ThymeleafEmailTemplateService.java` (novo pacote)
- `config/EmailConfig.java` (novo)
- `controller/AuthController.java` (novos endpoints)
- `dto/ForgotPasswordRequestDTO.java`, `dto/ResetPasswordRequestDTO.java` (novos)
- `db/migration/V26__create_password_reset_tokens_table.sql`, `resources/templates/password-reset.html`
- `pom.xml` (dependências `spring-boot-starter-mail` e `spring-boot-starter-thymeleaf`)
- `application.properties` / `test/resources/application.properties`
- `README.md`, `docs/context.md`, `docs/documentacao.html` (documentação atualizada)

## Referência

Closes #83


---
_Generated by [Claude Code](https://claude.ai/code/session_017SjCcSwMHYu5A9FF7Ma49V)_